### PR TITLE
Merge shape_tools package into geometric shapes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,7 +34,7 @@ else()
 endif()
 
 find_package(octomap REQUIRED)
-find_package(catkin COMPONENTS cmake_modules shape_msgs resource_retriever shape_tools random_numbers eigen_stl_containers)
+find_package(catkin COMPONENTS cmake_modules visualization_msgs shape_msgs resource_retriever random_numbers eigen_stl_containers)
 find_package(console_bridge REQUIRED)
 
 find_package(Eigen REQUIRED)
@@ -42,7 +42,7 @@ find_package(Eigen REQUIRED)
 catkin_package(
   INCLUDE_DIRS include ${OCTOMAP_INCLUDE_DIRS}
   LIBRARIES ${PROJECT_NAME} ${OCTOMAP_LIBRARIES}
-  CATKIN_DEPENDS shape_tools shape_msgs random_numbers eigen_stl_containers visualization_msgs
+  CATKIN_DEPENDS shape_msgs random_numbers eigen_stl_containers visualization_msgs
   DEPENDS Eigen console_bridge
   )
 
@@ -61,7 +61,9 @@ add_library(${PROJECT_NAME}
   src/shape_operations.cpp
   src/mesh_operations.cpp
   src/bodies.cpp
-  src/body_operations.cpp)
+  src/body_operations.cpp
+  src/shape_to_marker.cpp
+  src/shape_extents.cpp)
 target_link_libraries(${PROJECT_NAME} ${ASSIMP_LIBRARIES} ${QHULL_LIBRARIES} ${catkin_LIBRARIES} ${console_bridge_LIBRARIES} ${Boost_LIBRARIES})
 
 
