### PR TITLE
update usage of console_bridge to deal with version in Trusty

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,7 +34,8 @@ else()
 endif()
 
 find_package(octomap REQUIRED)
-find_package(catkin COMPONENTS cmake_modules shape_msgs resource_retriever shape_tools random_numbers console_bridge eigen_stl_containers)
+find_package(catkin COMPONENTS cmake_modules shape_msgs resource_retriever shape_tools random_numbers eigen_stl_containers)
+find_package(console_bridge REQUIRED)
 
 find_package(Eigen REQUIRED)
 
@@ -52,8 +53,8 @@ endif()
 
 include_directories(include)
 include_directories(SYSTEM ${EIGEN_INCLUDE_DIRS} ${Boost_INCLUDE_DIR} ${ASSIMP_INCLUDE_DIRS} ${OCTOMAP_INCLUDE_DIRS})
-include_directories(${catkin_INCLUDE_DIRS})
-link_directories(${catkin_LIBRARY_DIRS} ${ASSIMP_LIBRARY_DIRS})
+include_directories(${catkin_INCLUDE_DIRS} ${console_bridge_INCLUDE_DIRS})
+link_directories(${catkin_LIBRARY_DIRS} ${console_bridge_LIBRARY_DIRS} ${ASSIMP_LIBRARY_DIRS})
 
 add_library(${PROJECT_NAME}
   src/shapes.cpp
@@ -61,7 +62,7 @@ add_library(${PROJECT_NAME}
   src/mesh_operations.cpp
   src/bodies.cpp
   src/body_operations.cpp)
-target_link_libraries(${PROJECT_NAME} ${ASSIMP_LIBRARIES} ${QHULL_LIBRARIES} ${catkin_LIBRARIES} ${Boost_LIBRARIES})
+target_link_libraries(${PROJECT_NAME} ${ASSIMP_LIBRARIES} ${QHULL_LIBRARIES} ${catkin_LIBRARIES} ${console_bridge_LIBRARIES} ${Boost_LIBRARIES})
 
 
 if(CATKIN_ENABLE_TESTING)


### PR DESCRIPTION
This is required because of https://github.com/ros/rosdistro/issues/4633
