### PR TITLE
fix console_bridge incompatibilities

### DIFF
--- a/include/geometric_shapes/console_bridge_compatibility.hpp
+++ b/include/geometric_shapes/console_bridge_compatibility.hpp
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2017, Open Source Robotics Foundation, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the Open Source Robotics Foundation, Inc. nor the names of its
+ *       contributors may be used to endorse or promote products derived from
+ *       this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef CLASS_LOADER__CONSOLE_BRIDGE_COMPATIBILITY_HPP_
+#define CLASS_LOADER__CONSOLE_BRIDGE_COMPATIBILITY_HPP_
+
+#include <console_bridge/console.h>
+
+#ifndef CONSOLE_BRIDGE_logError
+# define CONSOLE_BRIDGE_logError(fmt, ...)  \
+  console_bridge::log( \
+    __FILE__, __LINE__, console_bridge::CONSOLE_BRIDGE_LOG_ERROR, fmt, ##__VA_ARGS__)
+#endif
+
+#ifndef CONSOLE_BRIDGE_logWarn
+# define CONSOLE_BRIDGE_logWarn(fmt, ...)   \
+  console_bridge::log( \
+    __FILE__, __LINE__, console_bridge::CONSOLE_BRIDGE_LOG_WARN,  fmt, ##__VA_ARGS__)
+#endif
+
+#ifndef CONSOLE_BRIDGE_logInform
+# define CONSOLE_BRIDGE_logInform(fmt, ...) \
+  console_bridge::log( \
+    __FILE__, __LINE__, console_bridge::CONSOLE_BRIDGE_LOG_INFO,  fmt, ##__VA_ARGS__)
+#endif
+
+#ifndef CONSOLE_BRIDGE_logDebug
+# define CONSOLE_BRIDGE_logDebug(fmt, ...)  \
+  console_bridge::log( \
+    __FILE__, __LINE__, console_bridge::CONSOLE_BRIDGE_LOG_DEBUG, fmt, ##__VA_ARGS__)
+#endif
+
+#endif  // CLASS_LOADER__CONSOLE_BRIDGE_COMPATIBILITY_HPP_

--- a/include/geometric_shapes/console_bridge_compatibility.hpp
+++ b/include/geometric_shapes/console_bridge_compatibility.hpp
@@ -33,27 +33,23 @@
 #include <console_bridge/console.h>
 
 #ifndef CONSOLE_BRIDGE_logError
-# define CONSOLE_BRIDGE_logError(fmt, ...)  \
-  console_bridge::log( \
-    __FILE__, __LINE__, console_bridge::CONSOLE_BRIDGE_LOG_ERROR, fmt, ##__VA_ARGS__)
+#define CONSOLE_BRIDGE_logError(fmt, ...)                                                                              \
+  console_bridge::log(__FILE__, __LINE__, console_bridge::CONSOLE_BRIDGE_LOG_ERROR, fmt, ##__VA_ARGS__)
 #endif
 
 #ifndef CONSOLE_BRIDGE_logWarn
-# define CONSOLE_BRIDGE_logWarn(fmt, ...)   \
-  console_bridge::log( \
-    __FILE__, __LINE__, console_bridge::CONSOLE_BRIDGE_LOG_WARN,  fmt, ##__VA_ARGS__)
+#define CONSOLE_BRIDGE_logWarn(fmt, ...)                                                                               \
+  console_bridge::log(__FILE__, __LINE__, console_bridge::CONSOLE_BRIDGE_LOG_WARN, fmt, ##__VA_ARGS__)
 #endif
 
 #ifndef CONSOLE_BRIDGE_logInform
-# define CONSOLE_BRIDGE_logInform(fmt, ...) \
-  console_bridge::log( \
-    __FILE__, __LINE__, console_bridge::CONSOLE_BRIDGE_LOG_INFO,  fmt, ##__VA_ARGS__)
+#define CONSOLE_BRIDGE_logInform(fmt, ...)                                                                             \
+  console_bridge::log(__FILE__, __LINE__, console_bridge::CONSOLE_BRIDGE_LOG_INFO, fmt, ##__VA_ARGS__)
 #endif
 
 #ifndef CONSOLE_BRIDGE_logDebug
-# define CONSOLE_BRIDGE_logDebug(fmt, ...)  \
-  console_bridge::log( \
-    __FILE__, __LINE__, console_bridge::CONSOLE_BRIDGE_LOG_DEBUG, fmt, ##__VA_ARGS__)
+#define CONSOLE_BRIDGE_logDebug(fmt, ...)                                                                              \
+  console_bridge::log(__FILE__, __LINE__, console_bridge::CONSOLE_BRIDGE_LOG_DEBUG, fmt, ##__VA_ARGS__)
 #endif
 
 #endif  // CLASS_LOADER__CONSOLE_BRIDGE_COMPATIBILITY_HPP_

--- a/src/bodies.cpp
+++ b/src/bodies.cpp
@@ -37,7 +37,7 @@
 #include "geometric_shapes/bodies.h"
 #include "geometric_shapes/body_operations.h"
 
-#include <console_bridge/console.h>
+#include "geometric_shapes/console_bridge_compatibility.hpp"
 
 extern "C" {
 #ifdef GEOMETRIC_SHAPES_HAVE_QHULL_2011

--- a/src/body_operations.cpp
+++ b/src/body_operations.cpp
@@ -36,7 +36,7 @@
 
 #include <geometric_shapes/body_operations.h>
 #include <geometric_shapes/shape_operations.h>
-#include <console_bridge/console.h>
+#include <geometric_shapes/console_bridge_compatibility.hpp>
 #include <Eigen/Geometry>
 
 bodies::Body* bodies::createBodyFromShape(const shapes::Shape* shape)

--- a/src/mesh_operations.cpp
+++ b/src/mesh_operations.cpp
@@ -43,7 +43,7 @@
 #include <set>
 #include <float.h>
 
-#include <console_bridge/console.h>
+#include "geometric_shapes/console_bridge_compatibility.hpp"
 #include <resource_retriever/retriever.h>
 
 #include <assimp/scene.h>

--- a/src/shape_operations.cpp
+++ b/src/shape_operations.cpp
@@ -42,7 +42,7 @@
 #include <set>
 #include <float.h>
 
-#include <console_bridge/console.h>
+#include "geometric_shapes/console_bridge_compatibility.hpp"
 
 #include <Eigen/Geometry>
 

--- a/src/shapes.cpp
+++ b/src/shapes.cpp
@@ -37,7 +37,7 @@
 #include "geometric_shapes/shapes.h"
 #include <eigen_stl_containers/eigen_stl_containers.h>
 #include <octomap/octomap.h>
-#include <console_bridge/console.h>
+#include "geometric_shapes/console_bridge_compatibility.hpp"
 
 namespace shapes
 {


### PR DESCRIPTION
As pointed out in #84, the new console_bridge API is not yet available in Jessie. To have both, older and newer API versions supported in Kinetic, we need to provide a compatibility wrapper as pointed out by Tully. This PR adds this.
My suggestion is to release `geometric_shapes` with this fix as 0.5.4 (again) into Kinetic.
For Melodic, I propose to release (without this fix) as 0.6.0. Agreed?