### PR TITLE
check for CATKIN_ENABLE_TESTING

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,8 +64,10 @@ add_library(${PROJECT_NAME}
 target_link_libraries(${PROJECT_NAME} ${ASSIMP_LIBRARIES} ${QHULL_LIBRARIES} ${catkin_LIBRARIES} ${Boost_LIBRARIES})
 
 
-# Unit tests
-add_subdirectory(test)
+if(CATKIN_ENABLE_TESTING)
+  # Unit tests
+  add_subdirectory(test)
+endif()
 
 install(TARGETS ${PROJECT_NAME}
         ARCHIVE DESTINATION lib

--- a/package.xml
+++ b/package.xml
@@ -8,7 +8,7 @@
   <license>BSD</license>  
   <url>http://ros.org/wiki/geometric_shapes</url>
 
-  <buildtool_depend>catkin</buildtool_depend>
+  <buildtool_depend version_gte="0.5.68">catkin</buildtool_depend>
 
   <build_depend>boost</build_depend>
   <build_depend>shape_msgs</build_depend>


### PR DESCRIPTION
Since version 0.5.68, catkin provides to optionally configure tests. This commit adjusts the CMakeLists.txt to opt-in the tests.