@@ -77,4 +79,3 @@ install(TARGETS ${PROJECT_NAME}
 install(DIRECTORY include/
         DESTINATION include
         FILES_MATCHING PATTERN "*.h")
-

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 geometric_shapes
 ================
 
-This package contains generic definitions of geometric shapes and bodies. Shapes represent only the form of an object.
+This package contains generic definitions of geometric shapes and bodies, as well as tools for operating on shape messages.
+Shapes represent only the form of an object.
 Bodies are shapes at a particular pose. Routines such as point containment and ray intersections are provided.
 
 Supported shapes:
@@ -12,7 +13,8 @@ Supported shapes:
 - mesh
 
 Note: Bodies for meshes compute the convex hull of those meshes in order to provide the point containment / ray intersection routines.
-
+Note: [shape_tools](https://github.com/ros-planning/shape_tools) package was recently merged into this package
+ 
 ## Build Status
 
 hydro-devel branch: [![Build Status](https://travis-ci.org/ros-planning/geometric_shapes.png?branch=hydro-devel)](https://travis-ci.org/ros-planning/geometric_shapes)

--- a/include/geometric_shapes/shape_extents.h
+++ b/include/geometric_shapes/shape_extents.h
@@ -1,0 +1,52 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2012, Willow Garage, Inc.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the Willow Garage nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+#ifndef GEOMETRIC_SHAPES_SHAPE_EXTENTS_
+#define GEOMETRIC_SHAPES_SHAPE_EXTENTS_
+
+#include <shape_msgs/SolidPrimitive.h>
+#include <shape_msgs/Mesh.h>
+
+namespace geometric_shapes
+{
+
+/** \brief Get the dimensions of an axis-aligned bounding box for the shape described by \e shape_msg */
+void getShapeExtents(const shape_msgs::SolidPrimitive& shape_msg, double& x_extent, double& y_extent, double& z_extent);
+
+/** \brief Get the dimensions of an axis-aligned bounding box for the shape described by \e shape_msg */
+void getShapeExtents(const shape_msgs::Mesh& shape_msg, double& x_extent, double& y_extent, double& z_extent);
+
+}
+
+#endif

--- a/include/geometric_shapes/shape_to_marker.h
+++ b/include/geometric_shapes/shape_to_marker.h
@@ -1,0 +1,60 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2012, Willow Garage, Inc.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the Willow Garage nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+#ifndef GEOMETRIC_SHAPES_SHAPE_TO_MARKER_
+#define GEOMETRIC_SHAPES_SHAPE_TO_MARKER_
+
+#include <shape_msgs/Mesh.h>
+#include <shape_msgs/SolidPrimitive.h>
+#include <visualization_msgs/Marker.h>
+
+namespace geometric_shapes
+{
+
+/** \brief Convert a shape_msgs::Mesh \e shape_msg to a
+    visualization_msgs::Marker \e marker. The corresponding marker
+    will be constructed as a LINE_LIST (if \e use_mesh_triangle_list
+    is false) or as a TRIANGLE_LIST (if \e use_mesh_triangle_list is
+    true). On incorrect input, this function throws a
+    std::runtime_error. */
+void constructMarkerFromShape(const shape_msgs::Mesh &shape_msg, visualization_msgs::Marker &marker, bool use_mesh_triangle_list = true);
+
+/** \brief Convert a shape_msgs::SolidPrimitive \e shape_msg to a
+    visualization_msgs::Marker \e marker. On incorrect input, this
+    function throws a std::runtime_error. */
+void constructMarkerFromShape(const shape_msgs::SolidPrimitive &shape_msg, visualization_msgs::Marker &marker);
+
+}
+
+#endif

--- a/include/geometric_shapes/solid_primitive_dims.h
+++ b/include/geometric_shapes/solid_primitive_dims.h
@@ -1,0 +1,99 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2012, Willow Garage, Inc.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the Willow Garage nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+#ifndef GEOMETRIC_SHAPES_SOLID_PRIMITIVE_DIMS_
+#define GEOMETRIC_SHAPES_SOLID_PRIMITIVE_DIMS_
+
+#include <shape_msgs/SolidPrimitive.h>
+
+namespace geometric_shapes
+{
+
+/** \brief The number of dimensions of a particular shape */
+template<int>
+struct SolidPrimitiveDimCount
+{
+  enum { value = 0 };
+};
+
+template<>
+struct SolidPrimitiveDimCount<shape_msgs::SolidPrimitive::SPHERE>
+{
+  enum
+    {
+      value = static_cast<int>(shape_msgs::SolidPrimitive::SPHERE_RADIUS) + 1
+    };
+};
+
+template<>
+struct SolidPrimitiveDimCount<shape_msgs::SolidPrimitive::BOX>
+{
+  enum
+    {
+      value = (static_cast<int>(shape_msgs::SolidPrimitive::BOX_X) >= static_cast<int>(shape_msgs::SolidPrimitive::BOX_Y) &&
+               static_cast<int>(shape_msgs::SolidPrimitive::BOX_X) >= static_cast<int>(shape_msgs::SolidPrimitive::BOX_Z)) ?
+      static_cast<int>(shape_msgs::SolidPrimitive::BOX_X) :
+      (((static_cast<int>(shape_msgs::SolidPrimitive::BOX_Y) >= static_cast<int>(shape_msgs::SolidPrimitive::BOX_X) &&
+         static_cast<int>(shape_msgs::SolidPrimitive::BOX_Y) >= static_cast<int>(shape_msgs::SolidPrimitive::BOX_Z))) ?
+       static_cast<int>(shape_msgs::SolidPrimitive::BOX_Y) :
+       ((static_cast<int>(shape_msgs::SolidPrimitive::BOX_Z) >= static_cast<int>(shape_msgs::SolidPrimitive::BOX_X) &&
+         static_cast<int>(shape_msgs::SolidPrimitive::BOX_Z) >= static_cast<int>(shape_msgs::SolidPrimitive::BOX_Y)) ?
+        static_cast<int>(shape_msgs::SolidPrimitive::BOX_Z) : 0)) + 1
+    };
+};
+
+template<>
+struct SolidPrimitiveDimCount<shape_msgs::SolidPrimitive::CONE>
+{
+  enum
+    {
+      value = (static_cast<int>(shape_msgs::SolidPrimitive::CONE_RADIUS) >= static_cast<int>(shape_msgs::SolidPrimitive::CONE_HEIGHT) ?
+               static_cast<int>(shape_msgs::SolidPrimitive::CONE_RADIUS) : static_cast<int>(shape_msgs::SolidPrimitive::CONE_HEIGHT)) + 1
+    };
+};
+
+template<>
+struct SolidPrimitiveDimCount<shape_msgs::SolidPrimitive::CYLINDER>
+{
+  enum
+    {
+      value = (static_cast<int>(shape_msgs::SolidPrimitive::CYLINDER_RADIUS) >= static_cast<int>(shape_msgs::SolidPrimitive::CYLINDER_HEIGHT) ?
+               static_cast<int>(shape_msgs::SolidPrimitive::CYLINDER_RADIUS) : static_cast<int>(shape_msgs::SolidPrimitive::CYLINDER_HEIGHT)) + 1
+    };
+};
+
+
+}
+
+#endif

--- a/package.xml
+++ b/package.xml
@@ -3,7 +3,9 @@
   <version>0.4.1</version>
   <description>This package contains generic definitions of geometric shapes and bodies.</description>
   <author email="isucan@google.com">Ioan Sucan</author>
+  <author email="gjones@willowgarage.edu">Gil Jones</author>
   <maintainer email="isucan@google.com">Ioan Sucan</maintainer>
+  <maintainer email="dave@dav.ee">Dave Coleman</maintainer>
 
   <license>BSD</license>  
   <url>http://ros.org/wiki/geometric_shapes</url>
@@ -12,7 +14,7 @@
 
   <build_depend>boost</build_depend>
   <build_depend>shape_msgs</build_depend>
-  <build_depend>shape_tools</build_depend>
+  <build_depend>visualization_msgs</build_depend>
   <build_depend>octomap</build_depend>
   <build_depend>assimp-dev</build_depend>
   <build_depend>eigen</build_depend>
@@ -27,7 +29,7 @@
 
   <run_depend>boost</run_depend>
   <run_depend>shape_msgs</run_depend>
-  <run_depend>shape_tools</run_depend>
+  <run_depend>visualization_msgs</run_depend>
   <run_depend>octomap</run_depend>
   <run_depend>assimp</run_depend>
   <run_depend>eigen</run_depend>

--- a/src/shape_extents.cpp
+++ b/src/shape_extents.cpp
@@ -1,0 +1,105 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2012, Willow Garage, Inc.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the Willow Garage nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+#include <geometric_shapes/shape_extents.h>
+#include <limits>
+
+void geometric_shapes::getShapeExtents(const shape_msgs::SolidPrimitive& shape_msg, double& x_extent, double& y_extent, double& z_extent)
+{
+  x_extent = y_extent = z_extent = 0.0;
+
+  if (shape_msg.type == shape_msgs::SolidPrimitive::SPHERE)
+  {
+    if (shape_msg.dimensions.size() > shape_msgs::SolidPrimitive::SPHERE_RADIUS)
+      x_extent = y_extent = z_extent = shape_msg.dimensions[shape_msgs::SolidPrimitive::SPHERE_RADIUS] * 2.0;
+  }
+  else if (shape_msg.type == shape_msgs::SolidPrimitive::BOX)
+  {
+    if (shape_msg.dimensions.size() > shape_msgs::SolidPrimitive::BOX_X &&
+        shape_msg.dimensions.size() > shape_msgs::SolidPrimitive::BOX_Y &&
+        shape_msg.dimensions.size() > shape_msgs::SolidPrimitive::BOX_Z)
+    {
+      x_extent = shape_msg.dimensions[shape_msgs::SolidPrimitive::BOX_X];
+      y_extent = shape_msg.dimensions[shape_msgs::SolidPrimitive::BOX_Y];
+      z_extent = shape_msg.dimensions[shape_msgs::SolidPrimitive::BOX_Z];
+    }
+  } 
+  else if (shape_msg.type == shape_msgs::SolidPrimitive::CYLINDER)
+  {
+    if (shape_msg.dimensions.size() > shape_msgs::SolidPrimitive::CYLINDER_RADIUS &&
+        shape_msg.dimensions.size() > shape_msgs::SolidPrimitive::CYLINDER_HEIGHT)
+    {
+      x_extent = y_extent = shape_msg.dimensions[shape_msgs::SolidPrimitive::CYLINDER_RADIUS] * 2.0;
+      z_extent = shape_msg.dimensions[shape_msgs::SolidPrimitive::CYLINDER_HEIGHT];
+    }
+  } 
+  else if (shape_msg.type == shape_msgs::SolidPrimitive::CONE)
+  {
+    if (shape_msg.dimensions.size() > shape_msgs::SolidPrimitive::CONE_RADIUS &&
+        shape_msg.dimensions.size() > shape_msgs::SolidPrimitive::CONE_HEIGHT)
+    {
+      x_extent = y_extent = shape_msg.dimensions[shape_msgs::SolidPrimitive::CONE_RADIUS] * 2.0;
+      z_extent = shape_msg.dimensions[shape_msgs::SolidPrimitive::CONE_HEIGHT];
+    }
+  }
+}
+
+void geometric_shapes::getShapeExtents(const shape_msgs::Mesh& shape_msg, double& x_extent, double& y_extent, double& z_extent)
+{
+  x_extent = y_extent = z_extent = 0.0;
+  if (shape_msg.vertices.size() > 0) 
+  {
+    double xmin = std::numeric_limits<double>::max(), ymin = std::numeric_limits<double>::max(), zmin = std::numeric_limits<double>::max();
+    double xmax = -std::numeric_limits<double>::max(), ymax = -std::numeric_limits<double>::max(), zmax = -std::numeric_limits<double>::max();
+    for (std::size_t i = 0; i < shape_msg.vertices.size() ; ++i)
+    {
+      if (shape_msg.vertices[i].x > xmax)
+        xmax = shape_msg.vertices[i].x;
+      if (shape_msg.vertices[i].x < xmin)
+        xmin = shape_msg.vertices[i].x;
+      if (shape_msg.vertices[i].y > ymax)
+        ymax = shape_msg.vertices[i].y;
+      if (shape_msg.vertices[i].y < ymin)
+        ymin = shape_msg.vertices[i].y;
+      if (shape_msg.vertices[i].z > zmax)
+        zmax = shape_msg.vertices[i].z;
+      if (shape_msg.vertices[i].z < zmin)
+        zmin = shape_msg.vertices[i].z;
+    }
+    x_extent = xmax-xmin;
+    y_extent = ymax-ymin;
+    z_extent = zmax-zmin;
+  }
+}
+

--- a/src/shape_operations.cpp
+++ b/src/shape_operations.cpp
@@ -46,9 +46,9 @@
 
 #include <Eigen/Geometry>
 
-#include <shape_tools/shape_to_marker.h>
-#include <shape_tools/shape_extents.h>
-#include <shape_tools/solid_primitive_dims.h>
+#include <geometric_shapes/shape_to_marker.h>
+#include <geometric_shapes/shape_extents.h>
+#include <geometric_shapes/solid_primitive_dims.h>
 
 namespace shapes
 {
@@ -173,12 +173,12 @@ public:
 
   void operator()(const shape_msgs::Mesh &shape_msg) const
   {
-    shape_tools::constructMarkerFromShape(shape_msg, *marker_, use_mesh_triangle_list_);
+    geometric_shapes::constructMarkerFromShape(shape_msg, *marker_, use_mesh_triangle_list_);
   }
 
   void operator()(const shape_msgs::SolidPrimitive &shape_msg) const
   {
-    shape_tools::constructMarkerFromShape(shape_msg, *marker_);
+    geometric_shapes::constructMarkerFromShape(shape_msg, *marker_);
   }
 
 private:
@@ -226,7 +226,7 @@ public:
   Eigen::Vector3d operator()(const shape_msgs::Mesh &shape_msg) const
   {
     double x_extent, y_extent, z_extent;
-    shape_tools::getShapeExtents(shape_msg, x_extent, y_extent, z_extent);
+    geometric_shapes::getShapeExtents(shape_msg, x_extent, y_extent, z_extent);
     Eigen::Vector3d e(x_extent, y_extent, z_extent);
     return e;
   }
@@ -234,7 +234,7 @@ public:
   Eigen::Vector3d operator()(const shape_msgs::SolidPrimitive &shape_msg) const
   {
     double x_extent, y_extent, z_extent;
-    shape_tools::getShapeExtents(shape_msg, x_extent, y_extent, z_extent);
+    geometric_shapes::getShapeExtents(shape_msg, x_extent, y_extent, z_extent);
     Eigen::Vector3d e(x_extent, y_extent, z_extent);
     return e;
   }
@@ -377,7 +377,7 @@ bool constructMsgFromShape(const Shape* shape, ShapeMsg &shape_msg)
   {
     shape_msgs::SolidPrimitive s;
     s.type = shape_msgs::SolidPrimitive::SPHERE;
-    s.dimensions.resize(shape_tools::SolidPrimitiveDimCount<shape_msgs::SolidPrimitive::SPHERE>::value);
+    s.dimensions.resize(geometric_shapes::SolidPrimitiveDimCount<shape_msgs::SolidPrimitive::SPHERE>::value);
     s.dimensions[shape_msgs::SolidPrimitive::SPHERE_RADIUS] = static_cast<const Sphere*>(shape)->radius;
     shape_msg = s;
   }
@@ -387,7 +387,7 @@ bool constructMsgFromShape(const Shape* shape, ShapeMsg &shape_msg)
       shape_msgs::SolidPrimitive s;
       s.type = shape_msgs::SolidPrimitive::BOX;
       const double* sz = static_cast<const Box*>(shape)->size;
-      s.dimensions.resize(shape_tools::SolidPrimitiveDimCount<shape_msgs::SolidPrimitive::BOX>::value);
+      s.dimensions.resize(geometric_shapes::SolidPrimitiveDimCount<shape_msgs::SolidPrimitive::BOX>::value);
       s.dimensions[shape_msgs::SolidPrimitive::BOX_X] = sz[0];
       s.dimensions[shape_msgs::SolidPrimitive::BOX_Y] = sz[1];
       s.dimensions[shape_msgs::SolidPrimitive::BOX_Z] = sz[2];
@@ -398,7 +398,7 @@ bool constructMsgFromShape(const Shape* shape, ShapeMsg &shape_msg)
       {
         shape_msgs::SolidPrimitive s;
         s.type = shape_msgs::SolidPrimitive::CYLINDER;
-        s.dimensions.resize(shape_tools::SolidPrimitiveDimCount<shape_msgs::SolidPrimitive::CYLINDER>::value);
+        s.dimensions.resize(geometric_shapes::SolidPrimitiveDimCount<shape_msgs::SolidPrimitive::CYLINDER>::value);
         s.dimensions[shape_msgs::SolidPrimitive::CYLINDER_RADIUS] = static_cast<const Cylinder*>(shape)->radius;
         s.dimensions[shape_msgs::SolidPrimitive::CYLINDER_HEIGHT] = static_cast<const Cylinder*>(shape)->length;
         shape_msg = s;
@@ -408,7 +408,7 @@ bool constructMsgFromShape(const Shape* shape, ShapeMsg &shape_msg)
         {
           shape_msgs::SolidPrimitive s;
           s.type = shape_msgs::SolidPrimitive::CONE;
-          s.dimensions.resize(shape_tools::SolidPrimitiveDimCount<shape_msgs::SolidPrimitive::CONE>::value);
+          s.dimensions.resize(geometric_shapes::SolidPrimitiveDimCount<shape_msgs::SolidPrimitive::CONE>::value);
           s.dimensions[shape_msgs::SolidPrimitive::CONE_RADIUS] = static_cast<const Cone*>(shape)->radius;
           s.dimensions[shape_msgs::SolidPrimitive::CONE_HEIGHT] = static_cast<const Cone*>(shape)->length;
           shape_msg = s;

--- a/src/shape_to_marker.cpp
+++ b/src/shape_to_marker.cpp
@@ -1,0 +1,129 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2012, Willow Garage, Inc.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the Willow Garage nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+#include <geometric_shapes/shape_to_marker.h>
+#include <sstream>
+#include <stdexcept>
+
+void geometric_shapes::constructMarkerFromShape(const shape_msgs::SolidPrimitive &shape_msg, visualization_msgs::Marker &mk)
+{  
+  switch (shape_msg.type)
+  {
+  case shape_msgs::SolidPrimitive::SPHERE:
+    if (shape_msg.dimensions.size() <= shape_msgs::SolidPrimitive::SPHERE_RADIUS)
+      throw std::runtime_error("Insufficient dimensions in sphere definition");
+    else
+    {
+      mk.type = visualization_msgs::Marker::SPHERE;
+      mk.scale.x = mk.scale.y = mk.scale.z = shape_msg.dimensions[shape_msgs::SolidPrimitive::SPHERE_RADIUS] * 2.0;
+    }
+    break;
+  case shape_msgs::SolidPrimitive::BOX:
+    if (shape_msg.dimensions.size() <= shape_msgs::SolidPrimitive::BOX_X ||
+        shape_msg.dimensions.size() <= shape_msgs::SolidPrimitive::BOX_Y ||
+        shape_msg.dimensions.size() <= shape_msgs::SolidPrimitive::BOX_Z)
+      throw std::runtime_error("Insufficient dimensions in box definition");
+    else
+    {
+      mk.type = visualization_msgs::Marker::CUBE;
+      mk.scale.x = shape_msg.dimensions[shape_msgs::SolidPrimitive::BOX_X];
+      mk.scale.y = shape_msg.dimensions[shape_msgs::SolidPrimitive::BOX_Y];
+      mk.scale.z = shape_msg.dimensions[shape_msgs::SolidPrimitive::BOX_Z];
+    }
+    break;
+  case shape_msgs::SolidPrimitive::CONE:
+    if (shape_msg.dimensions.size() <= shape_msgs::SolidPrimitive::CONE_RADIUS ||
+        shape_msg.dimensions.size() <= shape_msgs::SolidPrimitive::CONE_HEIGHT)
+      throw std::runtime_error("Insufficient dimensions in cone definition");
+    else
+    {
+      // there is no CONE marker, so this produces a cylinder marker as well 
+      mk.type = visualization_msgs::Marker::CYLINDER;
+      mk.scale.x = shape_msg.dimensions[shape_msgs::SolidPrimitive::CONE_RADIUS] * 2.0;
+      mk.scale.y = mk.scale.x;
+      mk.scale.z = shape_msg.dimensions[shape_msgs::SolidPrimitive::CONE_HEIGHT];
+    }
+    break;
+  case shape_msgs::SolidPrimitive::CYLINDER:
+    if (shape_msg.dimensions.size() <= shape_msgs::SolidPrimitive::CYLINDER_RADIUS ||
+        shape_msg.dimensions.size() <= shape_msgs::SolidPrimitive::CYLINDER_HEIGHT)
+      throw std::runtime_error("Insufficient dimensions in cylinder definition");
+    else
+    {
+      mk.type = visualization_msgs::Marker::CYLINDER;
+      mk.scale.x = shape_msg.dimensions[shape_msgs::SolidPrimitive::CYLINDER_RADIUS] * 2.0;
+      mk.scale.y = mk.scale.x;
+      mk.scale.z = shape_msg.dimensions[shape_msgs::SolidPrimitive::CYLINDER_HEIGHT];
+    }
+    break;
+  default:
+    {
+      std::stringstream ss;
+      ss << shape_msg.type;
+      throw std::runtime_error("Unknown shape type: " + ss.str());
+    }
+  }
+}
+
+void geometric_shapes::constructMarkerFromShape(const shape_msgs::Mesh &shape_msg, visualization_msgs::Marker &mk, bool use_mesh_triangle_list)
+{
+  if (shape_msg.triangles.empty() || shape_msg.vertices.empty())
+    throw std::runtime_error("Mesh definition is empty");
+  if (use_mesh_triangle_list)
+  {
+    mk.type = visualization_msgs::Marker::TRIANGLE_LIST;
+    mk.scale.x = mk.scale.y = mk.scale.z = 1.0;
+    for (std::size_t i = 0 ; i < shape_msg.triangles.size() ; ++i)
+    {
+      mk.points.push_back(shape_msg.vertices[shape_msg.triangles[i].vertex_indices[0]]);
+      mk.points.push_back(shape_msg.vertices[shape_msg.triangles[i].vertex_indices[1]]);
+      mk.points.push_back(shape_msg.vertices[shape_msg.triangles[i].vertex_indices[2]]);
+    }
+  }
+  else
+  {
+    mk.type = visualization_msgs::Marker::LINE_LIST;
+    mk.scale.x = mk.scale.y = mk.scale.z = 0.01;
+    for (std::size_t i = 0 ; i < shape_msg.triangles.size() ; ++i)
+    {
+      mk.points.push_back(shape_msg.vertices[shape_msg.triangles[i].vertex_indices[0]]);
+      mk.points.push_back(shape_msg.vertices[shape_msg.triangles[i].vertex_indices[1]]);
+      mk.points.push_back(shape_msg.vertices[shape_msg.triangles[i].vertex_indices[0]]);
+      mk.points.push_back(shape_msg.vertices[shape_msg.triangles[i].vertex_indices[2]]);
+      mk.points.push_back(shape_msg.vertices[shape_msg.triangles[i].vertex_indices[1]]);
+      mk.points.push_back(shape_msg.vertices[shape_msg.triangles[i].vertex_indices[2]]);
+    }
+  }    
+  
+}


### PR DESCRIPTION
As discussed in https://github.com/ros-planning/shape_tools/issues/4

This adds the two files in shape_tools to this package. I think we should release this package, then, once it is public, start switching the rest of MoveIt! to use this version of the shape message functions. Note I have already build all of MoveIt locally with this new setup.
