### PR TITLE
Prevent every mesh generation opening a new file handle.

### DIFF
--- a/src/bodies.cpp
+++ b/src/bodies.cpp
@@ -759,7 +759,7 @@ void bodies::ConvexMesh::useDimensions(const shapes::Shape *shape)
   mesh_data_->bounding_cylinder_.radius = maxdist;
   mesh_data_->bounding_cylinder_.length = cyl_length;
 
-  FILE* null = fopen ("/dev/null","w");
+  static FILE* null = fopen ("/dev/null","w");
 
   char flags[] = "qhull Tv";
   int exitcode = qh_new_qhull(3, mesh->vertex_count, points, true, flags, null, null);


### PR DESCRIPTION
This fixes moveit crashing, when using meshes in the planning scene.
This is untested for indigo as I don't have an indigo system, but should work that same as for hydro.
This is verified as part of #25 .

This causes a process to run out of file handles,
where the next fopen call returns nullptr, which is passed
into qhull, which segfaults.
Fixes ros-planning/moveit_ros#481 and
fixes ros-planning/moveit_ros#526.
