### PR TITLE
Clear root transformation on imported Collada meshes.

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -11,3 +11,6 @@ target_link_libraries(test_point_inclusion ${PROJECT_NAME} ${catkin_LIBRARIES} $
 
 catkin_add_gtest(test_bounding_sphere test_bounding_sphere.cpp)
 target_link_libraries(test_bounding_sphere ${PROJECT_NAME} ${catkin_LIBRARIES} ${Boost_LIBRARIES})
+
+catkin_add_gtest(test_create_mesh test_create_mesh.cpp)
+target_link_libraries(test_create_mesh ${PROJECT_NAME} ${catkin_LIBRARIES} ${Boost_LIBRARIES})

--- a/test/resources/triangle.stl
+++ b/test/resources/triangle.stl
@@ -1,0 +1,9 @@
+solid
+facet normal -0.577350 -0.577350 -0.577350
+outer loop
+vertex 0.000000 0.000000 1.000000
+vertex 0.000000 1.000000 0.000000
+vertex 1.000000 0.000000 0.000000
+endloop
+endfacet
+endsolid

--- a/test/resources/triangle_10m.dae
+++ b/test/resources/triangle_10m.dae
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<COLLADA xmlns="http://www.collada.org/2005/11/COLLADASchema" version="1.4.1">
+  <asset>
+    <created>2016-08-28T22:17:50</created>
+    <modified>2016-08-28T22:17:50</modified>
+    <unit name="decameter" meter="10"/>
+  </asset>
+  <library_images/>
+  <library_geometries>
+    <geometry id="triangle">
+      <mesh>
+        <source id="positions">
+          <float_array id="data" count="9">0 0 1 0 1 0 1 0 0</float_array>
+          <technique_common>
+            <accessor source="#data" count="3" stride="3">
+              <param name="X" type="float"/>
+              <param name="Y" type="float"/>
+              <param name="Z" type="float"/>
+            </accessor>
+          </technique_common>
+        </source>
+        <vertices id="vertices"><input semantic="POSITION" source="#positions"/></vertices>
+        <triangles count="1">
+          <input semantic="VERTEX" source="#vertices" offset="0"/>
+          <p>0 1 2</p>
+        </triangles>
+      </mesh>
+    </geometry>
+  </library_geometries>
+  <library_controllers/>
+  <library_visual_scenes>
+    <visual_scene id="scene"><node><instance_geometry url="#triangle"/></node></visual_scene>
+  </library_visual_scenes>
+  <scene><instance_visual_scene url="#scene"/></scene>
+</COLLADA>

--- a/test/resources/triangle_1m.dae
+++ b/test/resources/triangle_1m.dae
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<COLLADA xmlns="http://www.collada.org/2005/11/COLLADASchema" version="1.4.1">
+  <asset>
+    <created>2016-08-28T22:17:50</created>
+    <modified>2016-08-28T22:17:50</modified>
+    <unit name="meter" meter="1"/>
+  </asset>
+  <library_images/>
+  <library_geometries>
+    <geometry id="triangle">
+      <mesh>
+        <source id="positions">
+          <float_array id="data" count="9">0 0 1 0 1 0 1 0 0</float_array>
+          <technique_common>
+            <accessor source="#data" count="3" stride="3">
+              <param name="X" type="float"/>
+              <param name="Y" type="float"/>
+              <param name="Z" type="float"/>
+            </accessor>
+          </technique_common>
+        </source>
+        <vertices id="vertices"><input semantic="POSITION" source="#positions"/></vertices>
+        <triangles count="1">
+          <input semantic="VERTEX" source="#vertices" offset="0"/>
+          <p>0 1 2</p>
+        </triangles>
+      </mesh>
+    </geometry>
+  </library_geometries>
+  <library_controllers/>
+  <library_visual_scenes>
+    <visual_scene id="scene"><node><instance_geometry url="#triangle"/></node></visual_scene>
+  </library_visual_scenes>
+  <scene><instance_visual_scene url="#scene"/></scene>
+</COLLADA>

--- a/test/resources/triangle_no_unit.dae
+++ b/test/resources/triangle_no_unit.dae
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<COLLADA xmlns="http://www.collada.org/2005/11/COLLADASchema" version="1.4.1">
+  <asset>
+    <created>2016-08-28T22:17:50</created>
+    <modified>2016-08-28T22:17:50</modified>
+  </asset>
+  <library_images/>
+  <library_geometries>
+    <geometry id="triangle">
+      <mesh>
+        <source id="positions">
+          <float_array id="data" count="9">0 0 1 0 1 0 1 0 0</float_array>
+          <technique_common>
+            <accessor source="#data" count="3" stride="3">
+              <param name="X" type="float"/>
+              <param name="Y" type="float"/>
+              <param name="Z" type="float"/>
+            </accessor>
+          </technique_common>
+        </source>
+        <vertices id="vertices"><input semantic="POSITION" source="#positions"/></vertices>
+        <triangles count="1">
+          <input semantic="VERTEX" source="#vertices" offset="0"/>
+          <p>0 1 2</p>
+        </triangles>
+      </mesh>
+    </geometry>
+  </library_geometries>
+  <library_controllers/>
+  <library_visual_scenes>
+    <visual_scene id="scene"><node><instance_geometry url="#triangle"/></node></visual_scene>
+  </library_visual_scenes>
+  <scene><instance_visual_scene url="#scene"/></scene>
+</COLLADA>

--- a/test/resources/triangle_no_up.dae
+++ b/test/resources/triangle_no_up.dae
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<COLLADA xmlns="http://www.collada.org/2005/11/COLLADASchema" version="1.4.1">
+  <asset>
+    <created>2016-08-28T22:17:50</created>
+    <modified>2016-08-28T22:17:50</modified>
+    <unit name="meter" meter="1"/>
+  </asset>
+  <library_images/>
+  <library_geometries>
+    <geometry id="triangle">
+      <mesh>
+        <source id="positions">
+          <float_array id="data" count="9">0 0 1 0 1 0 1 0 0</float_array>
+          <technique_common>
+            <accessor source="#data" count="3" stride="3">
+              <param name="X" type="float"/>
+              <param name="Y" type="float"/>
+              <param name="Z" type="float"/>
+            </accessor>
+          </technique_common>
+        </source>
+        <vertices id="vertices"><input semantic="POSITION" source="#positions"/></vertices>
+        <triangles count="1">
+          <input semantic="VERTEX" source="#vertices" offset="0"/>
+          <p>0 1 2</p>
+        </triangles>
+      </mesh>
+    </geometry>
+  </library_geometries>
+  <library_controllers/>
+  <library_visual_scenes>
+    <visual_scene id="scene"><node><instance_geometry url="#triangle"/></node></visual_scene>
+  </library_visual_scenes>
+  <scene><instance_visual_scene url="#scene"/></scene>
+</COLLADA>

--- a/test/resources/triangle_x_up.dae
+++ b/test/resources/triangle_x_up.dae
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<COLLADA xmlns="http://www.collada.org/2005/11/COLLADASchema" version="1.4.1">
+  <asset>
+    <created>2016-08-28T22:17:50</created>
+    <modified>2016-08-28T22:17:50</modified>
+    <unit name="meter" meter="1"/>
+    <up_axis>X_UP</up_axis>
+  </asset>
+  <library_images/>
+  <library_geometries>
+    <geometry id="triangle">
+      <mesh>
+        <source id="positions">
+          <float_array id="data" count="9">0 0 1 0 1 0 1 0 0</float_array>
+          <technique_common>
+            <accessor source="#data" count="3" stride="3">
+              <param name="X" type="float"/>
+              <param name="Y" type="float"/>
+              <param name="Z" type="float"/>
+            </accessor>
+          </technique_common>
+        </source>
+        <vertices id="vertices"><input semantic="POSITION" source="#positions"/></vertices>
+        <triangles count="1">
+          <input semantic="VERTEX" source="#vertices" offset="0"/>
+          <p>0 1 2</p>
+        </triangles>
+      </mesh>
+    </geometry>
+  </library_geometries>
+  <library_controllers/>
+  <library_visual_scenes>
+    <visual_scene id="scene"><node><instance_geometry url="#triangle"/></node></visual_scene>
+  </library_visual_scenes>
+  <scene><instance_visual_scene url="#scene"/></scene>
+</COLLADA>

--- a/test/resources/triangle_y_up.dae
+++ b/test/resources/triangle_y_up.dae
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<COLLADA xmlns="http://www.collada.org/2005/11/COLLADASchema" version="1.4.1">
+  <asset>
+    <created>2016-08-28T22:17:50</created>
+    <modified>2016-08-28T22:17:50</modified>
+    <unit name="meter" meter="1"/>
+    <up_axis>Y_UP</up_axis>
+  </asset>
+  <library_images/>
+  <library_geometries>
+    <geometry id="triangle">
+      <mesh>
+        <source id="positions">
+          <float_array id="data" count="9">0 0 1 0 1 0 1 0 0</float_array>
+          <technique_common>
+            <accessor source="#data" count="3" stride="3">
+              <param name="X" type="float"/>
+              <param name="Y" type="float"/>
+              <param name="Z" type="float"/>
+            </accessor>
+          </technique_common>
+        </source>
+        <vertices id="vertices"><input semantic="POSITION" source="#positions"/></vertices>
+        <triangles count="1">
+          <input semantic="VERTEX" source="#vertices" offset="0"/>
+          <p>0 1 2</p>
+        </triangles>
+      </mesh>
+    </geometry>
+  </library_geometries>
+  <library_controllers/>
+  <library_visual_scenes>
+    <visual_scene id="scene"><node><instance_geometry url="#triangle"/></node></visual_scene>
+  </library_visual_scenes>
+  <scene><instance_visual_scene url="#scene"/></scene>
+</COLLADA>

--- a/test/resources/triangle_z_up.dae
+++ b/test/resources/triangle_z_up.dae
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<COLLADA xmlns="http://www.collada.org/2005/11/COLLADASchema" version="1.4.1">
+  <asset>
+    <created>2016-08-28T22:17:50</created>
+    <modified>2016-08-28T22:17:50</modified>
+    <unit name="meter" meter="1"/>
+    <up_axis>Z_UP</up_axis>
+  </asset>
+  <library_images/>
+  <library_geometries>
+    <geometry id="triangle">
+      <mesh>
+        <source id="positions">
+          <float_array id="data" count="9">0 0 1 0 1 0 1 0 0</float_array>
+          <technique_common>
+            <accessor source="#data" count="3" stride="3">
+              <param name="X" type="float"/>
+              <param name="Y" type="float"/>
+              <param name="Z" type="float"/>
+            </accessor>
+          </technique_common>
+        </source>
+        <vertices id="vertices"><input semantic="POSITION" source="#positions"/></vertices>
+        <triangles count="1">
+          <input semantic="VERTEX" source="#vertices" offset="0"/>
+          <p>0 1 2</p>
+        </triangles>
+      </mesh>
+    </geometry>
+  </library_geometries>
+  <library_controllers/>
+  <library_visual_scenes>
+    <visual_scene id="scene"><node><instance_geometry url="#triangle"/></node></visual_scene>
+  </library_visual_scenes>
+  <scene><instance_visual_scene url="#scene"/></scene>
+</COLLADA>

--- a/test/test_create_mesh.cpp
+++ b/test/test_create_mesh.cpp
@@ -1,0 +1,102 @@
+/*********************************************************************
+* Software License Agreement (BSD License)
+*
+*  Copyright (c) 2016, Delft Robotics
+*  All rights reserved.
+*
+*  Redistribution and use in source and binary forms, with or without
+*  modification, are permitted provided that the following conditions
+*  are met:
+*
+*   * Redistributions of source code must retain the above copyright
+*     notice, this list of conditions and the following disclaimer.
+*   * Redistributions in binary form must reproduce the above
+*     copyright notice, this list of conditions and the following
+*     disclaimer in the documentation and/or other materials provided
+*     with the distribution.
+*   * Neither the name of the copyright holder nor the names of its
+*     contributors may be used to endorse or promote products derived
+*     from this software without specific prior written permission.
+*
+*  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+*  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+*  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+*  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+*  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+*  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+*  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+*  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+*  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+*  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+*  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+*  POSSIBILITY OF SUCH DAMAGE.
+*********************************************************************/
+
+/** \Author Maarten de Vries <maarten@de-vri.es> */
+
+#include "resources/config.h"
+#include <geometric_shapes/mesh_operations.h>
+#include <gtest/gtest.h>
+#include <string>
+
+namespace {
+
+  void assertMesh(shapes::Mesh * mesh)
+  {
+    ASSERT_TRUE(mesh != NULL);
+    ASSERT_EQ(3, mesh->vertex_count);
+    ASSERT_EQ(1, mesh->triangle_count);
+
+    ASSERT_EQ(0, mesh->triangles[0]);
+    ASSERT_EQ(1, mesh->triangles[1]);
+    ASSERT_EQ(2, mesh->triangles[2]);
+
+    ASSERT_FLOAT_EQ(0, mesh->vertices[0 + 0]);
+    ASSERT_FLOAT_EQ(0, mesh->vertices[0 + 1]);
+    ASSERT_FLOAT_EQ(1, mesh->vertices[0 + 2]);
+    ASSERT_FLOAT_EQ(0, mesh->vertices[3 + 0]);
+    ASSERT_FLOAT_EQ(1, mesh->vertices[3 + 1]);
+    ASSERT_FLOAT_EQ(0, mesh->vertices[3 + 2]);
+    ASSERT_FLOAT_EQ(1, mesh->vertices[6 + 0]);
+    ASSERT_FLOAT_EQ(0, mesh->vertices[6 + 1]);
+    ASSERT_FLOAT_EQ(0, mesh->vertices[6 + 2]);
+  }
+
+  shapes::Mesh * loadMesh(const std::string & mesh)
+  {
+    std::string path = "file://" + std::string(TEST_RESOURCES_DIR) + "/" + mesh;
+    return shapes::createMeshFromResource(path);
+  }
+
+}
+
+TEST(CreateMesh, stl)
+{
+  assertMesh(loadMesh("triangle.stl"));
+}
+
+TEST(CreateMesh, daeNoUp)
+{
+  assertMesh(loadMesh("triangle_no_up.dae"));
+}
+
+TEST(CreateMesh, daeYUp)
+{
+  assertMesh(loadMesh("triangle_y_up.dae"));
+}
+
+TEST(CreateMesh, daeZUp)
+{
+  assertMesh(loadMesh("triangle_z_up.dae"));
+}
+
+TEST(CreateMesh, daeXUp)
+{
+  assertMesh(loadMesh("triangle_x_up.dae"));
+}
+
+int main(int argc, char **argv)
+{
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/test/test_create_mesh.cpp
+++ b/test/test_create_mesh.cpp
@@ -95,6 +95,21 @@ TEST(CreateMesh, daeXUp)
   assertMesh(loadMesh("triangle_x_up.dae"));
 }
 
+TEST(CreateMesh, daeNoUnit)
+{
+  assertMesh(loadMesh("triangle_no_unit.dae"));
+}
+
+TEST(CreateMesh, dae1M)
+{
+  assertMesh(loadMesh("triangle_1m.dae"));
+}
+
+TEST(CreateMesh, dae10M)
+{
+  assertMesh(loadMesh("triangle_10m.dae"));
+}
+
 int main(int argc, char **argv)
 {
   testing::InitGoogleTest(&argc, argv);


### PR DESCRIPTION
Assimp enforces a Y_UP convention when importing file formats that store this metadata, such as the collada format with the `<up_axis>` tag. If an imported model is using a different convention such as Z_UP, the whole model is rotated until the Y axis of the model is pointing up [1]. This is both confusing and not in-line with the ROS convention where the Z axis is pointing up.

Even worse, it causes collision checks on most collada models to use this wrongly rotated model. Rviz is already undoing this rotation[2], so the collision mesh used by moveit doesn't even match the collision mesh as visualized by rviz.

It is conceivable though that the root node transformation may be used for legit purposes with other file types, so this PR limits itself to files with `dae` or `zae` extension.

I made a small test case which publishes three meshes as markers [3]: a collada model with Z_UP, one with Y_UP and an stl model. Without this patch the Z_UP model is rotated, with the patch all three models are the same and the metadata is basically ignored.

Another option would be to assume Y is pointing up after import and rotate the model to make Z point up again. This would be in line with the ROS convention. However, this would still leave a mismatch with rviz, and frankly I think that Assimp adjusting the model orientation based on this metadata is misguided in the first place. I think that what was X in the CAD program or 3D modelling software should remain X after importing.

[1] https://github.com/assimp/assimp/blob/23baecaff30b7a280648834368b1c0c792e4092e/code/ColladaLoader.cpp#L192
[2] https://github.com/ros-visualization/rviz/blob/0d423d6249a39f7f3ddd591007952c6dc940b6ac/src/rviz/mesh_loader.cpp#L232
[3] https://github.com/de-vri-es/test_load_mesh
