### PR TITLE
a small radius cylinder looks bad

### DIFF
--- a/src/mesh_operations.cpp
+++ b/src/mesh_operations.cpp
@@ -500,7 +500,7 @@ Mesh* createMeshFromShape(const Cylinder& cylinder)
   double h = cylinder.length;
 
   const double pi = boost::math::constants::pi<double>();
-  unsigned int tot = ceil(tot_for_unit_cylinder * r);
+  unsigned int tot = std::max<unsigned int>(6, ceil(tot_for_unit_cylinder * r));
   double phid = pi * 2 / tot;
 
   double circle_edge = phid * r;


### PR DESCRIPTION
I've found that if I set a cylinder radius N[cm] in URDF and convert the URDF to COLLADA with ``urdf_to_collada`` of collada_urdf, the output cylinder in COLLADA will be Nth regular prism.

So the appearance of small radius cylinder (e.g. 0.2cm) is not good.

This behavior is originally reported in https://github.com/ros/collada_urdf/issues/20, and this PR will fix the problem.

A small example is below.

```xml
<?xml version="1.0"?>
<robot xmlns:xacro="http://ros.org/wiki/xacro" name="test" >
  <link name="test_link_1cm">
    <visual>
      <geometry>
        <cylinder length="0.1" radius="0.01"/>
      </geometry>
    </visual>
  </link>

  <joint name="test_joint_1" type="fixed">
    <parent link="test_link_1cm"/>
    <child link = "test_link_2cm"/>
    <origin xyz="0.1 0 0" rpy="0 0 0"/>
  </joint>
  <link name="test_link_2cm">
    <visual>
      <geometry>
        <cylinder length="0.1" radius="0.02"/>
      </geometry>
    </visual>
  </link>

  <joint name="test_joint_2" type="fixed">
    <parent link="test_link_2cm"/>
    <child link = "test_link_3cm"/>
    <origin xyz="0.1 0 0" rpy="0 0 0"/>
  </joint>
  <link name="test_link_3cm">
    <visual>
      <geometry>
        <cylinder length="0.1" radius="0.03"/>
      </geometry>
    </visual>
  </link>

  <joint name="test_joint_3" type="fixed">
    <parent link="test_link_3cm"/>
    <child link = "test_link_4cm"/>
    <origin xyz="0.1 0 0" rpy="0 0 0"/>
  </joint>
  <link name="test_link_4cm">
    <visual>
      <geometry>
        <cylinder length="0.1" radius="0.04"/>
      </geometry>
    </visual>
  </link>

  <joint name="test_joint_4" type="fixed">
    <parent link="test_link_4cm"/>
    <child link = "test_link_5cm"/>
    <origin xyz="0.1 0 0" rpy="0 0 0"/>
  </joint>
  <link name="test_link_5cm">
    <visual>
      <geometry>
        <cylinder length="0.1" radius="0.05"/>
      </geometry>
    </visual>
  </link>
</robot>
```

```bash
rosrun collada_urdf urdf_to_collada test.urdf test.dae
roslaunch urdf_tutorial display.launch model:=test.dae
```

![image](https://user-images.githubusercontent.com/4509039/49694549-a764c000-fbcf-11e8-8ca9-554341bed043.png)
