### PR TITLE
Port to ROS 2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,10 +15,14 @@ if (NOT ASSIMP_FOUND)
   find_package(PkgConfig REQUIRED)
   # assimp is required, so REQUIRE the second attempt
   pkg_check_modules(ASSIMP_PC REQUIRED assimp)
-  # find *absolute* paths to ASSIMP_LIBRARIES
   set(ASSIMP_INCLUDE_DIRS ${ASSIMP_PC_INCLUDE_DIRS})
-  find_library(ASSIMP_LIBRARIES assimp HINTS ${ASSIMP_LIBRARY_DIRS})
 endif()
+
+# find *absolute* paths to ASSIMP_LIBRARIES
+# Both, pkg-config and assimp's cmake-config don't provide an absolute library path.
+# For, pkg-config the path is in ASSIMP_PC_LIBRARY_DIRS, for cmake in ASSIMP_LIBRARY_DIRS.
+find_library(ASSIMP_ABS_LIBRARIES NAMES ${ASSIMP_LIBRARIES} assimp HINTS ${ASSIMP_LIBRARY_DIRS} ${ASSIMP_PC_LIBRARY_DIRS})
+set(ASSIMP_LIBRARIES "${ASSIMP_ABS_LIBRARIES}")
 
 find_package(Boost REQUIRED system filesystem)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,28 +42,11 @@ if (HAVE_QHULL_2011)
   add_definitions(-DGEOMETRIC_SHAPES_HAVE_QHULL_2011)
 endif()
 
-# catkin_package(
-#   INCLUDE_DIRS
-#     include
-#   LIBRARIES ${PROJECT_NAME} ${OCTOMAP_LIBRARIES}
-#   CATKIN_DEPENDS
-#     eigen_stl_containers
-#     random_numbers
-#     shape_msgs
-#     visualization_msgs
-#   DEPENDS
-#     EIGEN3
-#     OCTOMAP
-#     console_bridge
-#   )
-
-
 include_directories(include)
 include_directories(${EIGEN3_INCLUDE_DIR} ${Boost_INCLUDE_DIR} ${ASSIMP_INCLUDE_DIRS} ${OCTOMAP_INCLUDE_DIRS})
 include_directories(${rclcpp_INCLUDE_DIRS}
                     ${rmw_implementation_INCLUDE_DIRS}
                     ${console_bridge_INCLUDE_DIRS})
-# include_directories(${catkin_INCLUDE_DIRS} ${console_bridge_INCLUDE_DIRS})
 
 add_library(${PROJECT_NAME}
   src/bodies.cpp
@@ -81,9 +64,9 @@ ament_target_dependencies(${PROJECT_NAME}
     eigen_stl_containers
     geometry_msgs
     resource_retriever)
-# target_link_libraries(${PROJECT_NAME} ${ASSIMP_LIBRARIES} ${QHULL_LIBRARIES} ${catkin_LIBRARIES} ${console_bridge_LIBRARIES} ${Boost_LIBRARIES})
 
-# if(CATKIN_ENABLE_TESTING)
+# if(BUILD_TESTING)
+#   find_package(ament_cmake_gtest REQUIRED)
 #   # Unit tests
 #   add_subdirectory(test)
 # endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,14 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.5)
 project(geometric_shapes)
 
-add_compile_options(-std=c++11)
+# Default to C++14
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 14)
+endif()
+
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
 
 list(APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake/")
 
@@ -17,45 +24,46 @@ if (NOT ASSIMP_FOUND)
   pkg_check_modules(ASSIMP REQUIRED assimp)
 endif()
 
+find_package(shape_msgs REQUIRED)
+find_package(rclcpp REQUIRED)
 find_package(Boost REQUIRED system filesystem)
-
 find_package(console_bridge REQUIRED)
-
 find_package(Eigen3 REQUIRED)
-
 find_package(octomap REQUIRED)
-
-find_package(catkin REQUIRED COMPONENTS
-  eigen_stl_containers
-  random_numbers
-  resource_retriever
-  shape_msgs
-  visualization_msgs
-)
-
-catkin_package(
-  INCLUDE_DIRS
-    include
-  LIBRARIES ${PROJECT_NAME} ${OCTOMAP_LIBRARIES}
-  CATKIN_DEPENDS
-    eigen_stl_containers
-    random_numbers
-    shape_msgs
-    visualization_msgs
-  DEPENDS
-    EIGEN3
-    OCTOMAP
-    console_bridge
-  )
-
+find_package(ament_cmake REQUIRED)
+find_package(eigen_stl_containers REQUIRED)
+find_package(random_numbers REQUIRED)
+find_package(resource_retriever REQUIRED)
+find_package(shape_msgs REQUIRED)
+find_package(visualization_msgs REQUIRED)
+find_package(geometry_msgs REQUIRED)
 find_package(Qhull REQUIRED)
 if (HAVE_QHULL_2011)
   add_definitions(-DGEOMETRIC_SHAPES_HAVE_QHULL_2011)
 endif()
 
+# catkin_package(
+#   INCLUDE_DIRS
+#     include
+#   LIBRARIES ${PROJECT_NAME} ${OCTOMAP_LIBRARIES}
+#   CATKIN_DEPENDS
+#     eigen_stl_containers
+#     random_numbers
+#     shape_msgs
+#     visualization_msgs
+#   DEPENDS
+#     EIGEN3
+#     OCTOMAP
+#     console_bridge
+#   )
+
+
 include_directories(include)
 include_directories(${EIGEN3_INCLUDE_DIR} ${Boost_INCLUDE_DIR} ${ASSIMP_INCLUDE_DIRS} ${OCTOMAP_INCLUDE_DIRS})
-include_directories(${catkin_INCLUDE_DIRS} ${console_bridge_INCLUDE_DIRS})
+include_directories(${rclcpp_INCLUDE_DIRS}
+                    ${rmw_implementation_INCLUDE_DIRS}
+                    ${console_bridge_INCLUDE_DIRS})
+# include_directories(${catkin_INCLUDE_DIRS} ${console_bridge_INCLUDE_DIRS})
 
 add_library(${PROJECT_NAME}
   src/bodies.cpp
@@ -66,18 +74,25 @@ add_library(${PROJECT_NAME}
   src/shape_to_marker.cpp
   src/shapes.cpp
 )
+ament_target_dependencies(${PROJECT_NAME}
+    rclcpp shape_msgs
+    visualization_msgs
+    random_numbers
+    eigen_stl_containers
+    geometry_msgs
+    resource_retriever)
+# target_link_libraries(${PROJECT_NAME} ${ASSIMP_LIBRARIES} ${QHULL_LIBRARIES} ${catkin_LIBRARIES} ${console_bridge_LIBRARIES} ${Boost_LIBRARIES})
 
-target_link_libraries(${PROJECT_NAME} ${ASSIMP_LIBRARIES} ${QHULL_LIBRARIES} ${catkin_LIBRARIES} ${console_bridge_LIBRARIES} ${Boost_LIBRARIES})
-
-
-if(CATKIN_ENABLE_TESTING)
-  # Unit tests
-  add_subdirectory(test)
-endif()
+# if(CATKIN_ENABLE_TESTING)
+#   # Unit tests
+#   add_subdirectory(test)
+# endif()
 
 install(TARGETS ${PROJECT_NAME}
-        ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-        LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION})
+        ARCHIVE DESTINATION lib
+      LIBRARY DESTINATION lib)
 
 install(DIRECTORY include/${PROJECT_NAME}/
-        DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION})
+        DESTINATION include/${PROJECT_NAME})
+
+ament_package()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,14 +62,15 @@ add_library(${PROJECT_NAME} SHARED
   src/shapes.cpp
 )
 ament_target_dependencies(${PROJECT_NAME}
-		rclcpp
-		shape_msgs
-		visualization_msgs
-		random_numbers
-		eigen_stl_containers
-		geometry_msgs
-		assimp
-		QHULL)
+    rclcpp
+    shape_msgs
+    visualization_msgs
+    random_numbers
+    eigen_stl_containers
+    geometry_msgs
+    console_bridge
+    ASSIMP
+    QHULL)
 
 ament_export_libraries(${PROJECT_NAME})
 ament_export_include_directories(include)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,7 +52,7 @@ include_directories(include
                     ${console_bridge_INCLUDE_DIRS}
 )
 
