### PR TITLE
Fix for linking eigen3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,9 @@ find_package(Boost REQUIRED system filesystem)
 
 find_package(console_bridge REQUIRED)
 
-find_package(Eigen3 REQUIRED)
+find_package( PkgConfig )
+pkg_check_modules( EIGEN3 REQUIRED eigen3 )
+include_directories( ${EIGEN3_INCLUDE_DIRS} ) 
 
 find_package(octomap REQUIRED)
 


### PR DESCRIPTION
Added the following fix so that pkgconfig is used to find eigen3. Not having this caused an error for me while I was building ros from source on Slackware Linux 14.2:

```
CMake Error at CMakeLists.txt:24 (find_package):
  By not providing "FindEigen3.cmake" in CMAKE_MODULE_PATH this project has
  asked CMake to find a package configuration file provided by "Eigen3", but
  CMake did not find one.

  Could not find a package configuration file provided by "Eigen3" with any
  of the following names:

    Eigen3Config.cmake
    eigen3-config.cmake

  Add the installation prefix of "Eigen3" to CMAKE_PREFIX_PATH or set
  "Eigen3_DIR" to a directory containing one of the above files.  If "Eigen3"
  provides a separate development package or SDK, be sure it has been
  installed.
```

Hope this does not mess up with other distros.
