### PR TITLE
Use std::shared_ptr for compatibility with FCL 0.5.

### DIFF
--- a/include/geometric_shapes/shapes.h
+++ b/include/geometric_shapes/shapes.h
@@ -41,6 +41,7 @@
 #include <vector>
 #include <iostream>
 #include <boost/shared_ptr.hpp>
+#include <memory>
 #include <string>
 
 namespace octomap
@@ -250,7 +251,7 @@ class OcTree : public Shape
 {
 public:
   OcTree();
-  OcTree(const boost::shared_ptr<const octomap::OcTree> &t);
+  OcTree(const std::shared_ptr<const octomap::OcTree> &t);
 
   /** \brief The type of the shape, as a string */
   static const std::string STRING_NAME;
@@ -260,7 +261,7 @@ public:
   virtual void scaleAndPadd(double scale, double padd);
   virtual bool isFixed() const;
 
-  boost::shared_ptr<const octomap::OcTree> octree;
+  std::shared_ptr<const octomap::OcTree> octree;
 };
 
 

--- a/src/shapes.cpp
+++ b/src/shapes.cpp
@@ -159,7 +159,7 @@ shapes::OcTree::OcTree() : Shape()
   type = OCTREE;
 }
 
-shapes::OcTree::OcTree(const boost::shared_ptr<const octomap::OcTree> &t) : octree(t)
+shapes::OcTree::OcTree(const std::shared_ptr<const octomap::OcTree> &t) : octree(t)
 {
   type = OCTREE;
 }


### PR DESCRIPTION
FCL 0.5 uses `std::shared_ptr` (and `std::weak_ptr`) in their public API. To allow using `geometric_shapes` with FCL 0.5, this PR changes the relevant `shared_ptrs` to `std`. This change does affect the public API of `geometric_shapes`.

See also ros-planning/moveit_core#315

One question: should we hunt down other `shared_ptrs` as well? In any case, for compatibility with ROS messages, those types should continue to use `boost::shared_ptr` until `roscpp` switches (if that ever happens).

I suppose the pragmatic approach for now is to only switch to `std::shared_ptr` where required by external libraries, but I also wouldn't mind updating more to `std::shared_ptr` (where possible).
