### PR TITLE
Add method getPlanes and use double percision for planes

### DIFF
--- a/include/geometric_shapes/bodies.h
+++ b/include/geometric_shapes/bodies.h
@@ -425,6 +425,8 @@ public:
   const std::vector<unsigned int>& getTriangles() const;
   const EigenSTL::vector_Vector3d& getVertices() const;
   const EigenSTL::vector_Vector3d& getScaledVertices() const;
+  const EigenSTL::vector_Vector4d& getPlanes() const;
+
 
   virtual BodyPtr cloneAt(const Eigen::Affine3d &pose, double padding, double scale) const;
 
@@ -446,7 +448,7 @@ protected:
 
   struct MeshData
   {
-    EigenSTL::vector_Vector4f   planes_;
+    EigenSTL::vector_Vector4d   planes_;
     EigenSTL::vector_Vector3d   vertices_;
     std::vector<unsigned int>   triangles_;
     std::map<unsigned int, unsigned int> plane_for_triangle_;

--- a/include/geometric_shapes/bodies.h
+++ b/include/geometric_shapes/bodies.h
@@ -425,6 +425,11 @@ public:
   const std::vector<unsigned int>& getTriangles() const;
   const EigenSTL::vector_Vector3d& getVertices() const;
   const EigenSTL::vector_Vector3d& getScaledVertices() const;
+
+  /**
+   * @brief getPlanes Get the planes that define the convex shape.
+   * @return A a list of vector4d(nx, ny, nz, d).
+   */
   const EigenSTL::vector_Vector4d& getPlanes() const;
 
 

--- a/src/bodies.cpp
+++ b/src/bodies.cpp
@@ -825,7 +825,7 @@ void bodies::ConvexMesh::useDimensions(const shapes::Shape *shape)
   facetT * facet;
   FORALLfacets
   {
-    Eigen::Vector4f planeEquation(facet->normal[0], facet->normal[1], facet->normal[2], facet->offset);
+    Eigen::Vector4d planeEquation(facet->normal[0], facet->normal[1], facet->normal[2], facet->offset);
     if(!mesh_data_->planes_.empty()) {
         // filter equal planes - assuming same ones follow each other
         if((planeEquation - mesh_data_->planes_.back()).cwiseAbs().maxCoeff() > 1e-6)    // max diff to last
@@ -882,7 +882,7 @@ void bodies::ConvexMesh::computeScaledVerticesFromPlaneProjections()
         Eigen::Vector3d v(mesh_data_->vertices_[i] - mesh_data_->mesh_center_);
         EigenSTL::vector_Vector3d   projected_vertices;
         for(unsigned int t = 0; t < vertex_to_tris[i].size(); ++ t) {
-            const Eigen::Vector4f & plane =
+            const Eigen::Vector4d & plane =
                 mesh_data_->planes_[mesh_data_->plane_for_triangle_[vertex_to_tris[i][t]]];
             Eigen::Vector3d plane_normal(plane.x(), plane.y(), plane.z());
             double d_scaled_padded = scale_ * plane.w()
@@ -963,6 +963,12 @@ const EigenSTL::vector_Vector3d& bodies::ConvexMesh::getScaledVertices() const
   return scaled_vertices_ ? *scaled_vertices_ : getVertices();
 }
 
+const EigenSTL::vector_Vector4d& bodies::ConvexMesh::getPlanes() const
+{
+  static const EigenSTL::vector_Vector4d empty;
+  return mesh_data_ ? mesh_data_->planes_ : empty;
+}
+
 std::shared_ptr<bodies::Body> bodies::ConvexMesh::cloneAt(const Eigen::Affine3d &pose, double padding, double scale) const
 {
   ConvexMesh *m = new ConvexMesh();
@@ -995,7 +1001,7 @@ bool bodies::ConvexMesh::isPointInsidePlanes(const Eigen::Vector3d& point) const
   unsigned int numplanes = mesh_data_->planes_.size();
   for (unsigned int i = 0 ; i < numplanes ; ++i)
   {
-    const Eigen::Vector4f& plane = mesh_data_->planes_[i];
+    const Eigen::Vector4d& plane = mesh_data_->planes_[i];
     Eigen::Vector3d plane_vec(plane.x(), plane.y(), plane.z());
     double dist = plane_vec.dot(point) + plane.w() - padding_ - 1e-6;
     if (dist > 0.0)


### PR DESCRIPTION
Expose the ability to get plane data for convex shapes. 
Also store the plane as double precision.

I am working on a way to take advantage of convex hull shapes within moveit which the plane data is used to test if a shape is actually convex. 