### PR TITLE
Export C++11 compiler flag

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,6 +46,8 @@ catkin_package(
     EIGEN3
     OCTOMAP
     console_bridge
+  CFG_EXTRAS
+    geometric_shapes-extras.cmake
   )
 
 find_package(Qhull REQUIRED)

--- a/cmake/geometric_shapes-extras.cmake
+++ b/cmake/geometric_shapes-extras.cmake
@@ -1,2 +1,2 @@
-set(CMAKE_CXX_FLAGS "-std=c++11 ${CMAKE_CXX_FLAGS}")
+add_compile_options("-std=c++11")
 

--- a/cmake/geometric_shapes-extras.cmake
+++ b/cmake/geometric_shapes-extras.cmake
@@ -1,0 +1,2 @@
+set(CMAKE_CXX_FLAGS "-std=c++11 ${CMAKE_CXX_FLAGS}")
+


### PR DESCRIPTION
I'd recommend waiting on merging this until we get a bit more feedback on https://github.com/ros-planning/geometric_shapes/issues/49

If we decide to keep `std::shared_ptr` in the API of geometric_shapes, this PR exports the `-std=c++11` compiler flag so that packages that depend on geometric_shapes will compile properly.