-add_library(${PROJECT_NAME}
+add_library(${PROJECT_NAME} SHARED
   src/bodies.cpp
   src/body_operations.cpp
   src/mesh_operations.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,11 +42,15 @@ if (HAVE_QHULL_2011)
   add_definitions(-DGEOMETRIC_SHAPES_HAVE_QHULL_2011)
 endif()
 
-include_directories(include)
-include_directories(${EIGEN3_INCLUDE_DIR} ${Boost_INCLUDE_DIR} ${ASSIMP_INCLUDE_DIRS} ${OCTOMAP_INCLUDE_DIRS})
-include_directories(${rclcpp_INCLUDE_DIRS}
+include_directories(include
+                    ${EIGEN3_INCLUDE_DIR}
+                    ${Boost_INCLUDE_DIR}
+                    ${ASSIMP_INCLUDE_DIRS}
+                    ${OCTOMAP_INCLUDE_DIRS}
+                    ${QHULL_INCLUDE_DIRS}
                     ${rmw_implementation_INCLUDE_DIRS}
-                    ${console_bridge_INCLUDE_DIRS})
+                    ${console_bridge_INCLUDE_DIRS}
+)
 
 add_library(${PROJECT_NAME}
   src/bodies.cpp
@@ -58,18 +62,27 @@ add_library(${PROJECT_NAME}
   src/shapes.cpp
 )
 ament_target_dependencies(${PROJECT_NAME}
-    rclcpp shape_msgs
-    visualization_msgs
-    random_numbers
-    eigen_stl_containers
-    geometry_msgs
-    resource_retriever)
+		rclcpp
+		shape_msgs
+		visualization_msgs
+		random_numbers
+		eigen_stl_containers
+		geometry_msgs
+		assimp
+		QHULL)
 
-# if(BUILD_TESTING)
-#   find_package(ament_cmake_gtest REQUIRED)
-#   # Unit tests
-#   add_subdirectory(test)
-# endif()
+ament_export_libraries(${PROJECT_NAME})
+ament_export_include_directories(include)
+ament_export_dependencies(ASSIMP)
+target_link_libraries(${PROJECT_NAME}
+  resource_retriever::resource_retriever
+)
+
+if(BUILD_TESTING)
+  find_package(ament_cmake_gtest REQUIRED)
+  # Unit tests
+  add_subdirectory(test)
+endif()
 
 install(TARGETS ${PROJECT_NAME}
         ARCHIVE DESTINATION lib

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,6 +65,7 @@ include_directories(${EIGEN3_INCLUDE_DIR} ${Boost_INCLUDE_DIR} ${ASSIMP_INCLUDE_
 include_directories(${catkin_INCLUDE_DIRS} ${console_bridge_INCLUDE_DIRS})
 
 add_library(${PROJECT_NAME}
+  src/aabb.cpp
   src/bodies.cpp
   src/body_operations.cpp
   src/mesh_operations.cpp

--- a/include/geometric_shapes/aabb.h
+++ b/include/geometric_shapes/aabb.h
@@ -1,7 +1,7 @@
 /*********************************************************************
 * Software License Agreement (BSD License)
 *
-*  Copyright (c) 2008, Willow Garage, Inc.
+*  Copyright (c) 2019, Open Robotics
 *  All rights reserved.
 *
 *  Redistribution and use in source and binary forms, with or without
@@ -14,7 +14,7 @@
 *     copyright notice, this list of conditions and the following
 *     disclaimer in the documentation and/or other materials provided
 *     with the distribution.
-*   * Neither the name of the Willow Garage nor the names of its
+*   * Neither the name of Open Robotics nor the names of its
 *     contributors may be used to endorse or promote products derived
 *     from this software without specific prior written permission.
 *
@@ -32,38 +32,27 @@
 *  POSSIBILITY OF SUCH DAMAGE.
 *********************************************************************/
 
-/* Author: Ioan Sucan, E. Gil Jones */
+/* Author: Martin Pecka */
 
-#ifndef GEOMETRIC_SHAPES_BODY_OPERATIONS_
-#define GEOMETRIC_SHAPES_BODY_OPERATIONS_
+#ifndef GEOMETRIC_SHAPES_AABB_H
+#define GEOMETRIC_SHAPES_AABB_H
 
-#include "geometric_shapes/shapes.h"
-#include "geometric_shapes/bodies.h"
-#include "geometric_shapes/shape_messages.h"
-#include <geometry_msgs/Pose.h>
-#include <vector>
+#include <Eigen/Geometry>
 
 namespace bodies
 {
-/** \brief Create a body from a given shape */
-Body* createBodyFromShape(const shapes::Shape* shape);
+/** \brief Represents an axis-aligned bounding box. */
+class AABB : public Eigen::AlignedBox3d
+{
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 
-/** \brief Create a body from a given shape */
-Body* constructBodyFromMsg(const shape_msgs::Mesh& shape, const geometry_msgs::Pose& pose);
+  // inherit parent class constructors (since C++11)
+  using Eigen::AlignedBox3d::AlignedBox;
 
-/** \brief Create a body from a given shape */
-Body* constructBodyFromMsg(const shape_msgs::SolidPrimitive& shape, const geometry_msgs::Pose& pose);
-
-/** \brief Create a body from a given shape */
-Body* constructBodyFromMsg(const shapes::ShapeMsg& shape, const geometry_msgs::Pose& pose);
-
-/** \brief Compute a bounding sphere to enclose a set of bounding spheres */
-void mergeBoundingSpheres(const std::vector<BoundingSphere>& spheres, BoundingSphere& mergedSphere);
-
-/** \brief Compute an axis-aligned bounding box to enclose a set of bounding boxes. */
-void mergeBoundingBoxes(const std::vector<AABB>& boxes, AABB& mergedBox);
-
-/** \brief Compute the bounding sphere for a set of \e bodies and store the resulting sphere in \e mergedSphere */
-void computeBoundingSphere(const std::vector<const Body*>& bodies, BoundingSphere& mergedSphere);
+public:
+  /** \brief Extend with a box transformed by the given transform. */
+  void extendWithTransformedBox(const Eigen::Isometry3d& transform, const Eigen::Vector3d& box);
+};
 }
-#endif
+
+#endif  // GEOMETRIC_SHAPES_AABB_H

--- a/include/geometric_shapes/bodies.h
+++ b/include/geometric_shapes/bodies.h
@@ -67,7 +67,7 @@ struct BoundingSphere
 /** \brief Definition of a cylinder */
 struct BoundingCylinder
 {
-  Eigen::Isometry3d pose;
+  Eigen::Affine3d pose;
   double radius;
   double length;
 
@@ -132,14 +132,14 @@ public:
   }
 
   /** \brief Set the pose of the body. Default is identity */
-  void setPose(const Eigen::Isometry3d& pose)
+  void setPose(const Eigen::Affine3d& pose)
   {
     pose_ = pose;
     updateInternalData();
   }
 
   /** \brief Retrieve the pose of the body */
-  const Eigen::Isometry3d& getPose() const
+  const Eigen::Affine3d& getPose() const
   {
     return pose_;
   }
@@ -188,7 +188,7 @@ public:
   virtual void computeBoundingCylinder(BoundingCylinder& cylinder) const = 0;
 
   /** \brief Get a clone of this body, but one that is located at the pose \e pose */
-  BodyPtr cloneAt(const Eigen::Isometry3d& pose) const
+  BodyPtr cloneAt(const Eigen::Affine3d& pose)
   {
     return cloneAt(pose, padding_, scale_);
   }
@@ -197,7 +197,7 @@ public:
       pose \e pose and has possibly different passing and scaling: \e
       padding and \e scaling. This function is useful to implement
       thread safety, when bodies need to be moved around. */
-  virtual BodyPtr cloneAt(const Eigen::Isometry3d& pose, double padding, double scaling) const = 0;
+  virtual BodyPtr cloneAt(const Eigen::Affine3d& pose, double padding, double scaling);
 
 protected:
   /** \brief This function is called every time a change to the body
@@ -218,7 +218,7 @@ protected:
   shapes::ShapeType type_;
 
   /** \brief The location of the body (position and orientation) */
-  Eigen::Isometry3d pose_;
+  Eigen::Affine3d pose_;
 
 public:
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
@@ -255,7 +255,7 @@ public:
   virtual bool intersectsRay(const Eigen::Vector3d& origin, const Eigen::Vector3d& dir,
                              EigenSTL::vector_Vector3d* intersections = NULL, unsigned int count = 0) const;
 
-  virtual BodyPtr cloneAt(const Eigen::Isometry3d& pose, double padding, double scale) const;
+  virtual BodyPtr cloneAt(const Eigen::Affine3d& pose, double padding, double scale) const;
 
 protected:
   virtual void useDimensions(const shapes::Shape* shape);
@@ -304,7 +304,7 @@ public:
   virtual bool intersectsRay(const Eigen::Vector3d& origin, const Eigen::Vector3d& dir,
                              EigenSTL::vector_Vector3d* intersections = NULL, unsigned int count = 0) const;
 
-  virtual BodyPtr cloneAt(const Eigen::Isometry3d& pose, double padding, double scale) const;
+  virtual BodyPtr cloneAt(const Eigen::Affine3d& pose, double padding, double scale) const;
 
 protected:
   virtual void useDimensions(const shapes::Shape* shape);
@@ -363,7 +363,7 @@ public:
   virtual bool intersectsRay(const Eigen::Vector3d& origin, const Eigen::Vector3d& dir,
                              EigenSTL::vector_Vector3d* intersections = NULL, unsigned int count = 0) const;
 
-  virtual BodyPtr cloneAt(const Eigen::Isometry3d& pose, double padding, double scale) const;
+  virtual BodyPtr cloneAt(const Eigen::Affine3d& pose, double padding, double scale) const;
 
 protected:
   virtual void useDimensions(const shapes::Shape* shape);  // (x, y, z) = (length, width, height)
@@ -435,7 +435,7 @@ public:
    */
   const EigenSTL::vector_Vector4d& getPlanes() const;
 
-  virtual BodyPtr cloneAt(const Eigen::Isometry3d& pose, double padding, double scale) const;
+  virtual BodyPtr cloneAt(const Eigen::Affine3d& pose, double padding, double scale) const;
 
   /// Project the original vertex to the scaled and padded planes and average.
   void computeScaledVerticesFromPlaneProjections();
@@ -471,7 +471,7 @@ protected:
   std::shared_ptr<MeshData> mesh_data_;
 
   // pose/padding/scaling-dependent values & values computed for convenience and fast upcoming computations
-  Eigen::Isometry3d i_pose_;
+  Eigen::Affine3d i_pose_;
   Eigen::Vector3d center_;
   double radiusB_;
   double radiusBSqr_;

--- a/include/geometric_shapes/bodies.h
+++ b/include/geometric_shapes/bodies.h
@@ -41,6 +41,7 @@
 #error This header requires at least C++11
 #endif
 
+#include "geometric_shapes/aabb.h"
 #include "geometric_shapes/shapes.h"
 #include <eigen_stl_containers/eigen_stl_containers.h>
 #include <random_numbers/random_numbers.h>
@@ -187,6 +188,10 @@ public:
       pose. Scaling and padding are accounted for. */
   virtual void computeBoundingCylinder(BoundingCylinder& cylinder) const = 0;
 
+  /** \brief Compute the axis-aligned bounding box for the body, in its current
+      pose. Scaling and padding are accounted for. */
+  virtual void computeBoundingBox(AABB& bbox) const = 0;
+
   /** \brief Get a clone of this body, but one that is located at the pose \e pose */
   BodyPtr cloneAt(const Eigen::Isometry3d& pose) const
   {
@@ -252,6 +257,7 @@ public:
                                  Eigen::Vector3d& result);
   virtual void computeBoundingSphere(BoundingSphere& sphere) const;
   virtual void computeBoundingCylinder(BoundingCylinder& cylinder) const;
+  virtual void computeBoundingBox(AABB& bbox) const;
   virtual bool intersectsRay(const Eigen::Vector3d& origin, const Eigen::Vector3d& dir,
                              EigenSTL::vector_Vector3d* intersections = NULL, unsigned int count = 0) const;
 
@@ -301,6 +307,7 @@ public:
                                  Eigen::Vector3d& result);
   virtual void computeBoundingSphere(BoundingSphere& sphere) const;
   virtual void computeBoundingCylinder(BoundingCylinder& cylinder) const;
+  virtual void computeBoundingBox(AABB& bbox) const;
   virtual bool intersectsRay(const Eigen::Vector3d& origin, const Eigen::Vector3d& dir,
                              EigenSTL::vector_Vector3d* intersections = NULL, unsigned int count = 0) const;
 
@@ -360,6 +367,7 @@ public:
                                  Eigen::Vector3d& result);
   virtual void computeBoundingSphere(BoundingSphere& sphere) const;
   virtual void computeBoundingCylinder(BoundingCylinder& cylinder) const;
+  virtual void computeBoundingBox(AABB& bbox) const;
   virtual bool intersectsRay(const Eigen::Vector3d& origin, const Eigen::Vector3d& dir,
                              EigenSTL::vector_Vector3d* intersections = NULL, unsigned int count = 0) const;
 
@@ -422,6 +430,7 @@ public:
 
   virtual void computeBoundingSphere(BoundingSphere& sphere) const;
   virtual void computeBoundingCylinder(BoundingCylinder& cylinder) const;
+  virtual void computeBoundingBox(AABB& bbox) const;
   virtual bool intersectsRay(const Eigen::Vector3d& origin, const Eigen::Vector3d& dir,
                              EigenSTL::vector_Vector3d* intersections = NULL, unsigned int count = 0) const;
 

--- a/include/geometric_shapes/bodies.h
+++ b/include/geometric_shapes/bodies.h
@@ -188,7 +188,7 @@ public:
   virtual void computeBoundingCylinder(BoundingCylinder& cylinder) const = 0;
 
   /** \brief Get a clone of this body, but one that is located at the pose \e pose */
-  BodyPtr cloneAt(const Eigen::Isometry3d& pose)
+  BodyPtr cloneAt(const Eigen::Isometry3d& pose) const
   {
     return cloneAt(pose, padding_, scale_);
   }
@@ -197,7 +197,7 @@ public:
       pose \e pose and has possibly different passing and scaling: \e
       padding and \e scaling. This function is useful to implement
       thread safety, when bodies need to be moved around. */
-  virtual BodyPtr cloneAt(const Eigen::Isometry3d& pose, double padding, double scaling);
+  virtual BodyPtr cloneAt(const Eigen::Isometry3d& pose, double padding, double scaling) const = 0;
 
 protected:
   /** \brief This function is called every time a change to the body

--- a/include/geometric_shapes/bodies.h
+++ b/include/geometric_shapes/bodies.h
@@ -67,7 +67,7 @@ struct BoundingSphere
 /** \brief Definition of a cylinder */
 struct BoundingCylinder
 {
-  Eigen::Affine3d pose;
+  Eigen::Isometry3d pose;
   double radius;
   double length;
 
@@ -132,14 +132,14 @@ public:
   }
 
   /** \brief Set the pose of the body. Default is identity */
-  void setPose(const Eigen::Affine3d& pose)
+  void setPose(const Eigen::Isometry3d& pose)
   {
     pose_ = pose;
     updateInternalData();
   }
 
   /** \brief Retrieve the pose of the body */
-  const Eigen::Affine3d& getPose() const
+  const Eigen::Isometry3d& getPose() const
   {
     return pose_;
   }
@@ -188,7 +188,7 @@ public:
   virtual void computeBoundingCylinder(BoundingCylinder& cylinder) const = 0;
 
   /** \brief Get a clone of this body, but one that is located at the pose \e pose */
-  BodyPtr cloneAt(const Eigen::Affine3d& pose)
+  BodyPtr cloneAt(const Eigen::Isometry3d& pose)
   {
     return cloneAt(pose, padding_, scale_);
   }
@@ -197,7 +197,7 @@ public:
       pose \e pose and has possibly different passing and scaling: \e
       padding and \e scaling. This function is useful to implement
       thread safety, when bodies need to be moved around. */
-  virtual BodyPtr cloneAt(const Eigen::Affine3d& pose, double padding, double scaling);
+  virtual BodyPtr cloneAt(const Eigen::Isometry3d& pose, double padding, double scaling);
 
 protected:
   /** \brief This function is called every time a change to the body
@@ -218,7 +218,7 @@ protected:
   shapes::ShapeType type_;
 
   /** \brief The location of the body (position and orientation) */
-  Eigen::Affine3d pose_;
+  Eigen::Isometry3d pose_;
 
 public:
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
@@ -255,7 +255,7 @@ public:
   virtual bool intersectsRay(const Eigen::Vector3d& origin, const Eigen::Vector3d& dir,
                              EigenSTL::vector_Vector3d* intersections = NULL, unsigned int count = 0) const;
 
-  virtual BodyPtr cloneAt(const Eigen::Affine3d& pose, double padding, double scale) const;
+  virtual BodyPtr cloneAt(const Eigen::Isometry3d& pose, double padding, double scale) const;
 
 protected:
   virtual void useDimensions(const shapes::Shape* shape);
@@ -304,7 +304,7 @@ public:
   virtual bool intersectsRay(const Eigen::Vector3d& origin, const Eigen::Vector3d& dir,
                              EigenSTL::vector_Vector3d* intersections = NULL, unsigned int count = 0) const;
 
-  virtual BodyPtr cloneAt(const Eigen::Affine3d& pose, double padding, double scale) const;
+  virtual BodyPtr cloneAt(const Eigen::Isometry3d& pose, double padding, double scale) const;
 
 protected:
   virtual void useDimensions(const shapes::Shape* shape);
@@ -363,7 +363,7 @@ public:
   virtual bool intersectsRay(const Eigen::Vector3d& origin, const Eigen::Vector3d& dir,
                              EigenSTL::vector_Vector3d* intersections = NULL, unsigned int count = 0) const;
 
-  virtual BodyPtr cloneAt(const Eigen::Affine3d& pose, double padding, double scale) const;
+  virtual BodyPtr cloneAt(const Eigen::Isometry3d& pose, double padding, double scale) const;
 
 protected:
   virtual void useDimensions(const shapes::Shape* shape);  // (x, y, z) = (length, width, height)
@@ -435,7 +435,7 @@ public:
    */
   const EigenSTL::vector_Vector4d& getPlanes() const;
 
-  virtual BodyPtr cloneAt(const Eigen::Affine3d& pose, double padding, double scale) const;
+  virtual BodyPtr cloneAt(const Eigen::Isometry3d& pose, double padding, double scale) const;
 
   /// Project the original vertex to the scaled and padded planes and average.
   void computeScaledVerticesFromPlaneProjections();
@@ -471,7 +471,7 @@ protected:
   std::shared_ptr<MeshData> mesh_data_;
 
   // pose/padding/scaling-dependent values & values computed for convenience and fast upcoming computations
-  Eigen::Affine3d i_pose_;
+  Eigen::Isometry3d i_pose_;
   Eigen::Vector3d center_;
   double radiusB_;
   double radiusBSqr_;
@@ -499,7 +499,7 @@ public:
   BodyVector();
 
   /** \brief Construct a body vector from a vector of shapes, a vector of poses and a padding */
-  BodyVector(const std::vector<shapes::Shape*>& shapes, const EigenSTL::vector_Affine3d& poses, double padding = 0.0);
+  BodyVector(const std::vector<shapes::Shape*>& shapes, const EigenSTL::vector_Isometry3d& poses, double padding = 0.0);
 
   ~BodyVector();
 
@@ -507,13 +507,13 @@ public:
   void addBody(Body* body);
 
   /** \brief Add a body from a shape, a pose for the body and a padding */
-  void addBody(const shapes::Shape* shape, const Eigen::Affine3d& pose, double padding = 0.0);
+  void addBody(const shapes::Shape* shape, const Eigen::Isometry3d& pose, double padding = 0.0);
 
   /** \brief Clear all bodies from the vector*/
   void clear();
 
   /** \brief Set the pose of a particular body in the vector of bodies */
-  void setPose(unsigned int i, const Eigen::Affine3d& pose);
+  void setPose(unsigned int i, const Eigen::Isometry3d& pose);
 
   /** \brief Get the number of bodies in this vector*/
   std::size_t getCount() const;

--- a/include/geometric_shapes/bodies.h
+++ b/include/geometric_shapes/bodies.h
@@ -499,7 +499,7 @@ public:
   BodyVector();
 
   /** \brief Construct a body vector from a vector of shapes, a vector of poses and a padding */
-  BodyVector(const std::vector<shapes::Shape*>& shapes, const EigenSTL::vector_Isometry3d& poses, double padding = 0.0);
+  BodyVector(const std::vector<shapes::Shape*>& shapes, const EigenSTL::vector_Affine3d& poses, double padding = 0.0);
 
   ~BodyVector();
 
@@ -507,13 +507,13 @@ public:
   void addBody(Body* body);
 
   /** \brief Add a body from a shape, a pose for the body and a padding */
-  void addBody(const shapes::Shape* shape, const Eigen::Isometry3d& pose, double padding = 0.0);
+  void addBody(const shapes::Shape* shape, const Eigen::Affine3d& pose, double padding = 0.0);
 
   /** \brief Clear all bodies from the vector*/
   void clear();
 
   /** \brief Set the pose of a particular body in the vector of bodies */
-  void setPose(unsigned int i, const Eigen::Isometry3d& pose);
+  void setPose(unsigned int i, const Eigen::Affine3d& pose);
 
   /** \brief Get the number of bodies in this vector*/
   std::size_t getCount() const;

--- a/include/geometric_shapes/body_operations.h
+++ b/include/geometric_shapes/body_operations.h
@@ -40,7 +40,7 @@
 #include "geometric_shapes/shapes.h"
 #include "geometric_shapes/bodies.h"
 #include "geometric_shapes/shape_messages.h"
-#include <geometry_msgs/Pose.h>
+#include <geometry_msgs/msg/pose.hpp>
 #include <vector>
 
 namespace bodies
@@ -49,13 +49,13 @@ namespace bodies
 Body* createBodyFromShape(const shapes::Shape* shape);
 
 /** \brief Create a body from a given shape */
-Body* constructBodyFromMsg(const shape_msgs::msg::Mesh& shape, const geometry_msgs::Pose& pose);
+Body* constructBodyFromMsg(const shape_msgs::msg::Mesh& shape, const geometry_msgs::msg::Pose& pose);
 
 /** \brief Create a body from a given shape */
-Body* constructBodyFromMsg(const shape_msgs::msg::SolidPrimitive& shape, const geometry_msgs::Pose& pose);
+Body* constructBodyFromMsg(const shape_msgs::msg::SolidPrimitive& shape, const geometry_msgs::msg::Pose& pose);
 
 /** \brief Create a body from a given shape */
-Body* constructBodyFromMsg(const shapes::ShapeMsg& shape, const geometry_msgs::Pose& pose);
+Body* constructBodyFromMsg(const shapes::ShapeMsg& shape, const geometry_msgs::msg::Pose& pose);
 
 /** \brief Compute a bounding sphere to enclose a set of bounding spheres */
 void mergeBoundingSpheres(const std::vector<BoundingSphere>& spheres, BoundingSphere& mergedSphere);

--- a/include/geometric_shapes/body_operations.h
+++ b/include/geometric_shapes/body_operations.h
@@ -49,7 +49,7 @@ namespace bodies
 Body* createBodyFromShape(const shapes::Shape* shape);
 
 /** \brief Create a body from a given shape */
-Body* constructBodyFromMsg(const shape_msgs::Mesh& shape, const geometry_msgs::Pose& pose);
+Body* constructBodyFromMsg(const shape_msgs::msg::Mesh& shape, const geometry_msgs::Pose& pose);
 
 /** \brief Create a body from a given shape */
 Body* constructBodyFromMsg(const shape_msgs::msg::SolidPrimitive& shape, const geometry_msgs::Pose& pose);

--- a/include/geometric_shapes/body_operations.h
+++ b/include/geometric_shapes/body_operations.h
@@ -52,7 +52,7 @@ Body* createBodyFromShape(const shapes::Shape* shape);
 Body* constructBodyFromMsg(const shape_msgs::Mesh& shape, const geometry_msgs::Pose& pose);
 
 /** \brief Create a body from a given shape */
-Body* constructBodyFromMsg(const shape_msgs::SolidPrimitive& shape, const geometry_msgs::Pose& pose);
+Body* constructBodyFromMsg(const shape_msgs::msg::SolidPrimitive& shape, const geometry_msgs::Pose& pose);
 
 /** \brief Create a body from a given shape */
 Body* constructBodyFromMsg(const shapes::ShapeMsg& shape, const geometry_msgs::Pose& pose);

--- a/include/geometric_shapes/shape_extents.h
+++ b/include/geometric_shapes/shape_extents.h
@@ -35,16 +35,16 @@
 #ifndef GEOMETRIC_SHAPES_SHAPE_EXTENTS_
 #define GEOMETRIC_SHAPES_SHAPE_EXTENTS_
 
-#include <shape_msgs/SolidPrimitive.h>
-#include <shape_msgs/Mesh.h>
+#include "shape_msgs/msg/solid_primitive.hpp"
+#include "shape_msgs/msg/mesh.hpp"
 
 namespace geometric_shapes
 {
 /** \brief Get the dimensions of an axis-aligned bounding box for the shape described by \e shape_msg */
-void getShapeExtents(const shape_msgs::SolidPrimitive& shape_msg, double& x_extent, double& y_extent, double& z_extent);
+void getShapeExtents(const shape_msgs::msg::SolidPrimitive& shape_msg, double& x_extent, double& y_extent, double& z_extent);
 
 /** \brief Get the dimensions of an axis-aligned bounding box for the shape described by \e shape_msg */
-void getShapeExtents(const shape_msgs::Mesh& shape_msg, double& x_extent, double& y_extent, double& z_extent);
+void getShapeExtents(const shape_msgs::msg::Mesh& shape_msg, double& x_extent, double& y_extent, double& z_extent);
 }
 
 #endif

--- a/include/geometric_shapes/shape_messages.h
+++ b/include/geometric_shapes/shape_messages.h
@@ -37,9 +37,9 @@
 #ifndef GEOMETRIC_SHAPES_SHAPE_MESSAGES_
 #define GEOMETRIC_SHAPES_SHAPE_MESSAGES_
 
-#include <shape_msgs/SolidPrimitive.h>
-#include <shape_msgs/Mesh.h>
-#include <shape_msgs/Plane.h>
+#include "shape_msgs/msg/solid_primitive.hpp"
+#include "shape_msgs/msg/mesh.hpp"
+#include "shape_msgs/msg/plane.hpp"
 #include <boost/variant.hpp>
 
 #if __cplusplus <= 199711L
@@ -49,7 +49,7 @@
 namespace shapes
 {
 /** \brief Type that can hold any of the desired shape message types */
-typedef boost::variant<shape_msgs::SolidPrimitive, shape_msgs::Mesh, shape_msgs::Plane> ShapeMsg;
+typedef boost::variant<shape_msgs::msg::SolidPrimitive, shape_msgs::msg::Mesh, shape_msgs::msg::Plane> ShapeMsg;
 }
 
 #endif

--- a/include/geometric_shapes/shape_operations.h
+++ b/include/geometric_shapes/shape_operations.h
@@ -52,7 +52,7 @@ Shape* constructShapeFromMsg(const shape_msgs::msg::SolidPrimitive& shape_msg);
 Shape* constructShapeFromMsg(const shape_msgs::Plane& shape_msg);
 
 /** \brief Construct the shape that corresponds to the message. Return NULL on failure. */
-Shape* constructShapeFromMsg(const shape_msgs::Mesh& shape_msg);
+Shape* constructShapeFromMsg(const shape_msgs::msg::Mesh& shape_msg);
 
 /** \brief Construct the shape that corresponds to the message. Return NULL on failure. */
 Shape* constructShapeFromMsg(const ShapeMsg& shape_msg);

--- a/include/geometric_shapes/shape_operations.h
+++ b/include/geometric_shapes/shape_operations.h
@@ -46,7 +46,7 @@
 namespace shapes
 {
 /** \brief Construct the shape that corresponds to the message. Return NULL on failure. */
-Shape* constructShapeFromMsg(const shape_msgs::SolidPrimitive& shape_msg);
+Shape* constructShapeFromMsg(const shape_msgs::msg::SolidPrimitive& shape_msg);
 
 /** \brief Construct the shape that corresponds to the message. Return NULL on failure. */
 Shape* constructShapeFromMsg(const shape_msgs::Plane& shape_msg);

--- a/include/geometric_shapes/shape_operations.h
+++ b/include/geometric_shapes/shape_operations.h
@@ -40,7 +40,7 @@
 #include "geometric_shapes/shapes.h"
 #include "geometric_shapes/shape_messages.h"
 #include "geometric_shapes/mesh_operations.h"
-#include <visualization_msgs/Marker.h>
+#include "visualization_msgs/msg/marker.hpp"
 #include <iostream>
 
 namespace shapes
@@ -49,7 +49,7 @@ namespace shapes
 Shape* constructShapeFromMsg(const shape_msgs::msg::SolidPrimitive& shape_msg);
 
 /** \brief Construct the shape that corresponds to the message. Return NULL on failure. */
-Shape* constructShapeFromMsg(const shape_msgs::Plane& shape_msg);
+Shape* constructShapeFromMsg(const shape_msgs::msg::Plane& shape_msg);
 
 /** \brief Construct the shape that corresponds to the message. Return NULL on failure. */
 Shape* constructShapeFromMsg(const shape_msgs::msg::Mesh& shape_msg);

--- a/include/geometric_shapes/shape_operations.h
+++ b/include/geometric_shapes/shape_operations.h
@@ -61,7 +61,7 @@ Shape* constructShapeFromMsg(const ShapeMsg& shape_msg);
 bool constructMsgFromShape(const Shape* shape, ShapeMsg& shape_msg);
 
 /** \brief Construct the marker that corresponds to the shape. Return false on failure. */
-bool constructMarkerFromShape(const Shape* shape, visualization_msgs::Marker& mk, bool use_mesh_triangle_list = false);
+bool constructMarkerFromShape(const Shape* shape, visualization_msgs::msg::Marker& mk, bool use_mesh_triangle_list = false);
 
 /** \brief Compute the extents of a shape */
 Eigen::Vector3d computeShapeExtents(const ShapeMsg& shape_msg);

--- a/include/geometric_shapes/shape_to_marker.h
+++ b/include/geometric_shapes/shape_to_marker.h
@@ -35,24 +35,24 @@
 #ifndef GEOMETRIC_SHAPES_SHAPE_TO_MARKER_
 #define GEOMETRIC_SHAPES_SHAPE_TO_MARKER_
 
-#include <shape_msgs/Mesh.h>
-#include <shape_msgs/SolidPrimitive.h>
-#include <visualization_msgs/Marker.h>
+#include "shape_msgs/msg/solid_primitive.hpp"
+#include "shape_msgs/msg/mesh.hpp"
+#include "visualization_msgs/msg/marker.hpp"
 
 namespace geometric_shapes
 {
-/** \brief Convert a shape_msgs::Mesh \e shape_msg to a visualization_msgs::Marker \e marker.
+/** \brief Convert a shape_msgs::msg::Mesh \e shape_msg to a visualization_msgs::msg::Marker \e marker.
 
     The corresponding marker will be constructed as a LINE_LIST (if \e use_mesh_triangle_list
     is false) or as a TRIANGLE_LIST (if \e use_mesh_triangle_list is true).
     On incorrect input, this function throws a std::runtime_error. */
-void constructMarkerFromShape(const shape_msgs::Mesh& shape_msg, visualization_msgs::Marker& marker,
+void constructMarkerFromShape(const shape_msgs::msg::Mesh& shape_msg, visualization_msgs::msg::Marker& marker,
                               bool use_mesh_triangle_list = true);
 
-/** \brief Convert a shape_msgs::SolidPrimitive \e shape_msg to a visualization_msgs::Marker \e marker.
+/** \brief Convert a shape_msgs::msg::SolidPrimitive \e shape_msg to a visualization_msgs::msg::Marker \e marker.
 
     On incorrect input, this function throws a std::runtime_error. */
-void constructMarkerFromShape(const shape_msgs::SolidPrimitive& shape_msg, visualization_msgs::Marker& marker);
+void constructMarkerFromShape(const shape_msgs::msg::SolidPrimitive& shape_msg, visualization_msgs::msg::Marker& marker);
 }
 
 #endif

--- a/include/geometric_shapes/solid_primitive_dims.h
+++ b/include/geometric_shapes/solid_primitive_dims.h
@@ -35,7 +35,7 @@
 #ifndef GEOMETRIC_SHAPES_SOLID_PRIMITIVE_DIMS_
 #define GEOMETRIC_SHAPES_SOLID_PRIMITIVE_DIMS_
 
-#include <shape_msgs/SolidPrimitive.h>
+#include "shape_msgs/msg/solid_primitive.hpp"
 
 namespace geometric_shapes
 {
@@ -50,60 +50,60 @@ struct SolidPrimitiveDimCount
 };
 
 template <>
-struct SolidPrimitiveDimCount<shape_msgs::SolidPrimitive::SPHERE>
+struct SolidPrimitiveDimCount<shape_msgs::msg::SolidPrimitive::SPHERE>
 {
   enum
   {
-    value = static_cast<int>(shape_msgs::SolidPrimitive::SPHERE_RADIUS) + 1
+    value = static_cast<int>(shape_msgs::msg::SolidPrimitive::SPHERE_RADIUS) + 1
   };
 };
 
 template <>
-struct SolidPrimitiveDimCount<shape_msgs::SolidPrimitive::BOX>
+struct SolidPrimitiveDimCount<shape_msgs::msg::SolidPrimitive::BOX>
 {
   enum
   {
     value =
-        (static_cast<int>(shape_msgs::SolidPrimitive::BOX_X) >= static_cast<int>(shape_msgs::SolidPrimitive::BOX_Y) &&
-         static_cast<int>(shape_msgs::SolidPrimitive::BOX_X) >= static_cast<int>(shape_msgs::SolidPrimitive::BOX_Z)) ?
-            static_cast<int>(shape_msgs::SolidPrimitive::BOX_X) :
-            (((static_cast<int>(shape_msgs::SolidPrimitive::BOX_Y) >=
-                   static_cast<int>(shape_msgs::SolidPrimitive::BOX_X) &&
-               static_cast<int>(shape_msgs::SolidPrimitive::BOX_Y) >=
-                   static_cast<int>(shape_msgs::SolidPrimitive::BOX_Z))) ?
-                 static_cast<int>(shape_msgs::SolidPrimitive::BOX_Y) :
-                 ((static_cast<int>(shape_msgs::SolidPrimitive::BOX_Z) >=
-                       static_cast<int>(shape_msgs::SolidPrimitive::BOX_X) &&
-                   static_cast<int>(shape_msgs::SolidPrimitive::BOX_Z) >=
-                       static_cast<int>(shape_msgs::SolidPrimitive::BOX_Y)) ?
-                      static_cast<int>(shape_msgs::SolidPrimitive::BOX_Z) :
+        (static_cast<int>(shape_msgs::msg::SolidPrimitive::BOX_X) >= static_cast<int>(shape_msgs::msg::SolidPrimitive::BOX_Y) &&
+         static_cast<int>(shape_msgs::msg::SolidPrimitive::BOX_X) >= static_cast<int>(shape_msgs::msg::SolidPrimitive::BOX_Z)) ?
+            static_cast<int>(shape_msgs::msg::SolidPrimitive::BOX_X) :
+            (((static_cast<int>(shape_msgs::msg::SolidPrimitive::BOX_Y) >=
+                   static_cast<int>(shape_msgs::msg::SolidPrimitive::BOX_X) &&
+               static_cast<int>(shape_msgs::msg::SolidPrimitive::BOX_Y) >=
+                   static_cast<int>(shape_msgs::msg::SolidPrimitive::BOX_Z))) ?
+                 static_cast<int>(shape_msgs::msg::SolidPrimitive::BOX_Y) :
+                 ((static_cast<int>(shape_msgs::msg::SolidPrimitive::BOX_Z) >=
+                       static_cast<int>(shape_msgs::msg::SolidPrimitive::BOX_X) &&
+                   static_cast<int>(shape_msgs::msg::SolidPrimitive::BOX_Z) >=
+                       static_cast<int>(shape_msgs::msg::SolidPrimitive::BOX_Y)) ?
+                      static_cast<int>(shape_msgs::msg::SolidPrimitive::BOX_Z) :
                       0)) +
                 1
   };
 };
 
 template <>
-struct SolidPrimitiveDimCount<shape_msgs::SolidPrimitive::CONE>
+struct SolidPrimitiveDimCount<shape_msgs::msg::SolidPrimitive::CONE>
 {
   enum
   {
-    value = (static_cast<int>(shape_msgs::SolidPrimitive::CONE_RADIUS) >=
-                     static_cast<int>(shape_msgs::SolidPrimitive::CONE_HEIGHT) ?
-                 static_cast<int>(shape_msgs::SolidPrimitive::CONE_RADIUS) :
-                 static_cast<int>(shape_msgs::SolidPrimitive::CONE_HEIGHT)) +
+    value = (static_cast<int>(shape_msgs::msg::SolidPrimitive::CONE_RADIUS) >=
+                     static_cast<int>(shape_msgs::msg::SolidPrimitive::CONE_HEIGHT) ?
+                 static_cast<int>(shape_msgs::msg::SolidPrimitive::CONE_RADIUS) :
+                 static_cast<int>(shape_msgs::msg::SolidPrimitive::CONE_HEIGHT)) +
             1
   };
 };
 
 template <>
-struct SolidPrimitiveDimCount<shape_msgs::SolidPrimitive::CYLINDER>
+struct SolidPrimitiveDimCount<shape_msgs::msg::SolidPrimitive::CYLINDER>
 {
   enum
   {
-    value = (static_cast<int>(shape_msgs::SolidPrimitive::CYLINDER_RADIUS) >=
-                     static_cast<int>(shape_msgs::SolidPrimitive::CYLINDER_HEIGHT) ?
-                 static_cast<int>(shape_msgs::SolidPrimitive::CYLINDER_RADIUS) :
-                 static_cast<int>(shape_msgs::SolidPrimitive::CYLINDER_HEIGHT)) +
+    value = (static_cast<int>(shape_msgs::msg::SolidPrimitive::CYLINDER_RADIUS) >=
+                     static_cast<int>(shape_msgs::msg::SolidPrimitive::CYLINDER_HEIGHT) ?
+                 static_cast<int>(shape_msgs::msg::SolidPrimitive::CYLINDER_RADIUS) :
+                 static_cast<int>(shape_msgs::msg::SolidPrimitive::CYLINDER_HEIGHT)) +
             1
   };
 };

--- a/package.xml
+++ b/package.xml
@@ -31,7 +31,9 @@
   <build_depend>shape_msgs</build_depend>
   <build_depend>geometry_msgs</build_depend>
   <build_depend>visualization_msgs</build_depend>
+  <build_depend>rclcpp</build_depend>
 
+  <exec_depend>rclcpp</exec_depend>
   <exec_depend>rosidl_default_runtime</exec_depend>
   <exec_depend>assimp</exec_depend>
   <exec_depend>boost</exec_depend>
@@ -45,6 +47,9 @@
   <exec_depend>shape_msgs</exec_depend>
   <exec_depend>geometry_msgs</exec_depend>
   <exec_depend>visualization_msgs</exec_depend>
+
+  <test_depend>ament_cmake_gtest</test_depend>
+  <test_depend>ament_lint_auto</test_depend>
   <export>
     <build_type>ament_cmake</build_type>
   </export>

--- a/package.xml
+++ b/package.xml
@@ -1,6 +1,8 @@
-<package>
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
   <name>geometric_shapes</name>
-  <version>0.6.1</version>
+  <version>0.6.2</version>
   <description>This package contains generic definitions of geometric shapes and bodies.</description>
 
   <author email="isucan@google.com">Ioan Sucan</author>
@@ -8,11 +10,13 @@
 
   <maintainer email="dave@dav.ee">Dave Coleman</maintainer>
   <maintainer email="130s@2000.jukuin.keio.ac.jp">Isaac I. Y. Saito</maintainer>
+  <maintainer email="vmayoral@acutronicrobotics.com">Víctor Mayoral Vilches</maintainer>
 
   <license>BSD</license>
   <url>http://ros.org/wiki/geometric_shapes</url>
 
-  <buildtool_depend version_gte="0.5.68">catkin</buildtool_depend>
+  <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>rosidl_default_generators</buildtool_depend>
 
   <build_depend>assimp-dev</build_depend>
   <build_depend>boost</build_depend>
@@ -25,19 +29,24 @@
   <build_depend>random_numbers</build_depend>
   <build_depend>resource_retriever</build_depend>
   <build_depend>shape_msgs</build_depend>
+  <build_depend>geometry_msgs</build_depend>
   <build_depend>visualization_msgs</build_depend>
 
-  <run_depend>assimp</run_depend>
-  <run_depend>boost</run_depend>
-  <run_depend>eigen</run_depend>
-  <run_depend>eigen_stl_containers</run_depend>
-  <run_depend>libconsole-bridge-dev</run_depend>
-  <run_depend>libqhull</run_depend>
-  <run_depend>octomap</run_depend>
-  <run_depend>random_numbers</run_depend>
-  <run_depend>resource_retriever</run_depend>
-  <run_depend>shape_msgs</run_depend>
-  <run_depend>visualization_msgs</run_depend>
+  <exec_depend>rosidl_default_runtime</exec_depend>
+  <exec_depend>assimp</exec_depend>
+  <exec_depend>boost</exec_depend>
+  <exec_depend>eigen</exec_depend>
+  <exec_depend>eigen_stl_containers</exec_depend>
+  <exec_depend>libconsole-bridge-dev</exec_depend>
+  <exec_depend>libqhull</exec_depend>
+  <exec_depend>octomap</exec_depend>
+  <exec_depend>random_numbers</exec_depend>
+  <exec_depend>resource_retriever</exec_depend>
+  <exec_depend>shape_msgs</exec_depend>
+  <exec_depend>geometry_msgs</exec_depend>
+  <exec_depend>visualization_msgs</exec_depend>
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
 
-  <test_depend>rosunit</test_depend>
 </package>

--- a/src/aabb.cpp
+++ b/src/aabb.cpp
@@ -1,7 +1,7 @@
 /*********************************************************************
 * Software License Agreement (BSD License)
 *
-*  Copyright (c) 2008, Willow Garage, Inc.
+*  Copyright (c) 2019, Open Robotics
 *  All rights reserved.
 *
 *  Redistribution and use in source and binary forms, with or without
@@ -14,7 +14,7 @@
 *     copyright notice, this list of conditions and the following
 *     disclaimer in the documentation and/or other materials provided
 *     with the distribution.
-*   * Neither the name of the Willow Garage nor the names of its
+*   * Neither the name of the Open Robotics nor the names of its
 *     contributors may be used to endorse or promote products derived
 *     from this software without specific prior written permission.
 *
@@ -32,38 +32,26 @@
 *  POSSIBILITY OF SUCH DAMAGE.
 *********************************************************************/
 
-/* Author: Ioan Sucan, E. Gil Jones */
+/* Author: Martin Pecka */
 
-#ifndef GEOMETRIC_SHAPES_BODY_OPERATIONS_
-#define GEOMETRIC_SHAPES_BODY_OPERATIONS_
+#include <geometric_shapes/aabb.h>
 
-#include "geometric_shapes/shapes.h"
-#include "geometric_shapes/bodies.h"
-#include "geometric_shapes/shape_messages.h"
-#include <geometry_msgs/Pose.h>
-#include <vector>
-
-namespace bodies
+void bodies::AABB::extendWithTransformedBox(const Eigen::Isometry3d& transform, const Eigen::Vector3d& box)
 {
-/** \brief Create a body from a given shape */
-Body* createBodyFromShape(const shapes::Shape* shape);
+  // Method adapted from FCL src/shape/geometric_shapes_utility.cpp#computeBV<AABB, Box>(...) (BSD-licensed code):
+  // https://github.com/flexible-collision-library/fcl/blob/fcl-0.4/src/shape/geometric_shapes_utility.cpp#L292
+  // We don't call their code because it would need creating temporary objects, and their method is in floats.
+  //
+  // Here's a nice explanation why it works: https://zeuxcg.org/2010/10/17/aabb-from-obb-with-component-wise-abs/
 
-/** \brief Create a body from a given shape */
-Body* constructBodyFromMsg(const shape_msgs::Mesh& shape, const geometry_msgs::Pose& pose);
+  const Eigen::Matrix3d& r = transform.rotation();
+  const Eigen::Vector3d& t = transform.translation();
 
-/** \brief Create a body from a given shape */
-Body* constructBodyFromMsg(const shape_msgs::SolidPrimitive& shape, const geometry_msgs::Pose& pose);
+  double x_range = 0.5 * (fabs(r(0, 0) * box[0]) + fabs(r(0, 1) * box[1]) + fabs(r(0, 2) * box[2]));
+  double y_range = 0.5 * (fabs(r(1, 0) * box[0]) + fabs(r(1, 1) * box[1]) + fabs(r(1, 2) * box[2]));
+  double z_range = 0.5 * (fabs(r(2, 0) * box[0]) + fabs(r(2, 1) * box[1]) + fabs(r(2, 2) * box[2]));
 
-/** \brief Create a body from a given shape */
-Body* constructBodyFromMsg(const shapes::ShapeMsg& shape, const geometry_msgs::Pose& pose);
-
-/** \brief Compute a bounding sphere to enclose a set of bounding spheres */
-void mergeBoundingSpheres(const std::vector<BoundingSphere>& spheres, BoundingSphere& mergedSphere);
-
-/** \brief Compute an axis-aligned bounding box to enclose a set of bounding boxes. */
-void mergeBoundingBoxes(const std::vector<AABB>& boxes, AABB& mergedBox);
-
-/** \brief Compute the bounding sphere for a set of \e bodies and store the resulting sphere in \e mergedSphere */
-void computeBoundingSphere(const std::vector<const Body*>& bodies, BoundingSphere& mergedSphere);
+  const Eigen::Vector3d v_delta(x_range, y_range, z_range);
+  extend(t + v_delta);
+  extend(t - v_delta);
 }
-#endif

--- a/src/bodies.cpp
+++ b/src/bodies.cpp
@@ -151,7 +151,7 @@ void bodies::Sphere::updateInternalData()
   center_ = pose_.translation();
 }
 
-std::shared_ptr<bodies::Body> bodies::Sphere::cloneAt(const Eigen::Isometry3d& pose, double padding, double scale) const
+std::shared_ptr<bodies::Body> bodies::Sphere::cloneAt(const Eigen::Affine3d& pose, double padding, double scale) const
 {
   Sphere* s = new Sphere();
   s->radius_ = radius_;
@@ -330,7 +330,7 @@ bool bodies::Cylinder::samplePointInside(random_numbers::RandomNumberGenerator& 
   return true;
 }
 
-std::shared_ptr<bodies::Body> bodies::Cylinder::cloneAt(const Eigen::Isometry3d& pose, double padding,
+std::shared_ptr<bodies::Body> bodies::Cylinder::cloneAt(const Eigen::Affine3d& pose, double padding,
                                                         double scale) const
 {
   Cylinder* c = new Cylinder();
@@ -531,7 +531,7 @@ void bodies::Box::updateInternalData()
   corner2_ = center_ + tmp;
 }
 
-std::shared_ptr<bodies::Body> bodies::Box::cloneAt(const Eigen::Isometry3d& pose, double padding, double scale) const
+std::shared_ptr<bodies::Body> bodies::Box::cloneAt(const Eigen::Affine3d& pose, double padding, double scale) const
 {
   Box* b = new Box();
   b->length_ = length_;
@@ -947,7 +947,7 @@ void bodies::ConvexMesh::updateInternalData()
 {
   if (!mesh_data_)
     return;
-  Eigen::Isometry3d pose = pose_;
+  Eigen::Affine3d pose = pose_;
   pose.translation() = Eigen::Vector3d(pose_ * mesh_data_->box_offset_);
 
   std::unique_ptr<shapes::Box> box_shape(
@@ -1003,7 +1003,7 @@ const EigenSTL::vector_Vector4d& bodies::ConvexMesh::getPlanes() const
   return mesh_data_ ? mesh_data_->planes_ : empty;
 }
 
-std::shared_ptr<bodies::Body> bodies::ConvexMesh::cloneAt(const Eigen::Isometry3d& pose, double padding,
+std::shared_ptr<bodies::Body> bodies::ConvexMesh::cloneAt(const Eigen::Affine3d& pose, double padding,
                                                           double scale) const
 {
   ConvexMesh* m = new ConvexMesh();

--- a/src/bodies.cpp
+++ b/src/bodies.cpp
@@ -564,7 +564,7 @@ void bodies::Box::computeBoundingCylinder(BoundingCylinder& cylinder) const
     cylinder.length = length2_ * 2.0;
     a = width2_;
     b = height2_;
-    Eigen::Isometry3d rot(Eigen::AngleAxisd(90.0f * (M_PI / 180.0f), Eigen::Vector3d::UnitY()));
+    Eigen::Affine3d rot(Eigen::AngleAxisd(90.0f * (M_PI / 180.0f), Eigen::Vector3d::UnitY()));
     cylinder.pose = pose_ * rot;
   }
   else if (width2_ > height2_)
@@ -573,7 +573,7 @@ void bodies::Box::computeBoundingCylinder(BoundingCylinder& cylinder) const
     a = height2_;
     b = length2_;
     cylinder.radius = sqrt(height2_ * height2_ + length2_ * length2_);
-    Eigen::Isometry3d rot(Eigen::AngleAxisd(90.0f * (M_PI / 180.0f), Eigen::Vector3d::UnitX()));
+    Eigen::Affine3d rot(Eigen::AngleAxisd(90.0f * (M_PI / 180.0f), Eigen::Vector3d::UnitX()));
     cylinder.pose = pose_ * rot;
   }
   else
@@ -1170,7 +1170,7 @@ bodies::BodyVector::BodyVector()
 {
 }
 
-bodies::BodyVector::BodyVector(const std::vector<shapes::Shape*>& shapes, const EigenSTL::vector_Isometry3d& poses,
+bodies::BodyVector::BodyVector(const std::vector<shapes::Shape*>& shapes, const EigenSTL::vector_Affine3d& poses,
                                double padding)
 {
   for (unsigned int i = 0; i < shapes.size(); i++)
@@ -1196,7 +1196,7 @@ void bodies::BodyVector::addBody(Body* body)
   body->computeBoundingSphere(sphere);
 }
 
-void bodies::BodyVector::addBody(const shapes::Shape* shape, const Eigen::Isometry3d& pose, double padding)
+void bodies::BodyVector::addBody(const shapes::Shape* shape, const Eigen::Affine3d& pose, double padding)
 {
   bodies::Body* body = bodies::createBodyFromShape(shape);
   body->setPose(pose);
@@ -1209,7 +1209,7 @@ std::size_t bodies::BodyVector::getCount() const
   return bodies_.size();
 }
 
-void bodies::BodyVector::setPose(unsigned int i, const Eigen::Isometry3d& pose)
+void bodies::BodyVector::setPose(unsigned int i, const Eigen::Affine3d& pose)
 {
   if (i >= bodies_.size())
   {

--- a/src/bodies.cpp
+++ b/src/bodies.cpp
@@ -151,7 +151,7 @@ void bodies::Sphere::updateInternalData()
   center_ = pose_.translation();
 }
 
-std::shared_ptr<bodies::Body> bodies::Sphere::cloneAt(const Eigen::Affine3d& pose, double padding, double scale) const
+std::shared_ptr<bodies::Body> bodies::Sphere::cloneAt(const Eigen::Isometry3d& pose, double padding, double scale) const
 {
   Sphere* s = new Sphere();
   s->radius_ = radius_;
@@ -330,7 +330,7 @@ bool bodies::Cylinder::samplePointInside(random_numbers::RandomNumberGenerator& 
   return true;
 }
 
-std::shared_ptr<bodies::Body> bodies::Cylinder::cloneAt(const Eigen::Affine3d& pose, double padding,
+std::shared_ptr<bodies::Body> bodies::Cylinder::cloneAt(const Eigen::Isometry3d& pose, double padding,
                                                         double scale) const
 {
   Cylinder* c = new Cylinder();
@@ -531,7 +531,7 @@ void bodies::Box::updateInternalData()
   corner2_ = center_ + tmp;
 }
 
-std::shared_ptr<bodies::Body> bodies::Box::cloneAt(const Eigen::Affine3d& pose, double padding, double scale) const
+std::shared_ptr<bodies::Body> bodies::Box::cloneAt(const Eigen::Isometry3d& pose, double padding, double scale) const
 {
   Box* b = new Box();
   b->length_ = length_;
@@ -564,7 +564,7 @@ void bodies::Box::computeBoundingCylinder(BoundingCylinder& cylinder) const
     cylinder.length = length2_ * 2.0;
     a = width2_;
     b = height2_;
-    Eigen::Affine3d rot(Eigen::AngleAxisd(90.0f * (M_PI / 180.0f), Eigen::Vector3d::UnitY()));
+    Eigen::Isometry3d rot(Eigen::AngleAxisd(90.0f * (M_PI / 180.0f), Eigen::Vector3d::UnitY()));
     cylinder.pose = pose_ * rot;
   }
   else if (width2_ > height2_)
@@ -573,7 +573,7 @@ void bodies::Box::computeBoundingCylinder(BoundingCylinder& cylinder) const
     a = height2_;
     b = length2_;
     cylinder.radius = sqrt(height2_ * height2_ + length2_ * length2_);
-    Eigen::Affine3d rot(Eigen::AngleAxisd(90.0f * (M_PI / 180.0f), Eigen::Vector3d::UnitX()));
+    Eigen::Isometry3d rot(Eigen::AngleAxisd(90.0f * (M_PI / 180.0f), Eigen::Vector3d::UnitX()));
     cylinder.pose = pose_ * rot;
   }
   else
@@ -947,7 +947,7 @@ void bodies::ConvexMesh::updateInternalData()
 {
   if (!mesh_data_)
     return;
-  Eigen::Affine3d pose = pose_;
+  Eigen::Isometry3d pose = pose_;
   pose.translation() = Eigen::Vector3d(pose_ * mesh_data_->box_offset_);
 
   std::unique_ptr<shapes::Box> box_shape(
@@ -1003,7 +1003,7 @@ const EigenSTL::vector_Vector4d& bodies::ConvexMesh::getPlanes() const
   return mesh_data_ ? mesh_data_->planes_ : empty;
 }
 
-std::shared_ptr<bodies::Body> bodies::ConvexMesh::cloneAt(const Eigen::Affine3d& pose, double padding,
+std::shared_ptr<bodies::Body> bodies::ConvexMesh::cloneAt(const Eigen::Isometry3d& pose, double padding,
                                                           double scale) const
 {
   ConvexMesh* m = new ConvexMesh();
@@ -1170,7 +1170,7 @@ bodies::BodyVector::BodyVector()
 {
 }
 
-bodies::BodyVector::BodyVector(const std::vector<shapes::Shape*>& shapes, const EigenSTL::vector_Affine3d& poses,
+bodies::BodyVector::BodyVector(const std::vector<shapes::Shape*>& shapes, const EigenSTL::vector_Isometry3d& poses,
                                double padding)
 {
   for (unsigned int i = 0; i < shapes.size(); i++)
@@ -1196,7 +1196,7 @@ void bodies::BodyVector::addBody(Body* body)
   body->computeBoundingSphere(sphere);
 }
 
-void bodies::BodyVector::addBody(const shapes::Shape* shape, const Eigen::Affine3d& pose, double padding)
+void bodies::BodyVector::addBody(const shapes::Shape* shape, const Eigen::Isometry3d& pose, double padding)
 {
   bodies::Body* body = bodies::createBodyFromShape(shape);
   body->setPose(pose);
@@ -1209,7 +1209,7 @@ std::size_t bodies::BodyVector::getCount() const
   return bodies_.size();
 }
 
-void bodies::BodyVector::setPose(unsigned int i, const Eigen::Affine3d& pose)
+void bodies::BodyVector::setPose(unsigned int i, const Eigen::Isometry3d& pose)
 {
   if (i >= bodies_.size())
   {

--- a/src/body_operations.cpp
+++ b/src/body_operations.cpp
@@ -175,3 +175,9 @@ void bodies::computeBoundingSphere(const std::vector<const bodies::Body*>& bodie
   }
   sphere.radius = sqrt(max_dist_squared);
 }
+
+void bodies::mergeBoundingBoxes(const std::vector<bodies::AABB>& boxes, bodies::AABB& mergedBox)
+{
+  for (const auto& box : boxes)
+    mergedBox.extend(box);
+}

--- a/src/body_operations.cpp
+++ b/src/body_operations.cpp
@@ -134,7 +134,7 @@ bodies::Body* bodies::constructBodyFromMsg(const shape_msgs::Mesh& shape_msg, co
   return constructBodyFromMsgHelper(shape_msg, pose);
 }
 
-bodies::Body* bodies::constructBodyFromMsg(const shape_msgs::SolidPrimitive& shape_msg, const geometry_msgs::Pose& pose)
+bodies::Body* bodies::constructBodyFromMsg(const shape_msgs::msg::SolidPrimitive& shape_msg, const geometry_msgs::Pose& pose)
 {
   return constructBodyFromMsgHelper(shape_msg, pose);
 }

--- a/src/body_operations.cpp
+++ b/src/body_operations.cpp
@@ -129,7 +129,7 @@ bodies::Body* bodies::constructBodyFromMsg(const shapes::ShapeMsg& shape_msg, co
   return constructBodyFromMsgHelper(shape_msg, pose);
 }
 
-bodies::Body* bodies::constructBodyFromMsg(const shape_msgs::Mesh& shape_msg, const geometry_msgs::Pose& pose)
+bodies::Body* bodies::constructBodyFromMsg(const shape_msgs::msg::Mesh& shape_msg, const geometry_msgs::Pose& pose)
 {
   return constructBodyFromMsgHelper(shape_msg, pose);
 }

--- a/src/body_operations.cpp
+++ b/src/body_operations.cpp
@@ -100,7 +100,7 @@ void bodies::mergeBoundingSpheres(const std::vector<BoundingSphere>& spheres, Bo
 namespace bodies
 {
 template <typename T>
-Body* constructBodyFromMsgHelper(const T& shape_msg, const geometry_msgs::Pose& pose)
+Body* constructBodyFromMsgHelper(const T& shape_msg, const geometry_msgs::msg::Pose& pose)
 {
   shapes::Shape* shape = shapes::constructShapeFromMsg(shape_msg);
 
@@ -124,17 +124,17 @@ Body* constructBodyFromMsgHelper(const T& shape_msg, const geometry_msgs::Pose& 
 }
 }
 
-bodies::Body* bodies::constructBodyFromMsg(const shapes::ShapeMsg& shape_msg, const geometry_msgs::Pose& pose)
+bodies::Body* bodies::constructBodyFromMsg(const shapes::ShapeMsg& shape_msg, const geometry_msgs::msg::Pose& pose)
 {
   return constructBodyFromMsgHelper(shape_msg, pose);
 }
 
-bodies::Body* bodies::constructBodyFromMsg(const shape_msgs::msg::Mesh& shape_msg, const geometry_msgs::Pose& pose)
+bodies::Body* bodies::constructBodyFromMsg(const shape_msgs::msg::Mesh& shape_msg, const geometry_msgs::msg::Pose& pose)
 {
   return constructBodyFromMsgHelper(shape_msg, pose);
 }
 
-bodies::Body* bodies::constructBodyFromMsg(const shape_msgs::msg::SolidPrimitive& shape_msg, const geometry_msgs::Pose& pose)
+bodies::Body* bodies::constructBodyFromMsg(const shape_msgs::msg::SolidPrimitive& shape_msg, const geometry_msgs::msg::Pose& pose)
 {
   return constructBodyFromMsgHelper(shape_msg, pose);
 }

--- a/src/shape_extents.cpp
+++ b/src/shape_extents.cpp
@@ -35,43 +35,43 @@
 #include <geometric_shapes/shape_extents.h>
 #include <limits>
 
-void geometric_shapes::getShapeExtents(const shape_msgs::SolidPrimitive& shape_msg, double& x_extent, double& y_extent,
+void geometric_shapes::getShapeExtents(const shape_msgs::msg::SolidPrimitive& shape_msg, double& x_extent, double& y_extent,
                                        double& z_extent)
 {
   x_extent = y_extent = z_extent = 0.0;
 
-  if (shape_msg.type == shape_msgs::SolidPrimitive::SPHERE)
+  if (shape_msg.type == shape_msgs::msg::SolidPrimitive::SPHERE)
   {
-    if (shape_msg.dimensions.size() > shape_msgs::SolidPrimitive::SPHERE_RADIUS)
-      x_extent = y_extent = z_extent = shape_msg.dimensions[shape_msgs::SolidPrimitive::SPHERE_RADIUS] * 2.0;
+    if (shape_msg.dimensions.size() > shape_msgs::msg::SolidPrimitive::SPHERE_RADIUS)
+      x_extent = y_extent = z_extent = shape_msg.dimensions[shape_msgs::msg::SolidPrimitive::SPHERE_RADIUS] * 2.0;
   }
-  else if (shape_msg.type == shape_msgs::SolidPrimitive::BOX)
+  else if (shape_msg.type == shape_msgs::msg::SolidPrimitive::BOX)
   {
-    if (shape_msg.dimensions.size() > shape_msgs::SolidPrimitive::BOX_X &&
-        shape_msg.dimensions.size() > shape_msgs::SolidPrimitive::BOX_Y &&
-        shape_msg.dimensions.size() > shape_msgs::SolidPrimitive::BOX_Z)
+    if (shape_msg.dimensions.size() > shape_msgs::msg::SolidPrimitive::BOX_X &&
+        shape_msg.dimensions.size() > shape_msgs::msg::SolidPrimitive::BOX_Y &&
+        shape_msg.dimensions.size() > shape_msgs::msg::SolidPrimitive::BOX_Z)
     {
-      x_extent = shape_msg.dimensions[shape_msgs::SolidPrimitive::BOX_X];
-      y_extent = shape_msg.dimensions[shape_msgs::SolidPrimitive::BOX_Y];
-      z_extent = shape_msg.dimensions[shape_msgs::SolidPrimitive::BOX_Z];
+      x_extent = shape_msg.dimensions[shape_msgs::msg::SolidPrimitive::BOX_X];
+      y_extent = shape_msg.dimensions[shape_msgs::msg::SolidPrimitive::BOX_Y];
+      z_extent = shape_msg.dimensions[shape_msgs::msg::SolidPrimitive::BOX_Z];
     }
   }
-  else if (shape_msg.type == shape_msgs::SolidPrimitive::CYLINDER)
+  else if (shape_msg.type == shape_msgs::msg::SolidPrimitive::CYLINDER)
   {
-    if (shape_msg.dimensions.size() > shape_msgs::SolidPrimitive::CYLINDER_RADIUS &&
-        shape_msg.dimensions.size() > shape_msgs::SolidPrimitive::CYLINDER_HEIGHT)
+    if (shape_msg.dimensions.size() > shape_msgs::msg::SolidPrimitive::CYLINDER_RADIUS &&
+        shape_msg.dimensions.size() > shape_msgs::msg::SolidPrimitive::CYLINDER_HEIGHT)
     {
-      x_extent = y_extent = shape_msg.dimensions[shape_msgs::SolidPrimitive::CYLINDER_RADIUS] * 2.0;
-      z_extent = shape_msg.dimensions[shape_msgs::SolidPrimitive::CYLINDER_HEIGHT];
+      x_extent = y_extent = shape_msg.dimensions[shape_msgs::msg::SolidPrimitive::CYLINDER_RADIUS] * 2.0;
+      z_extent = shape_msg.dimensions[shape_msgs::msg::SolidPrimitive::CYLINDER_HEIGHT];
     }
   }
-  else if (shape_msg.type == shape_msgs::SolidPrimitive::CONE)
+  else if (shape_msg.type == shape_msgs::msg::SolidPrimitive::CONE)
   {
-    if (shape_msg.dimensions.size() > shape_msgs::SolidPrimitive::CONE_RADIUS &&
-        shape_msg.dimensions.size() > shape_msgs::SolidPrimitive::CONE_HEIGHT)
+    if (shape_msg.dimensions.size() > shape_msgs::msg::SolidPrimitive::CONE_RADIUS &&
+        shape_msg.dimensions.size() > shape_msgs::msg::SolidPrimitive::CONE_HEIGHT)
     {
-      x_extent = y_extent = shape_msg.dimensions[shape_msgs::SolidPrimitive::CONE_RADIUS] * 2.0;
-      z_extent = shape_msg.dimensions[shape_msgs::SolidPrimitive::CONE_HEIGHT];
+      x_extent = y_extent = shape_msg.dimensions[shape_msgs::msg::SolidPrimitive::CONE_RADIUS] * 2.0;
+      z_extent = shape_msg.dimensions[shape_msgs::msg::SolidPrimitive::CONE_HEIGHT];
     }
   }
 }

--- a/src/shape_extents.cpp
+++ b/src/shape_extents.cpp
@@ -76,7 +76,7 @@ void geometric_shapes::getShapeExtents(const shape_msgs::msg::SolidPrimitive& sh
   }
 }
 
-void geometric_shapes::getShapeExtents(const shape_msgs::Mesh& shape_msg, double& x_extent, double& y_extent,
+void geometric_shapes::getShapeExtents(const shape_msgs::msg::Mesh& shape_msg, double& x_extent, double& y_extent,
                                        double& z_extent)
 {
   x_extent = y_extent = z_extent = 0.0;

--- a/src/shape_operations.cpp
+++ b/src/shape_operations.cpp
@@ -150,7 +150,7 @@ namespace
 class ShapeVisitorMarker : public boost::static_visitor<void>
 {
 public:
-  ShapeVisitorMarker(visualization_msgs::Marker* marker, bool use_mesh_triangle_list)
+  ShapeVisitorMarker(visualization_msgs::msg::Marker* marker, bool use_mesh_triangle_list)
     : boost::static_visitor<void>(), use_mesh_triangle_list_(use_mesh_triangle_list), marker_(marker)
   {
   }
@@ -172,11 +172,11 @@ public:
 
 private:
   bool use_mesh_triangle_list_;
-  visualization_msgs::Marker* marker_;
+  visualization_msgs::msg::Marker* marker_;
 };
 }
 
-bool constructMarkerFromShape(const Shape* shape, visualization_msgs::Marker& marker, bool use_mesh_triangle_list)
+bool constructMarkerFromShape(const Shape* shape, visualization_msgs::msg::Marker& marker, bool use_mesh_triangle_list)
 {
   ShapeMsg shape_msg;
   if (constructMsgFromShape(shape, shape_msg))

--- a/src/shape_operations.cpp
+++ b/src/shape_operations.cpp
@@ -57,7 +57,7 @@ Shape* constructShapeFromMsg(const shape_msgs::Plane& shape_msg)
   return new Plane(shape_msg.coef[0], shape_msg.coef[1], shape_msg.coef[2], shape_msg.coef[3]);
 }
 
-Shape* constructShapeFromMsg(const shape_msgs::Mesh& shape_msg)
+Shape* constructShapeFromMsg(const shape_msgs::msg::Mesh& shape_msg)
 {
   if (shape_msg.triangles.empty() || shape_msg.vertices.empty())
   {
@@ -128,7 +128,7 @@ public:
     return constructShapeFromMsg(shape_msg);
   }
 
-  Shape* operator()(const shape_msgs::Mesh& shape_msg) const
+  Shape* operator()(const shape_msgs::msg::Mesh& shape_msg) const
   {
     return constructShapeFromMsg(shape_msg);
   }
@@ -160,7 +160,7 @@ public:
     throw std::runtime_error("No visual markers can be constructed for planes");
   }
 
-  void operator()(const shape_msgs::Mesh& shape_msg) const
+  void operator()(const shape_msgs::msg::Mesh& shape_msg) const
   {
     geometric_shapes::constructMarkerFromShape(shape_msg, *marker_, use_mesh_triangle_list_);
   }
@@ -208,7 +208,7 @@ public:
     return e;
   }
 
-  Eigen::Vector3d operator()(const shape_msgs::Mesh& shape_msg) const
+  Eigen::Vector3d operator()(const shape_msgs::msg::Mesh& shape_msg) const
   {
     double x_extent, y_extent, z_extent;
     geometric_shapes::getShapeExtents(shape_msg, x_extent, y_extent, z_extent);
@@ -398,7 +398,7 @@ bool constructMsgFromShape(const Shape* shape, ShapeMsg& shape_msg)
   }
   else if (shape->type == MESH)
   {
-    shape_msgs::Mesh s;
+    shape_msgs::msg::Mesh s;
     const Mesh* mesh = static_cast<const Mesh*>(shape);
     s.vertices.resize(mesh->vertex_count);
     s.triangles.resize(mesh->triangle_count);

--- a/src/shape_operations.cpp
+++ b/src/shape_operations.cpp
@@ -52,7 +52,7 @@
 
 namespace shapes
 {
-Shape* constructShapeFromMsg(const shape_msgs::Plane& shape_msg)
+Shape* constructShapeFromMsg(const shape_msgs::msg::Plane& shape_msg)
 {
   return new Plane(shape_msg.coef[0], shape_msg.coef[1], shape_msg.coef[2], shape_msg.coef[3]);
 }
@@ -123,7 +123,7 @@ namespace
 class ShapeVisitorAlloc : public boost::static_visitor<Shape*>
 {
 public:
-  Shape* operator()(const shape_msgs::Plane& shape_msg) const
+  Shape* operator()(const shape_msgs::msg::Plane& shape_msg) const
   {
     return constructShapeFromMsg(shape_msg);
   }
@@ -155,7 +155,7 @@ public:
   {
   }
 
-  void operator()(const shape_msgs::Plane& shape_msg) const
+  void operator()(const shape_msgs::msg::Plane& shape_msg) const
   {
     throw std::runtime_error("No visual markers can be constructed for planes");
   }
@@ -202,7 +202,7 @@ namespace
 class ShapeVisitorComputeExtents : public boost::static_visitor<Eigen::Vector3d>
 {
 public:
-  Eigen::Vector3d operator()(const shape_msgs::Plane& shape_msg) const
+  Eigen::Vector3d operator()(const shape_msgs::msg::Plane& shape_msg) const
   {
     Eigen::Vector3d e(0.0, 0.0, 0.0);
     return e;
@@ -388,7 +388,7 @@ bool constructMsgFromShape(const Shape* shape, ShapeMsg& shape_msg)
   }
   else if (shape->type == PLANE)
   {
-    shape_msgs::Plane s;
+    shape_msgs::msg::Plane s;
     const Plane* p = static_cast<const Plane*>(shape);
     s.coef[0] = p->a;
     s.coef[1] = p->b;

--- a/src/shape_operations.cpp
+++ b/src/shape_operations.cpp
@@ -81,36 +81,36 @@ Shape* constructShapeFromMsg(const shape_msgs::Mesh& shape_msg)
   }
 }
 
-Shape* constructShapeFromMsg(const shape_msgs::SolidPrimitive& shape_msg)
+Shape* constructShapeFromMsg(const shape_msgs::msg::SolidPrimitive& shape_msg)
 {
   Shape* shape = NULL;
-  if (shape_msg.type == shape_msgs::SolidPrimitive::SPHERE)
+  if (shape_msg.type == shape_msgs::msg::SolidPrimitive::SPHERE)
   {
-    if (shape_msg.dimensions.size() > shape_msgs::SolidPrimitive::SPHERE_RADIUS)
-      shape = new Sphere(shape_msg.dimensions[shape_msgs::SolidPrimitive::SPHERE_RADIUS]);
+    if (shape_msg.dimensions.size() > shape_msgs::msg::SolidPrimitive::SPHERE_RADIUS)
+      shape = new Sphere(shape_msg.dimensions[shape_msgs::msg::SolidPrimitive::SPHERE_RADIUS]);
   }
-  else if (shape_msg.type == shape_msgs::SolidPrimitive::BOX)
+  else if (shape_msg.type == shape_msgs::msg::SolidPrimitive::BOX)
   {
-    if (shape_msg.dimensions.size() > shape_msgs::SolidPrimitive::BOX_X &&
-        shape_msg.dimensions.size() > shape_msgs::SolidPrimitive::BOX_Y &&
-        shape_msg.dimensions.size() > shape_msgs::SolidPrimitive::BOX_Z)
-      shape = new Box(shape_msg.dimensions[shape_msgs::SolidPrimitive::BOX_X],
-                      shape_msg.dimensions[shape_msgs::SolidPrimitive::BOX_Y],
-                      shape_msg.dimensions[shape_msgs::SolidPrimitive::BOX_Z]);
+    if (shape_msg.dimensions.size() > shape_msgs::msg::SolidPrimitive::BOX_X &&
+        shape_msg.dimensions.size() > shape_msgs::msg::SolidPrimitive::BOX_Y &&
+        shape_msg.dimensions.size() > shape_msgs::msg::SolidPrimitive::BOX_Z)
+      shape = new Box(shape_msg.dimensions[shape_msgs::msg::SolidPrimitive::BOX_X],
+                      shape_msg.dimensions[shape_msgs::msg::SolidPrimitive::BOX_Y],
+                      shape_msg.dimensions[shape_msgs::msg::SolidPrimitive::BOX_Z]);
   }
-  else if (shape_msg.type == shape_msgs::SolidPrimitive::CYLINDER)
+  else if (shape_msg.type == shape_msgs::msg::SolidPrimitive::CYLINDER)
   {
-    if (shape_msg.dimensions.size() > shape_msgs::SolidPrimitive::CYLINDER_RADIUS &&
-        shape_msg.dimensions.size() > shape_msgs::SolidPrimitive::CYLINDER_HEIGHT)
-      shape = new Cylinder(shape_msg.dimensions[shape_msgs::SolidPrimitive::CYLINDER_RADIUS],
-                           shape_msg.dimensions[shape_msgs::SolidPrimitive::CYLINDER_HEIGHT]);
+    if (shape_msg.dimensions.size() > shape_msgs::msg::SolidPrimitive::CYLINDER_RADIUS &&
+        shape_msg.dimensions.size() > shape_msgs::msg::SolidPrimitive::CYLINDER_HEIGHT)
+      shape = new Cylinder(shape_msg.dimensions[shape_msgs::msg::SolidPrimitive::CYLINDER_RADIUS],
+                           shape_msg.dimensions[shape_msgs::msg::SolidPrimitive::CYLINDER_HEIGHT]);
   }
-  else if (shape_msg.type == shape_msgs::SolidPrimitive::CONE)
+  else if (shape_msg.type == shape_msgs::msg::SolidPrimitive::CONE)
   {
-    if (shape_msg.dimensions.size() > shape_msgs::SolidPrimitive::CONE_RADIUS &&
-        shape_msg.dimensions.size() > shape_msgs::SolidPrimitive::CONE_HEIGHT)
-      shape = new Cone(shape_msg.dimensions[shape_msgs::SolidPrimitive::CONE_RADIUS],
-                       shape_msg.dimensions[shape_msgs::SolidPrimitive::CONE_HEIGHT]);
+    if (shape_msg.dimensions.size() > shape_msgs::msg::SolidPrimitive::CONE_RADIUS &&
+        shape_msg.dimensions.size() > shape_msgs::msg::SolidPrimitive::CONE_HEIGHT)
+      shape = new Cone(shape_msg.dimensions[shape_msgs::msg::SolidPrimitive::CONE_RADIUS],
+                       shape_msg.dimensions[shape_msgs::msg::SolidPrimitive::CONE_HEIGHT]);
   }
   if (shape == NULL)
     CONSOLE_BRIDGE_logError("Unable to construct shape corresponding to shape_msg of type %d", (int)shape_msg.type);
@@ -133,7 +133,7 @@ public:
     return constructShapeFromMsg(shape_msg);
   }
 
-  Shape* operator()(const shape_msgs::SolidPrimitive& shape_msg) const
+  Shape* operator()(const shape_msgs::msg::SolidPrimitive& shape_msg) const
   {
     return constructShapeFromMsg(shape_msg);
   }
@@ -165,7 +165,7 @@ public:
     geometric_shapes::constructMarkerFromShape(shape_msg, *marker_, use_mesh_triangle_list_);
   }
 
-  void operator()(const shape_msgs::SolidPrimitive& shape_msg) const
+  void operator()(const shape_msgs::msg::SolidPrimitive& shape_msg) const
   {
     geometric_shapes::constructMarkerFromShape(shape_msg, *marker_);
   }
@@ -216,7 +216,7 @@ public:
     return e;
   }
 
-  Eigen::Vector3d operator()(const shape_msgs::SolidPrimitive& shape_msg) const
+  Eigen::Vector3d operator()(const shape_msgs::msg::SolidPrimitive& shape_msg) const
   {
     double x_extent, y_extent, z_extent;
     geometric_shapes::getShapeExtents(shape_msg, x_extent, y_extent, z_extent);
@@ -351,39 +351,39 @@ bool constructMsgFromShape(const Shape* shape, ShapeMsg& shape_msg)
 {
   if (shape->type == SPHERE)
   {
-    shape_msgs::SolidPrimitive s;
-    s.type = shape_msgs::SolidPrimitive::SPHERE;
-    s.dimensions.resize(geometric_shapes::SolidPrimitiveDimCount<shape_msgs::SolidPrimitive::SPHERE>::value);
-    s.dimensions[shape_msgs::SolidPrimitive::SPHERE_RADIUS] = static_cast<const Sphere*>(shape)->radius;
+    shape_msgs::msg::SolidPrimitive s;
+    s.type = shape_msgs::msg::SolidPrimitive::SPHERE;
+    s.dimensions.resize(geometric_shapes::SolidPrimitiveDimCount<shape_msgs::msg::SolidPrimitive::SPHERE>::value);
+    s.dimensions[shape_msgs::msg::SolidPrimitive::SPHERE_RADIUS] = static_cast<const Sphere*>(shape)->radius;
     shape_msg = s;
   }
   else if (shape->type == BOX)
   {
-    shape_msgs::SolidPrimitive s;
-    s.type = shape_msgs::SolidPrimitive::BOX;
+    shape_msgs::msg::SolidPrimitive s;
+    s.type = shape_msgs::msg::SolidPrimitive::BOX;
     const double* sz = static_cast<const Box*>(shape)->size;
-    s.dimensions.resize(geometric_shapes::SolidPrimitiveDimCount<shape_msgs::SolidPrimitive::BOX>::value);
-    s.dimensions[shape_msgs::SolidPrimitive::BOX_X] = sz[0];
-    s.dimensions[shape_msgs::SolidPrimitive::BOX_Y] = sz[1];
-    s.dimensions[shape_msgs::SolidPrimitive::BOX_Z] = sz[2];
+    s.dimensions.resize(geometric_shapes::SolidPrimitiveDimCount<shape_msgs::msg::SolidPrimitive::BOX>::value);
+    s.dimensions[shape_msgs::msg::SolidPrimitive::BOX_X] = sz[0];
+    s.dimensions[shape_msgs::msg::SolidPrimitive::BOX_Y] = sz[1];
+    s.dimensions[shape_msgs::msg::SolidPrimitive::BOX_Z] = sz[2];
     shape_msg = s;
   }
   else if (shape->type == CYLINDER)
   {
-    shape_msgs::SolidPrimitive s;
-    s.type = shape_msgs::SolidPrimitive::CYLINDER;
-    s.dimensions.resize(geometric_shapes::SolidPrimitiveDimCount<shape_msgs::SolidPrimitive::CYLINDER>::value);
-    s.dimensions[shape_msgs::SolidPrimitive::CYLINDER_RADIUS] = static_cast<const Cylinder*>(shape)->radius;
-    s.dimensions[shape_msgs::SolidPrimitive::CYLINDER_HEIGHT] = static_cast<const Cylinder*>(shape)->length;
+    shape_msgs::msg::SolidPrimitive s;
+    s.type = shape_msgs::msg::SolidPrimitive::CYLINDER;
+    s.dimensions.resize(geometric_shapes::SolidPrimitiveDimCount<shape_msgs::msg::SolidPrimitive::CYLINDER>::value);
+    s.dimensions[shape_msgs::msg::SolidPrimitive::CYLINDER_RADIUS] = static_cast<const Cylinder*>(shape)->radius;
+    s.dimensions[shape_msgs::msg::SolidPrimitive::CYLINDER_HEIGHT] = static_cast<const Cylinder*>(shape)->length;
     shape_msg = s;
   }
   else if (shape->type == CONE)
   {
-    shape_msgs::SolidPrimitive s;
-    s.type = shape_msgs::SolidPrimitive::CONE;
-    s.dimensions.resize(geometric_shapes::SolidPrimitiveDimCount<shape_msgs::SolidPrimitive::CONE>::value);
-    s.dimensions[shape_msgs::SolidPrimitive::CONE_RADIUS] = static_cast<const Cone*>(shape)->radius;
-    s.dimensions[shape_msgs::SolidPrimitive::CONE_HEIGHT] = static_cast<const Cone*>(shape)->length;
+    shape_msgs::msg::SolidPrimitive s;
+    s.type = shape_msgs::msg::SolidPrimitive::CONE;
+    s.dimensions.resize(geometric_shapes::SolidPrimitiveDimCount<shape_msgs::msg::SolidPrimitive::CONE>::value);
+    s.dimensions[shape_msgs::msg::SolidPrimitive::CONE_RADIUS] = static_cast<const Cone*>(shape)->radius;
+    s.dimensions[shape_msgs::msg::SolidPrimitive::CONE_HEIGHT] = static_cast<const Cone*>(shape)->length;
     shape_msg = s;
   }
   else if (shape->type == PLANE)

--- a/src/shape_to_marker.cpp
+++ b/src/shape_to_marker.cpp
@@ -36,56 +36,56 @@
 #include <sstream>
 #include <stdexcept>
 
-void geometric_shapes::constructMarkerFromShape(const shape_msgs::SolidPrimitive& shape_msg,
+void geometric_shapes::constructMarkerFromShape(const shape_msgs::msg::SolidPrimitive& shape_msg,
                                                 visualization_msgs::Marker& mk)
 {
   switch (shape_msg.type)
   {
-    case shape_msgs::SolidPrimitive::SPHERE:
-      if (shape_msg.dimensions.size() <= shape_msgs::SolidPrimitive::SPHERE_RADIUS)
+    case shape_msgs::msg::SolidPrimitive::SPHERE:
+      if (shape_msg.dimensions.size() <= shape_msgs::msg::SolidPrimitive::SPHERE_RADIUS)
         throw std::runtime_error("Insufficient dimensions in sphere definition");
       else
       {
         mk.type = visualization_msgs::Marker::SPHERE;
-        mk.scale.x = mk.scale.y = mk.scale.z = shape_msg.dimensions[shape_msgs::SolidPrimitive::SPHERE_RADIUS] * 2.0;
+        mk.scale.x = mk.scale.y = mk.scale.z = shape_msg.dimensions[shape_msgs::msg::SolidPrimitive::SPHERE_RADIUS] * 2.0;
       }
       break;
-    case shape_msgs::SolidPrimitive::BOX:
-      if (shape_msg.dimensions.size() <= shape_msgs::SolidPrimitive::BOX_X ||
-          shape_msg.dimensions.size() <= shape_msgs::SolidPrimitive::BOX_Y ||
-          shape_msg.dimensions.size() <= shape_msgs::SolidPrimitive::BOX_Z)
+    case shape_msgs::msg::SolidPrimitive::BOX:
+      if (shape_msg.dimensions.size() <= shape_msgs::msg::SolidPrimitive::BOX_X ||
+          shape_msg.dimensions.size() <= shape_msgs::msg::SolidPrimitive::BOX_Y ||
+          shape_msg.dimensions.size() <= shape_msgs::msg::SolidPrimitive::BOX_Z)
         throw std::runtime_error("Insufficient dimensions in box definition");
       else
       {
         mk.type = visualization_msgs::Marker::CUBE;
-        mk.scale.x = shape_msg.dimensions[shape_msgs::SolidPrimitive::BOX_X];
-        mk.scale.y = shape_msg.dimensions[shape_msgs::SolidPrimitive::BOX_Y];
-        mk.scale.z = shape_msg.dimensions[shape_msgs::SolidPrimitive::BOX_Z];
+        mk.scale.x = shape_msg.dimensions[shape_msgs::msg::SolidPrimitive::BOX_X];
+        mk.scale.y = shape_msg.dimensions[shape_msgs::msg::SolidPrimitive::BOX_Y];
+        mk.scale.z = shape_msg.dimensions[shape_msgs::msg::SolidPrimitive::BOX_Z];
       }
       break;
-    case shape_msgs::SolidPrimitive::CONE:
-      if (shape_msg.dimensions.size() <= shape_msgs::SolidPrimitive::CONE_RADIUS ||
-          shape_msg.dimensions.size() <= shape_msgs::SolidPrimitive::CONE_HEIGHT)
+    case shape_msgs::msg::SolidPrimitive::CONE:
+      if (shape_msg.dimensions.size() <= shape_msgs::msg::SolidPrimitive::CONE_RADIUS ||
+          shape_msg.dimensions.size() <= shape_msgs::msg::SolidPrimitive::CONE_HEIGHT)
         throw std::runtime_error("Insufficient dimensions in cone definition");
       else
       {
         // there is no CONE marker, so this produces a cylinder marker as well
         mk.type = visualization_msgs::Marker::CYLINDER;
-        mk.scale.x = shape_msg.dimensions[shape_msgs::SolidPrimitive::CONE_RADIUS] * 2.0;
+        mk.scale.x = shape_msg.dimensions[shape_msgs::msg::SolidPrimitive::CONE_RADIUS] * 2.0;
         mk.scale.y = mk.scale.x;
-        mk.scale.z = shape_msg.dimensions[shape_msgs::SolidPrimitive::CONE_HEIGHT];
+        mk.scale.z = shape_msg.dimensions[shape_msgs::msg::SolidPrimitive::CONE_HEIGHT];
       }
       break;
-    case shape_msgs::SolidPrimitive::CYLINDER:
-      if (shape_msg.dimensions.size() <= shape_msgs::SolidPrimitive::CYLINDER_RADIUS ||
-          shape_msg.dimensions.size() <= shape_msgs::SolidPrimitive::CYLINDER_HEIGHT)
+    case shape_msgs::msg::SolidPrimitive::CYLINDER:
+      if (shape_msg.dimensions.size() <= shape_msgs::msg::SolidPrimitive::CYLINDER_RADIUS ||
+          shape_msg.dimensions.size() <= shape_msgs::msg::SolidPrimitive::CYLINDER_HEIGHT)
         throw std::runtime_error("Insufficient dimensions in cylinder definition");
       else
       {
         mk.type = visualization_msgs::Marker::CYLINDER;
-        mk.scale.x = shape_msg.dimensions[shape_msgs::SolidPrimitive::CYLINDER_RADIUS] * 2.0;
+        mk.scale.x = shape_msg.dimensions[shape_msgs::msg::SolidPrimitive::CYLINDER_RADIUS] * 2.0;
         mk.scale.y = mk.scale.x;
-        mk.scale.z = shape_msg.dimensions[shape_msgs::SolidPrimitive::CYLINDER_HEIGHT];
+        mk.scale.z = shape_msg.dimensions[shape_msgs::msg::SolidPrimitive::CYLINDER_HEIGHT];
       }
       break;
     default:

--- a/src/shape_to_marker.cpp
+++ b/src/shape_to_marker.cpp
@@ -37,7 +37,7 @@
 #include <stdexcept>
 
 void geometric_shapes::constructMarkerFromShape(const shape_msgs::msg::SolidPrimitive& shape_msg,
-                                                visualization_msgs::Marker& mk)
+                                                visualization_msgs::msg::Marker& mk)
 {
   switch (shape_msg.type)
   {
@@ -46,7 +46,7 @@ void geometric_shapes::constructMarkerFromShape(const shape_msgs::msg::SolidPrim
         throw std::runtime_error("Insufficient dimensions in sphere definition");
       else
       {
-        mk.type = visualization_msgs::Marker::SPHERE;
+        mk.type = visualization_msgs::msg::Marker::SPHERE;
         mk.scale.x = mk.scale.y = mk.scale.z = shape_msg.dimensions[shape_msgs::msg::SolidPrimitive::SPHERE_RADIUS] * 2.0;
       }
       break;
@@ -57,7 +57,7 @@ void geometric_shapes::constructMarkerFromShape(const shape_msgs::msg::SolidPrim
         throw std::runtime_error("Insufficient dimensions in box definition");
       else
       {
-        mk.type = visualization_msgs::Marker::CUBE;
+        mk.type = visualization_msgs::msg::Marker::CUBE;
         mk.scale.x = shape_msg.dimensions[shape_msgs::msg::SolidPrimitive::BOX_X];
         mk.scale.y = shape_msg.dimensions[shape_msgs::msg::SolidPrimitive::BOX_Y];
         mk.scale.z = shape_msg.dimensions[shape_msgs::msg::SolidPrimitive::BOX_Z];
@@ -70,7 +70,7 @@ void geometric_shapes::constructMarkerFromShape(const shape_msgs::msg::SolidPrim
       else
       {
         // there is no CONE marker, so this produces a cylinder marker as well
-        mk.type = visualization_msgs::Marker::CYLINDER;
+        mk.type = visualization_msgs::msg::Marker::CYLINDER;
         mk.scale.x = shape_msg.dimensions[shape_msgs::msg::SolidPrimitive::CONE_RADIUS] * 2.0;
         mk.scale.y = mk.scale.x;
         mk.scale.z = shape_msg.dimensions[shape_msgs::msg::SolidPrimitive::CONE_HEIGHT];
@@ -82,7 +82,7 @@ void geometric_shapes::constructMarkerFromShape(const shape_msgs::msg::SolidPrim
         throw std::runtime_error("Insufficient dimensions in cylinder definition");
       else
       {
-        mk.type = visualization_msgs::Marker::CYLINDER;
+        mk.type = visualization_msgs::msg::Marker::CYLINDER;
         mk.scale.x = shape_msg.dimensions[shape_msgs::msg::SolidPrimitive::CYLINDER_RADIUS] * 2.0;
         mk.scale.y = mk.scale.x;
         mk.scale.z = shape_msg.dimensions[shape_msgs::msg::SolidPrimitive::CYLINDER_HEIGHT];
@@ -97,14 +97,14 @@ void geometric_shapes::constructMarkerFromShape(const shape_msgs::msg::SolidPrim
   }
 }
 
-void geometric_shapes::constructMarkerFromShape(const shape_msgs::msg::Mesh& shape_msg, visualization_msgs::Marker& mk,
+void geometric_shapes::constructMarkerFromShape(const shape_msgs::msg::Mesh& shape_msg, visualization_msgs::msg::Marker& mk,
                                                 bool use_mesh_triangle_list)
 {
   if (shape_msg.triangles.empty() || shape_msg.vertices.empty())
     throw std::runtime_error("Mesh definition is empty");
   if (use_mesh_triangle_list)
   {
-    mk.type = visualization_msgs::Marker::TRIANGLE_LIST;
+    mk.type = visualization_msgs::msg::Marker::TRIANGLE_LIST;
     mk.scale.x = mk.scale.y = mk.scale.z = 1.0;
     for (std::size_t i = 0; i < shape_msg.triangles.size(); ++i)
     {
@@ -115,7 +115,7 @@ void geometric_shapes::constructMarkerFromShape(const shape_msgs::msg::Mesh& sha
   }
   else
   {
-    mk.type = visualization_msgs::Marker::LINE_LIST;
+    mk.type = visualization_msgs::msg::Marker::LINE_LIST;
     mk.scale.x = mk.scale.y = mk.scale.z = 0.01;
     for (std::size_t i = 0; i < shape_msg.triangles.size(); ++i)
     {

--- a/src/shape_to_marker.cpp
+++ b/src/shape_to_marker.cpp
@@ -97,7 +97,7 @@ void geometric_shapes::constructMarkerFromShape(const shape_msgs::msg::SolidPrim
   }
 }
 
-void geometric_shapes::constructMarkerFromShape(const shape_msgs::Mesh& shape_msg, visualization_msgs::Marker& mk,
+void geometric_shapes::constructMarkerFromShape(const shape_msgs::msg::Mesh& shape_msg, visualization_msgs::Marker& mk,
                                                 bool use_mesh_triangle_list)
 {
   if (shape_msg.triangles.empty() || shape_msg.vertices.empty())

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -7,13 +7,13 @@ configure_file(resources/config.h.in "${CMAKE_CURRENT_BINARY_DIR}/resources/conf
 include_directories(${CMAKE_CURRENT_BINARY_DIR})
 
 ament_add_gtest(test_point_inclusion test_point_inclusion.cpp)
-target_link_libraries(test_point_inclusion ${PROJECT_NAME} ${Boost_LIBRARIES})
+target_link_libraries(test_point_inclusion ${PROJECT_NAME} ${Boost_LIBRARIES} console_bridge assimp )
 
 ament_add_gtest(test_bounding_sphere test_bounding_sphere.cpp)
-target_link_libraries(test_bounding_sphere ${PROJECT_NAME} ${Boost_LIBRARIES})
+target_link_libraries(test_bounding_sphere ${PROJECT_NAME} ${Boost_LIBRARIES} console_bridge assimp )
 
 ament_add_gtest(test_create_mesh test_create_mesh.cpp)
-target_link_libraries(test_create_mesh ${PROJECT_NAME} ${Boost_LIBRARIES})
+target_link_libraries(test_create_mesh ${PROJECT_NAME} ${Boost_LIBRARIES} console_bridge assimp )
 
 ament_add_gtest(test_loaded_meshes test_loaded_meshes.cpp)
-target_link_libraries(test_loaded_meshes ${PROJECT_NAME} ${Boost_LIBRARIES})
+target_link_libraries(test_loaded_meshes ${PROJECT_NAME} ${Boost_LIBRARIES} console_bridge assimp )

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -12,6 +12,9 @@ target_link_libraries(test_point_inclusion ${PROJECT_NAME} ${catkin_LIBRARIES} $
 catkin_add_gtest(test_bounding_sphere test_bounding_sphere.cpp)
 target_link_libraries(test_bounding_sphere ${PROJECT_NAME} ${catkin_LIBRARIES} ${Boost_LIBRARIES})
 
+catkin_add_gtest(test_bounding_box test_bounding_box.cpp)
+target_link_libraries(test_bounding_box ${PROJECT_NAME} ${catkin_LIBRARIES} ${Boost_LIBRARIES})
+
 catkin_add_gtest(test_create_mesh test_create_mesh.cpp)
 target_link_libraries(test_create_mesh ${PROJECT_NAME} ${catkin_LIBRARIES} ${Boost_LIBRARIES})
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -6,14 +6,14 @@ endif()
 configure_file(resources/config.h.in "${CMAKE_CURRENT_BINARY_DIR}/resources/config.h")
 include_directories(${CMAKE_CURRENT_BINARY_DIR})
 
-catkin_add_gtest(test_point_inclusion test_point_inclusion.cpp)
-target_link_libraries(test_point_inclusion ${PROJECT_NAME} ${catkin_LIBRARIES} ${Boost_LIBRARIES})
+ament_add_gtest(test_point_inclusion test_point_inclusion.cpp)
+target_link_libraries(test_point_inclusion ${PROJECT_NAME} ${Boost_LIBRARIES})
 
-catkin_add_gtest(test_bounding_sphere test_bounding_sphere.cpp)
-target_link_libraries(test_bounding_sphere ${PROJECT_NAME} ${catkin_LIBRARIES} ${Boost_LIBRARIES})
+ament_add_gtest(test_bounding_sphere test_bounding_sphere.cpp)
+target_link_libraries(test_bounding_sphere ${PROJECT_NAME} ${Boost_LIBRARIES})
 
-catkin_add_gtest(test_create_mesh test_create_mesh.cpp)
-target_link_libraries(test_create_mesh ${PROJECT_NAME} ${catkin_LIBRARIES} ${Boost_LIBRARIES})
+ament_add_gtest(test_create_mesh test_create_mesh.cpp)
+target_link_libraries(test_create_mesh ${PROJECT_NAME} ${Boost_LIBRARIES})
 
-catkin_add_gtest(test_loaded_meshes test_loaded_meshes.cpp)
-target_link_libraries(test_loaded_meshes ${PROJECT_NAME} ${catkin_LIBRARIES} ${Boost_LIBRARIES})
+ament_add_gtest(test_loaded_meshes test_loaded_meshes.cpp)
+target_link_libraries(test_loaded_meshes ${PROJECT_NAME} ${Boost_LIBRARIES})

--- a/test/test_bounding_box.cpp
+++ b/test/test_bounding_box.cpp
@@ -1,0 +1,390 @@
+/*********************************************************************
+* Software License Agreement (BSD License)
+*
+*  Copyright (c) 2019, Open Robotics.
+*  All rights reserved.
+*
+*  Redistribution and use in source and binary forms, with or without
+*  modification, are permitted provided that the following conditions
+*  are met:
+*
+*   * Redistributions of source code must retain the above copyright
+*     notice, this list of conditions and the following disclaimer.
+*   * Redistributions in binary form must reproduce the above
+*     copyright notice, this list of conditions and the following
+*     disclaimer in the documentation and/or other materials provided
+*     with the distribution.
+*   * Neither the name of the Open Robotics nor the names of its
+*     contributors may be used to endorse or promote products derived
+*     from this software without specific prior written permission.
+*
+*  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+*  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+*  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+*  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+*  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+*  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+*  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+*  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+*  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+*  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+*  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+*  POSSIBILITY OF SUCH DAMAGE.
+*********************************************************************/
+
+/** \Author Martin Pecka */
+
+#include <geometric_shapes/bodies.h>
+#include <geometric_shapes/body_operations.h>
+#include <random_numbers/random_numbers.h>
+#include <gtest/gtest.h>
+
+// The magic numbers in this test were verified visually using Blender
+
+TEST(SphereBoundingBox, Sphere1)
+{
+  shapes::Sphere shape(1.0);
+  bodies::Sphere body(&shape);
+  bodies::AABB bbox;
+  body.computeBoundingBox(bbox);
+
+  EXPECT_NEAR(-1.0, bbox.min().x(), 1e-4);
+  EXPECT_NEAR(-1.0, bbox.min().y(), 1e-4);
+  EXPECT_NEAR(-1.0, bbox.min().z(), 1e-4);
+  EXPECT_NEAR(1.0, bbox.max().x(), 1e-4);
+  EXPECT_NEAR(1.0, bbox.max().y(), 1e-4);
+  EXPECT_NEAR(1.0, bbox.max().z(), 1e-4);
+}
+
+TEST(SphereBoundingBox, Sphere2)
+{
+  shapes::Sphere shape(2.0);
+  bodies::Sphere body(&shape);
+  Eigen::Isometry3d pose;
+  pose.setIdentity();
+  pose.translation() = Eigen::Vector3d(1, 2, 3);
+  body.setPose(pose);
+  bodies::AABB bbox;
+  body.computeBoundingBox(bbox);
+
+  EXPECT_NEAR(-1.0, bbox.min().x(), 1e-4);
+  EXPECT_NEAR(0.0, bbox.min().y(), 1e-4);
+  EXPECT_NEAR(1.0, bbox.min().z(), 1e-4);
+  EXPECT_NEAR(3.0, bbox.max().x(), 1e-4);
+  EXPECT_NEAR(4.0, bbox.max().y(), 1e-4);
+  EXPECT_NEAR(5.0, bbox.max().z(), 1e-4);
+
+  pose *= Eigen::AngleAxisd(M_PI_2, Eigen::Vector3d(1, 1, 1));
+  body.setPose(pose);
+  body.computeBoundingBox(bbox);
+
+  EXPECT_NEAR(-1.0, bbox.min().x(), 1e-4);
+  EXPECT_NEAR(0.0, bbox.min().y(), 1e-4);
+  EXPECT_NEAR(1.0, bbox.min().z(), 1e-4);
+  EXPECT_NEAR(3.0, bbox.max().x(), 1e-4);
+  EXPECT_NEAR(4.0, bbox.max().y(), 1e-4);
+  EXPECT_NEAR(5.0, bbox.max().z(), 1e-4);
+
+  // verify the bounding box is rotation-invariant
+
+  random_numbers::RandomNumberGenerator gen;
+  double quatData[4];
+  Eigen::Quaterniond quat;
+
+  for (size_t i = 0; i < 10; ++i)
+  {
+    gen.quaternion(quatData);
+    quat.x() = quatData[0];
+    quat.y() = quatData[1];
+    quat.z() = quatData[2];
+    quat.w() = quatData[3];
+    pose.linear() = quat.toRotationMatrix();
+    body.setPose(pose);
+    bodies::AABB bbox2;
+    body.computeBoundingBox(bbox2);
+
+    EXPECT_NEAR(bbox2.min().x(), bbox.min().x(), 1e-4);
+    EXPECT_NEAR(bbox2.min().y(), bbox.min().y(), 1e-4);
+    EXPECT_NEAR(bbox2.min().z(), bbox.min().z(), 1e-4);
+    EXPECT_NEAR(bbox2.max().x(), bbox.max().x(), 1e-4);
+    EXPECT_NEAR(bbox2.max().y(), bbox.max().y(), 1e-4);
+    EXPECT_NEAR(bbox2.max().z(), bbox.max().z(), 1e-4);
+  }
+}
+
+TEST(BoxBoundingBox, Box1)
+{
+  shapes::Box shape(1.0, 2.0, 3.0);
+  bodies::Box body(&shape);
+  bodies::AABB bbox;
+  body.computeBoundingBox(bbox);
+
+  EXPECT_NEAR(-0.5, bbox.min().x(), 1e-4);
+  EXPECT_NEAR(-1.0, bbox.min().y(), 1e-4);
+  EXPECT_NEAR(-1.5, bbox.min().z(), 1e-4);
+  EXPECT_NEAR(0.5, bbox.max().x(), 1e-4);
+  EXPECT_NEAR(1.0, bbox.max().y(), 1e-4);
+  EXPECT_NEAR(1.5, bbox.max().z(), 1e-4);
+}
+
+TEST(BoxBoundingBox, Box2)
+{
+  shapes::Box shape(1.0, 2.0, 3.0);
+  bodies::Box body(&shape);
+  Eigen::Isometry3d pose;
+  pose.setIdentity();
+  pose.translation() = Eigen::Vector3d(1, 2, 3);
+  body.setPose(pose);
+  bodies::AABB bbox;
+  body.computeBoundingBox(bbox);
+
+  EXPECT_NEAR(0.5, bbox.min().x(), 1e-4);
+  EXPECT_NEAR(1.0, bbox.min().y(), 1e-4);
+  EXPECT_NEAR(1.5, bbox.min().z(), 1e-4);
+  EXPECT_NEAR(1.5, bbox.max().x(), 1e-4);
+  EXPECT_NEAR(3.0, bbox.max().y(), 1e-4);
+  EXPECT_NEAR(4.5, bbox.max().z(), 1e-4);
+
+  pose *= Eigen::AngleAxisd(M_PI_2, Eigen::Vector3d(1, 1, 1));
+  body.setPose(pose);
+  body.computeBoundingBox(bbox);
+
+  EXPECT_NEAR(-0.7767, bbox.min().x(), 1e-4);
+  EXPECT_NEAR(0.8452, bbox.min().y(), 1e-4);
+  EXPECT_NEAR(1.4673, bbox.min().z(), 1e-4);
+  EXPECT_NEAR(2.7767, bbox.max().x(), 1e-4);
+  EXPECT_NEAR(3.1547, bbox.max().y(), 1e-4);
+  EXPECT_NEAR(4.5326, bbox.max().z(), 1e-4);
+}
+
+TEST(CylinderBoundingCylinder, Cylinder1)
+{
+  shapes::Cylinder shape(1.0, 2.0);
+  bodies::Cylinder body(&shape);
+  bodies::AABB bbox;
+  body.computeBoundingBox(bbox);
+
+  EXPECT_NEAR(-1.0, bbox.min().x(), 1e-4);
+  EXPECT_NEAR(-1.0, bbox.min().y(), 1e-4);
+  EXPECT_NEAR(-1.0, bbox.min().z(), 1e-4);
+  EXPECT_NEAR(1.0, bbox.max().x(), 1e-4);
+  EXPECT_NEAR(1.0, bbox.max().y(), 1e-4);
+  EXPECT_NEAR(1.0, bbox.max().z(), 1e-4);
+}
+
+TEST(CylinderBoundingCylinder, Cylinder2)
+{
+  shapes::Cylinder shape(1.0, 2.0);
+  bodies::Cylinder body(&shape);
+  Eigen::Isometry3d pose;
+  pose.setIdentity();
+  pose.translation() = Eigen::Vector3d(1, 2, 3);
+  body.setPose(pose);
+  bodies::AABB bbox;
+  body.computeBoundingBox(bbox);
+
+  EXPECT_NEAR(0.0, bbox.min().x(), 1e-4);
+  EXPECT_NEAR(1.0, bbox.min().y(), 1e-4);
+  EXPECT_NEAR(2.0, bbox.min().z(), 1e-4);
+  EXPECT_NEAR(2.0, bbox.max().x(), 1e-4);
+  EXPECT_NEAR(3.0, bbox.max().y(), 1e-4);
+  EXPECT_NEAR(4.0, bbox.max().z(), 1e-4);
+
+  pose.linear() = Eigen::AngleAxisd(M_PI_2, Eigen::Vector3d(1, 1, 1)).toRotationMatrix();
+  body.setPose(pose);
+  body.computeBoundingBox(bbox);
+
+  EXPECT_NEAR(-0.3238, bbox.min().x(), 1e-4);
+  EXPECT_NEAR(0.7862, bbox.min().y(), 1e-4);
+  EXPECT_NEAR(1.7239, bbox.min().z(), 1e-4);
+  EXPECT_NEAR(2.3238, bbox.max().x(), 1e-4);
+  EXPECT_NEAR(3.2138, bbox.max().y(), 1e-4);
+  EXPECT_NEAR(4.2761, bbox.max().z(), 1e-4);
+
+  // verify the bounding box is yaw-invariant
+
+  random_numbers::RandomNumberGenerator gen;
+  const auto rollPitch =
+      Eigen::AngleAxisd(1.0, Eigen::Vector3d::UnitX()) * Eigen::AngleAxisd(1.0, Eigen::Vector3d::UnitY());
+
+  pose.linear() = rollPitch.toRotationMatrix();
+  body.setPose(pose);
+  body.computeBoundingBox(bbox);
+
+  bodies::AABB bbox2;
+  for (size_t i = 0; i < 10; ++i)
+  {
+    const auto angle = gen.uniformReal(-M_PI, M_PI);
+    const auto yaw = Eigen::AngleAxisd(angle, Eigen::Vector3d::UnitZ());
+    pose.linear() = (rollPitch * yaw).toRotationMatrix();
+    body.setPose(pose);
+    body.computeBoundingBox(bbox2);
+
+    EXPECT_NEAR(bbox2.min().x(), bbox.min().x(), 1e-4);
+    EXPECT_NEAR(bbox2.min().y(), bbox.min().y(), 1e-4);
+    EXPECT_NEAR(bbox2.min().z(), bbox.min().z(), 1e-4);
+    EXPECT_NEAR(bbox2.max().x(), bbox.max().x(), 1e-4);
+    EXPECT_NEAR(bbox2.max().y(), bbox.max().y(), 1e-4);
+    EXPECT_NEAR(bbox2.max().z(), bbox.max().z(), 1e-4);
+  }
+}
+
+shapes::Mesh* createBoxMesh(const Eigen::Vector3d& min, const Eigen::Vector3d& max)
+{
+  shapes::Mesh* m = new shapes::Mesh(8, 12);
+
+  m->vertices[3 * 0 + 0] = min.x();
+  m->vertices[3 * 0 + 1] = min.y();
+  m->vertices[3 * 0 + 2] = min.z();
+
+  m->vertices[3 * 1 + 0] = max.x();
+  m->vertices[3 * 1 + 1] = min.y();
+  m->vertices[3 * 1 + 2] = min.z();
+
+  m->vertices[3 * 2 + 0] = min.x();
+  m->vertices[3 * 2 + 1] = max.y();
+  m->vertices[3 * 2 + 2] = min.z();
+
+  m->vertices[3 * 3 + 0] = max.x();
+  m->vertices[3 * 3 + 1] = max.y();
+  m->vertices[3 * 3 + 2] = min.z();
+
+  m->vertices[3 * 4 + 0] = min.x();
+  m->vertices[3 * 4 + 1] = min.y();
+  m->vertices[3 * 4 + 2] = max.z();
+
+  m->vertices[3 * 5 + 0] = max.x();
+  m->vertices[3 * 5 + 1] = min.y();
+  m->vertices[3 * 5 + 2] = max.z();
+
+  m->vertices[3 * 6 + 0] = min.x();
+  m->vertices[3 * 6 + 1] = max.y();
+  m->vertices[3 * 6 + 2] = max.z();
+
+  m->vertices[3 * 7 + 0] = max.x();
+  m->vertices[3 * 7 + 1] = max.y();
+  m->vertices[3 * 7 + 2] = max.z();
+
+  m->triangles[3 * 0 + 0] = 0;
+  m->triangles[3 * 0 + 1] = 1;
+  m->triangles[3 * 0 + 2] = 2;
+
+  m->triangles[3 * 1 + 0] = 1;
+  m->triangles[3 * 1 + 1] = 3;
+  m->triangles[3 * 1 + 2] = 2;
+
+  m->triangles[3 * 2 + 0] = 5;
+  m->triangles[3 * 2 + 1] = 4;
+  m->triangles[3 * 2 + 2] = 6;
+
+  m->triangles[3 * 3 + 0] = 5;
+  m->triangles[3 * 3 + 1] = 6;
+  m->triangles[3 * 3 + 2] = 7;
+
+  m->triangles[3 * 4 + 0] = 1;
+  m->triangles[3 * 4 + 1] = 5;
+  m->triangles[3 * 4 + 2] = 3;
+
+  m->triangles[3 * 5 + 0] = 5;
+  m->triangles[3 * 5 + 1] = 7;
+  m->triangles[3 * 5 + 2] = 3;
+
+  m->triangles[3 * 6 + 0] = 4;
+  m->triangles[3 * 6 + 1] = 0;
+  m->triangles[3 * 6 + 2] = 2;
+
+  m->triangles[3 * 7 + 0] = 4;
+  m->triangles[3 * 7 + 1] = 2;
+  m->triangles[3 * 7 + 2] = 6;
+
+  m->triangles[3 * 8 + 0] = 2;
+  m->triangles[3 * 8 + 1] = 3;
+  m->triangles[3 * 8 + 2] = 6;
+
+  m->triangles[3 * 9 + 0] = 3;
+  m->triangles[3 * 9 + 1] = 7;
+  m->triangles[3 * 9 + 2] = 6;
+
+  m->triangles[3 * 10 + 0] = 1;
+  m->triangles[3 * 10 + 1] = 0;
+  m->triangles[3 * 10 + 2] = 4;
+
+  m->triangles[3 * 11 + 0] = 1;
+  m->triangles[3 * 11 + 1] = 4;
+  m->triangles[3 * 11 + 2] = 5;
+
+  return m;
+}
+
+TEST(MeshBoundingBox, Mesh1)
+{
+  shapes::Mesh* m = createBoxMesh({ -1, -1, -1 }, { 1, 1, 1 });
+
+  bodies::ConvexMesh body(m);
+  bodies::AABB bbox;
+  body.computeBoundingBox(bbox);
+
+  EXPECT_NEAR(-1.0, bbox.min().x(), 1e-4);
+  EXPECT_NEAR(-1.0, bbox.min().y(), 1e-4);
+  EXPECT_NEAR(-1.0, bbox.min().z(), 1e-4);
+  EXPECT_NEAR(1.0, bbox.max().x(), 1e-4);
+  EXPECT_NEAR(1.0, bbox.max().y(), 1e-4);
+  EXPECT_NEAR(1.0, bbox.max().z(), 1e-4);
+  delete m;
+}
+
+TEST(MeshBoundingBox, Mesh2)
+{
+  shapes::Mesh* m = createBoxMesh({ -0.5, -1.0, -1.5 }, { 0.5, 1.0, 1.5 });
+
+  bodies::ConvexMesh body(m);
+  Eigen::Isometry3d pose;
+  pose.setIdentity();
+  pose.translation() = Eigen::Vector3d(1, 2, 3);
+  body.setPose(pose);
+  bodies::AABB bbox;
+  body.computeBoundingBox(bbox);
+
+  EXPECT_NEAR(0.5, bbox.min().x(), 1e-4);
+  EXPECT_NEAR(1.0, bbox.min().y(), 1e-4);
+  EXPECT_NEAR(1.5, bbox.min().z(), 1e-4);
+  EXPECT_NEAR(1.5, bbox.max().x(), 1e-4);
+  EXPECT_NEAR(3.0, bbox.max().y(), 1e-4);
+  EXPECT_NEAR(4.5, bbox.max().z(), 1e-4);
+
+  pose *= Eigen::AngleAxisd(M_PI_2, Eigen::Vector3d(1, 1, 1));
+  body.setPose(pose);
+  body.computeBoundingBox(bbox);
+
+  EXPECT_NEAR(-0.7767, bbox.min().x(), 1e-4);
+  EXPECT_NEAR(0.8452, bbox.min().y(), 1e-4);
+  EXPECT_NEAR(1.4673, bbox.min().z(), 1e-4);
+  EXPECT_NEAR(2.7767, bbox.max().x(), 1e-4);
+  EXPECT_NEAR(3.1547, bbox.max().y(), 1e-4);
+  EXPECT_NEAR(4.5326, bbox.max().z(), 1e-4);
+
+  delete m;
+}
+
+TEST(MergeBoundingBoxes, Merge1)
+{
+  std::vector<bodies::AABB> boxes;
+  boxes.emplace_back(Eigen::Vector3d(-1, -1, -1), Eigen::Vector3d(0, 0, 0));
+  boxes.emplace_back(Eigen::Vector3d(0, 0, 0), Eigen::Vector3d(1, 1, 1));
+
+  bodies::AABB bbox;
+  bodies::mergeBoundingBoxes(boxes, bbox);
+
+  EXPECT_NEAR(-1.0, bbox.min().x(), 1e-4);
+  EXPECT_NEAR(-1.0, bbox.min().y(), 1e-4);
+  EXPECT_NEAR(-1.0, bbox.min().z(), 1e-4);
+  EXPECT_NEAR(1.0, bbox.max().x(), 1e-4);
+  EXPECT_NEAR(1.0, bbox.max().y(), 1e-4);
+  EXPECT_NEAR(1.0, bbox.max().z(), 1e-4);
+}
+
+int main(int argc, char** argv)
+{
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
**Note to maintainers**: Please do not merge in this branch, create a ros2 branch and modify this PR.

With the changes provided, package compiles in a ROS 2 workspace. 

Pending items:
- [x] Review warnings
- [ ] Port testing

For completeness, warnings pending of review:
```bash
In file included from /Users/victor/ros2_moveit_ws/src/geometric_shapes/src/shapes.cpp:39:
In file included from /usr/local/include/octomap/octomap.h:37:
In file included from /usr/local/include/octomap/OcTree.h:38:
In file included from /usr/local/include/octomap/OccupancyOcTreeBase.h:506:
/usr/local/include/octomap/OccupancyOcTreeBase.hxx:116:108: warning: unused parameter 'maxrange' [-Wunused-parameter]
  void OccupancyOcTreeBase<NODE>::insertPointCloudRays(const Pointcloud& pc, const point3d& origin, double maxrange, bool lazy_eval) {
                                                                                                           ^
In file included from /Users/victor/ros2_moveit_ws/src/geometric_shapes/src/shapes.cpp:40:
/usr/local/include/console_bridge/console.h:70:88: warning: token pasting of ',' and __VA_ARGS__ is a GNU extension [-Wgnu-zero-variadic-macro-arguments]
  console_bridge::log(__FILE__, __LINE__, console_bridge::CONSOLE_BRIDGE_LOG_WARN,  fmt, ##__VA_ARGS__)
                                                                                       ^
/Users/victor/ros2_moveit_ws/src/geometric_shapes/src/shapes.cpp:265:34: warning: unused parameter 'scale' [-Wunused-parameter]
void OcTree::scaleAndPadd(double scale, double padd)
                                 ^
/Users/victor/ros2_moveit_ws/src/geometric_shapes/src/shapes.cpp:265:48: warning: unused parameter 'padd' [-Wunused-parameter]
void OcTree::scaleAndPadd(double scale, double padd)
                                               ^
In file included from /Users/victor/ros2_moveit_ws/src/geometric_shapes/src/shapes.cpp:40:
/usr/local/include/console_bridge/console.h:70:88: warning: token pasting of ',' and __VA_ARGS__ is a GNU extension [-Wgnu-zero-variadic-macro-arguments]
  console_bridge::log(__FILE__, __LINE__, console_bridge::CONSOLE_BRIDGE_LOG_WARN,  fmt, ##__VA_ARGS__)
                                                                                       ^
/Users/victor/ros2_moveit_ws/src/geometric_shapes/src/shapes.cpp:270:33: warning: unused parameter 'scale' [-Wunused-parameter]
void Plane::scaleAndPadd(double scale, double padding)
                                ^
/Users/victor/ros2_moveit_ws/src/geometric_shapes/src/shapes.cpp:270:47: warning: unused parameter 'padding' [-Wunused-parameter]
void Plane::scaleAndPadd(double scale, double padding)
                                              ^
In file included from /Users/victor/ros2_moveit_ws/src/geometric_shapes/src/mesh_operations.cpp:49:
/usr/local/include/assimp/scene.h:240:1: warning: 'aiScene' defined as a struct here but previously declared as a class [-Wmismatched-tags]
struct aiScene
^
/Users/victor/ros2_moveit_ws/src/geometric_shapes/include/geometric_shapes/mesh_operations.h:45:1: note: did you mean struct here?
class aiScene;
^~~~~
struct
In file included from /Users/victor/ros2_moveit_ws/src/geometric_shapes/src/body_operations.cpp:39:
/usr/local/include/console_bridge/console.h:67:90: warning: token pasting of ',' and __VA_ARGS__ is a GNU extension [-Wgnu-zero-variadic-macro-arguments]
  console_bridge::log(__FILE__, __LINE__, console_bridge::CONSOLE_BRIDGE_LOG_ERROR, fmt, ##__VA_ARGS__)
                                                                                         ^
In file included from /Users/victor/ros2_moveit_ws/src/geometric_shapes/src/shape_operations.cpp:45:
/usr/local/include/console_bridge/console.h:70:88: warning: token pasting of ',' and __VA_ARGS__ is a GNU extension [-Wgnu-zero-variadic-macro-arguments]
  console_bridge::log(__FILE__, __LINE__, console_bridge::CONSOLE_BRIDGE_LOG_WARN,  fmt, ##__VA_ARGS__)
                                                                                       ^
/usr/local/include/console_bridge/console.h:67:90: warning: token pasting of ',' and __VA_ARGS__ is a GNU extension [-Wgnu-zero-variadic-macro-arguments]
  console_bridge::log(__FILE__, __LINE__, console_bridge::CONSOLE_BRIDGE_LOG_ERROR, fmt, ##__VA_ARGS__)
                                                                                         ^
/usr/local/include/console_bridge/console.h:67:88: warning: token pasting of ',' and __VA_ARGS__ is a GNU extension [-Wgnu-zero-variadic-macro-arguments]
  console_bridge::log(__FILE__, __LINE__, console_bridge::CONSOLE_BRIDGE_LOG_ERROR, fmt, ##__VA_ARGS__)
                                                                                       ^
/Users/victor/ros2_moveit_ws/src/geometric_shapes/src/shape_operations.cpp:158:49: warning: unused parameter 'shape_msg' [-Wunused-parameter]
  void operator()(const shape_msgs::msg::Plane& shape_msg) const
                                                ^
In file included from /Users/victor/ros2_moveit_ws/src/geometric_shapes/src/shape_operations.cpp:45:
/usr/local/include/console_bridge/console.h:67:90: warning: token pasting of ',' and __VA_ARGS__ is a GNU extension [-Wgnu-zero-variadic-macro-arguments]
  console_bridge::log(__FILE__, __LINE__, console_bridge::CONSOLE_BRIDGE_LOG_ERROR, fmt, ##__VA_ARGS__)
                                                                                         ^
/Users/victor/ros2_moveit_ws/src/geometric_shapes/src/shape_operations.cpp:205:60: warning: unused parameter 'shape_msg' [-Wunused-parameter]
  Eigen::Vector3d operator()(const shape_msgs::msg::Plane& shape_msg) const
                                                           ^
In file included from /Users/victor/ros2_moveit_ws/src/geometric_shapes/src/shape_operations.cpp:45:
/usr/local/include/console_bridge/console.h:67:90: warning: token pasting of ',' and __VA_ARGS__ is a GNU extension [-Wgnu-zero-variadic-macro-arguments]
  console_bridge::log(__FILE__, __LINE__, console_bridge::CONSOLE_BRIDGE_LOG_ERROR, fmt, ##__VA_ARGS__)
                                                                                         ^
/usr/local/include/console_bridge/console.h:67:90: warning: token pasting of ',' and __VA_ARGS__ is a GNU extension [-Wgnu-zero-variadic-macro-arguments]
/usr/local/include/console_bridge/console.h:67:90: warning: token pasting of ',' and __VA_ARGS__ is a GNU extension [-Wgnu-zero-variadic-macro-arguments]
7 warnings generated.
/Users/victor/ros2_moveit_ws/src/geometric_shapes/src/bodies.cpp:131:67: warning: unused parameter 'verbose' [-Wunused-parameter]
bool bodies::Sphere::containsPoint(const Eigen::Vector3d& p, bool verbose) const
                                                                  ^
In file included from /Users/victor/ros2_moveit_ws/src/geometric_shapes/src/mesh_operations.cpp:46:
/usr/local/include/console_bridge/console.h:67:88: warning: token pasting of ',' and __VA_ARGS__ is a GNU extension [-Wgnu-zero-variadic-macro-arguments]
  console_bridge::log(__FILE__, __LINE__, console_bridge::CONSOLE_BRIDGE_LOG_ERROR, fmt, ##__VA_ARGS__)
                                                                                       ^
/usr/local/include/console_bridge/console.h:70:88: warning: token pasting of ',' and __VA_ARGS__ is a GNU extension [-Wgnu-zero-variadic-macro-arguments]
  console_bridge::log(__FILE__, __LINE__, console_bridge::CONSOLE_BRIDGE_LOG_WARN,  fmt, ##__VA_ARGS__)
                                                                                       ^
/usr/local/include/console_bridge/console.h:67:90: warning: token pasting of ',' and __VA_ARGS__ is a GNU extension [-Wgnu-zero-variadic-macro-arguments]
  console_bridge::log(__FILE__, __LINE__, console_bridge::CONSOLE_BRIDGE_LOG_ERROR, fmt, ##__VA_ARGS__)
                                                                                         ^
/usr/local/include/console_bridge/console.h:70:90: warning: token pasting of ',' and __VA_ARGS__ is a GNU extension [-Wgnu-zero-variadic-macro-arguments]
  console_bridge::log(__FILE__, __LINE__, console_bridge::CONSOLE_BRIDGE_LOG_WARN,  fmt, ##__VA_ARGS__)
                                                                                         ^
/usr/local/include/console_bridge/console.h:70:90: warning: token pasting of ',' and __VA_ARGS__ is a GNU extension [-Wgnu-zero-variadic-macro-arguments]
/usr/local/include/console_bridge/console.h:70:88: warning: token pasting of ',' and __VA_ARGS__ is a GNU extension [-Wgnu-zero-variadic-macro-arguments]
  console_bridge::log(__FILE__, __LINE__, console_bridge::CONSOLE_BRIDGE_LOG_WARN,  fmt, ##__VA_ARGS__)
                                                                                       ^
/usr/local/include/console_bridge/console.h:70:90: warning: token pasting of ',' and __VA_ARGS__ is a GNU extension [-Wgnu-zero-variadic-macro-arguments]
  console_bridge::log(__FILE__, __LINE__, console_bridge::CONSOLE_BRIDGE_LOG_WARN,  fmt, ##__VA_ARGS__)
                                                                                         ^
/usr/local/include/console_bridge/console.h:70:90: warning: token pasting of ',' and __VA_ARGS__ is a GNU extension [-Wgnu-zero-variadic-macro-arguments]
/usr/local/include/console_bridge/console.h:70:90: warning: token pasting of ',' and __VA_ARGS__ is a GNU extension [-Wgnu-zero-variadic-macro-arguments]
/usr/local/include/console_bridge/console.h:67:90: warning: token pasting of ',' and __VA_ARGS__ is a GNU extension [-Wgnu-zero-variadic-macro-arguments]
  console_bridge::log(__FILE__, __LINE__, console_bridge::CONSOLE_BRIDGE_LOG_ERROR, fmt, ##__VA_ARGS__)
                                                                                         ^
/Users/victor/ros2_moveit_ws/src/geometric_shapes/src/bodies.cpp:264:69: warning: unused parameter 'verbose' [-Wunused-parameter]
bool bodies::Cylinder::containsPoint(const Eigen::Vector3d& p, bool verbose) const
                                                                    ^
/Users/victor/ros2_moveit_ws/src/geometric_shapes/src/bodies.cpp:317:99: warning: unused parameter 'max_attempts' [-Wunused-parameter]
bool bodies::Cylinder::samplePointInside(random_numbers::RandomNumberGenerator& rng, unsigned int max_attempts,
                                                                                                  ^
/Users/victor/ros2_moveit_ws/src/geometric_shapes/src/bodies.cpp:477:64: warning: unused parameter 'verbose' [-Wunused-parameter]
bool bodies::Box::containsPoint(const Eigen::Vector3d& p, bool verbose) const
                                                               ^
/Users/victor/ros2_moveit_ws/src/geometric_shapes/src/bodies.cpp:665:71: warning: unused parameter 'verbose' [-Wunused-parameter]
bool bodies::ConvexMesh::containsPoint(const Eigen::Vector3d& p, bool verbose) const
                                                                      ^
In file included from /Users/victor/ros2_moveit_ws/src/geometric_shapes/src/bodies.cpp:40:
/usr/local/include/console_bridge/console.h:70:88: warning: token pasting of ',' and __VA_ARGS__ is a GNU extension [-Wgnu-zero-variadic-macro-arguments]
  console_bridge::log(__FILE__, __LINE__, console_bridge::CONSOLE_BRIDGE_LOG_WARN,  fmt, ##__VA_ARGS__)
                                                                                       ^
/Users/victor/ros2_moveit_ws/src/geometric_shapes/src/mesh_operations.cpp:633:13: warning: unused function 'writeFloatToSTL' [-Wunused-function]
inline void writeFloatToSTL(char*& ptr, float data)
            ^
/usr/local/include/console_bridge/console.h:67:90: warning: token pasting of ',' and __VA_ARGS__ is a GNU extension [-Wgnu-zero-variadic-macro-arguments]
  console_bridge::log(__FILE__, __LINE__, console_bridge::CONSOLE_BRIDGE_LOG_ERROR, fmt, ##__VA_ARGS__)
                                                                                         ^
/usr/local/include/console_bridge/console.h:67:90: warning: token pasting of ',' and __VA_ARGS__ is a GNU extension [-Wgnu-zero-variadic-macro-arguments]
2 warnings generated.
8 warnings generated.
12 warnings generated.
8 warnings generated.
```