### PR TITLE
Add run_depend on visualization_msgs

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -36,5 +36,6 @@
   <run_depend>random_numbers</run_depend>
   <run_depend>eigen_stl_containers</run_depend>
   <run_depend>resource_retriever</run_depend>
+  <run_depend>visualization_msgs</run_depend>
 
 </package>


### PR DESCRIPTION
I get a configuration error on utopic without this change:

```
CMake Error at /opt/ros/jade/share/catkin/cmake/catkin_package.cmake:217 (message):
  catkin_package() DEPENDS on the catkin package 'visualization_msgs' which
  must therefore be listed as a run dependency in the package.xml
Call Stack (most recent call first):
  /opt/ros/jade/share/catkin/cmake/catkin_package.cmake:98 (_catkin_package)
  CMakeLists.txt:42 (catkin_package)


-- Configuring incomplete, errors occurred!
See also "/home/ws/build_isolated/geometric_shapes/CMakeFiles/CMakeOutput.log".
See also "/home/ws/build_isolated/geometric_shapes/CMakeFiles/CMakeError.log".
Makefile:675: recipe for target 'cmake_check_build_system' failed
make: *** [cmake_check_build_system] Error 1
<== Failed to process package 'geometric_shapes': 
```
