### PR TITLE
Fix incorrect hint always sent to Assimp, improved STL reading

### DIFF
--- a/src/mesh_operations.cpp
+++ b/src/mesh_operations.cpp
@@ -237,9 +237,9 @@ Mesh* createMeshFromBinary(const char *buffer, std::size_t size, const Eigen::Ve
   {
     hint = assimp_hint.substr(pos + 1);
     std::transform(hint.begin(), hint.end(), hint.begin(), ::tolower);
-    if (hint.find("stl") != std::string::npos)
-      hint = "stl";
   }
+  if (hint.empty())
+    hint = assimp_hint; // send entire file name as hint if no extension was found
 
   // Create an instance of the Importer class
   Assimp::Importer importer;
@@ -251,9 +251,10 @@ Mesh* createMeshFromBinary(const char *buffer, std::size_t size, const Eigen::Ve
                                                      aiProcess_JoinIdenticalVertices  |
                                                      aiProcess_SortByPType            |
                                                      aiProcess_OptimizeGraph          |
-                                                     aiProcess_OptimizeMeshes, assimp_hint.c_str());
+                                                     aiProcess_OptimizeMeshes,
+                                                     hint.c_str());
   if (scene)
-    return createMeshFromAsset(scene, scale, assimp_hint);
+    return createMeshFromAsset(scene, scale, hint);
   else
     return NULL;
 }


### PR DESCRIPTION
This greatly improved reading various formats for STL files. Previously the code sent the extension hint as _always_ the entire file name, when it should have sent the extension. Now it does, but falls back to the whole path name.
