### PR TITLE
Switch to eigen 3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,9 +21,7 @@ find_package(Boost REQUIRED system filesystem)
 
 find_package(console_bridge REQUIRED)
 
-# required to find 'Eigen' in indigo
-find_package(cmake_modules REQUIRED)
-find_package(Eigen REQUIRED)
+find_package(Eigen3 REQUIRED)
 
 find_package(octomap REQUIRED)
 
@@ -36,7 +34,8 @@ find_package(catkin REQUIRED COMPONENTS
 )
 
 catkin_package(
-  INCLUDE_DIRS include
+  INCLUDE_DIRS
+    include
   LIBRARIES ${PROJECT_NAME} ${OCTOMAP_LIBRARIES}
   CATKIN_DEPENDS
     eigen_stl_containers
@@ -44,7 +43,7 @@ catkin_package(
     shape_msgs
     visualization_msgs
   DEPENDS
-    Eigen
+    EIGEN3
     OCTOMAP
     console_bridge
   )
@@ -55,7 +54,7 @@ if (HAVE_QHULL_2011)
 endif()
 
 include_directories(include)
-include_directories(SYSTEM ${EIGEN_INCLUDE_DIRS} ${Boost_INCLUDE_DIR} ${ASSIMP_INCLUDE_DIRS} ${OCTOMAP_INCLUDE_DIRS})
+include_directories(SYSTEM ${EIGEN3_INCLUDE_DIR} ${Boost_INCLUDE_DIR} ${ASSIMP_INCLUDE_DIRS} ${OCTOMAP_INCLUDE_DIRS})
 include_directories(${catkin_INCLUDE_DIRS} ${console_bridge_INCLUDE_DIRS})
 
 add_library(${PROJECT_NAME}

--- a/package.xml
+++ b/package.xml
@@ -7,14 +7,13 @@
   <maintainer email="isucan@google.com">Ioan Sucan</maintainer>
   <maintainer email="dave@dav.ee">Dave Coleman</maintainer>
 
-  <license>BSD</license>  
+  <license>BSD</license>
   <url>http://ros.org/wiki/geometric_shapes</url>
 
   <buildtool_depend version_gte="0.5.68">catkin</buildtool_depend>
 
   <build_depend>assimp-dev</build_depend>
   <build_depend>boost</build_depend>
-  <build_depend>cmake_modules</build_depend>
   <build_depend>eigen</build_depend>
   <build_depend>eigen_stl_containers</build_depend>
   <build_depend>libconsole-bridge-dev</build_depend>


### PR DESCRIPTION
Fixes warning

```
CMake Warning at /opt/ros/kinetic/share/cmake_modules/cmake/Modules/FindEigen.cmake:62 (message):
  The FindEigen.cmake Module in the cmake_modules package is deprecated.

  Please use the FindEigen3.cmake Module provided with Eigen.  Change
  instances of find_package(Eigen) to find_package(Eigen3).  Check the
  FindEigen3.cmake Module for the resulting CMake variable names.
```
