### PR TITLE
gracefully handle negative cylinder height

### DIFF
--- a/src/mesh_operations.cpp
+++ b/src/mesh_operations.cpp
@@ -504,7 +504,7 @@ Mesh* createMeshFromShape(const Cylinder& cylinder)
   double phid = pi * 2 / tot;
 
   double circle_edge = phid * r;
-  unsigned int h_num = ceil(h / circle_edge);
+  unsigned int h_num = ceil(std::abs(h) / circle_edge);
 
   double phi = 0;
   double hd = h / h_num;


### PR DESCRIPTION
As pointed out in #64, computing `h_num` from a negative cylinder height results in a huge
number of vertices to be generated, eventually exhausting memory.