### PR TITLE
Added bodies::Body::computeBoundingBox (oriented box version). 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,8 +49,13 @@ find_package(Eigen3 REQUIRED)
 find_package(octomap REQUIRED)
 
 pkg_check_modules(LIBFCL_PC REQUIRED fcl)
+# find *absolute* paths to LIBFCL_* paths
 find_path(LIBFCL_INCLUDE_DIRS fcl/config.h HINTS ${LIBFCL_PC_INCLUDE_DIR} ${LIBFCL_PC_INCLUDE_DIRS})
-find_library(LIBFCL_LIBRARIES fcl HINTS ${LIBFCL_PC_LIBRARY_DIRS})
+set(LIBFCL_LIBRARIES)
+foreach(_lib ${LIBFCL_PC_LIBRARIES})
+  find_library(_lib_${_lib} ${_lib} HINTS ${LIBFCL_PC_LIBRARY_DIRS})
+  list(APPEND LIBFCL_LIBRARIES ${_lib_${_lib}})
+endforeach()
 
 find_package(catkin REQUIRED COMPONENTS
   eigen_stl_containers

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,9 +21,14 @@ if (NOT CMAKE_CONFIGURATION_TYPES AND NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE Release)
 endif()
 
+# used for finding Assimp and FCL
+find_package(PkgConfig REQUIRED)
+
+# TODO(henningkayser): Remove policy fix when assimp 5.1 is available
+# Suppress policy warning in assimp (https://github.com/assimp/assimp/pull/2722)
+set(CMAKE_POLICY_DEFAULT_CMP0012 NEW)
 find_package(ASSIMP QUIET)
-if (NOT ASSIMP_FOUND)
-  find_package(PkgConfig REQUIRED)
+if(NOT ASSIMP_FOUND)
   # assimp is required, so REQUIRE the second attempt
   pkg_check_modules(ASSIMP_PC REQUIRED assimp)
   set(ASSIMP_INCLUDE_DIRS ${ASSIMP_PC_INCLUDE_DIRS})
@@ -42,6 +47,10 @@ find_package(console_bridge REQUIRED)
 find_package(Eigen3 REQUIRED)
 
 find_package(octomap REQUIRED)
+
+pkg_check_modules(LIBFCL_PC REQUIRED fcl)
+find_path(LIBFCL_INCLUDE_DIRS fcl/config.h HINTS ${LIBFCL_PC_INCLUDE_DIR} ${LIBFCL_PC_INCLUDE_DIRS})
+find_library(LIBFCL_LIBRARIES fcl HINTS ${LIBFCL_PC_LIBRARY_DIRS})
 
 find_package(catkin REQUIRED COMPONENTS
   eigen_stl_containers
@@ -72,14 +81,16 @@ if (HAVE_QHULL_2011)
 endif()
 
 include_directories(include)
-include_directories(${EIGEN3_INCLUDE_DIR} ${Boost_INCLUDE_DIR} ${ASSIMP_INCLUDE_DIRS} ${OCTOMAP_INCLUDE_DIRS})
-include_directories(${catkin_INCLUDE_DIRS} ${console_bridge_INCLUDE_DIRS})
+include_directories(SYSTEM
+  ${EIGEN3_INCLUDE_DIR} ${Boost_INCLUDE_DIR} ${ASSIMP_INCLUDE_DIRS} ${OCTOMAP_INCLUDE_DIRS}
+  ${QHULL_INCLUDE_DIRS} ${LIBFCL_INCLUDE_DIRS} ${catkin_INCLUDE_DIRS} ${console_bridge_INCLUDE_DIRS})
 
 add_library(${PROJECT_NAME}
   src/aabb.cpp
   src/bodies.cpp
   src/body_operations.cpp
   src/mesh_operations.cpp
+  src/obb.cpp
   src/shape_extents.cpp
   src/shape_operations.cpp
   src/shape_to_marker.cpp
@@ -87,7 +98,7 @@ add_library(${PROJECT_NAME}
 )
 target_compile_options(${PROJECT_NAME} PRIVATE ${PROJECT_COMPILE_OPTIONS})
 
-target_link_libraries(${PROJECT_NAME} ${ASSIMP_LIBRARIES} ${QHULL_LIBRARIES} ${catkin_LIBRARIES} ${console_bridge_LIBRARIES} ${Boost_LIBRARIES})
+target_link_libraries(${PROJECT_NAME} ${ASSIMP_LIBRARIES} ${QHULL_LIBRARIES} ${catkin_LIBRARIES} ${console_bridge_LIBRARIES} ${Boost_LIBRARIES} ${LIBFCL_LIBRARIES})
 
 
 if(CATKIN_ENABLE_TESTING)

--- a/include/geometric_shapes/bodies.h
+++ b/include/geometric_shapes/bodies.h
@@ -42,6 +42,7 @@
 #endif
 
 #include "geometric_shapes/aabb.h"
+#include "geometric_shapes/obb.h"
 #include "geometric_shapes/shapes.h"
 #include <eigen_stl_containers/eigen_stl_containers.h>
 #include <random_numbers/random_numbers.h>
@@ -244,6 +245,10 @@ public:
       pose. Scaling and padding are accounted for. */
   virtual void computeBoundingBox(AABB& bbox) const = 0;
 
+  /** \brief Compute the oriented bounding box for the body, in its current
+      pose. Scaling and padding are accounted for. */
+  virtual void computeBoundingBox(OBB& bbox) const = 0;
+
   /** \brief Get a clone of this body, but one that is located at the pose \e pose */
   BodyPtr cloneAt(const Eigen::Isometry3d& pose) const
   {
@@ -321,6 +326,7 @@ public:
   void computeBoundingSphere(BoundingSphere& sphere) const override;
   void computeBoundingCylinder(BoundingCylinder& cylinder) const override;
   void computeBoundingBox(AABB& bbox) const override;
+  void computeBoundingBox(OBB& bbox) const override;
   bool intersectsRay(const Eigen::Vector3d& origin, const Eigen::Vector3d& dir,
                      EigenSTL::vector_Vector3d* intersections = nullptr, unsigned int count = 0) const override;
 
@@ -380,6 +386,7 @@ public:
   void computeBoundingSphere(BoundingSphere& sphere) const override;
   void computeBoundingCylinder(BoundingCylinder& cylinder) const override;
   void computeBoundingBox(AABB& bbox) const override;
+  void computeBoundingBox(OBB& bbox) const override;
   bool intersectsRay(const Eigen::Vector3d& origin, const Eigen::Vector3d& dir,
                      EigenSTL::vector_Vector3d* intersections = nullptr, unsigned int count = 0) const override;
 
@@ -452,6 +459,7 @@ public:
   void computeBoundingSphere(BoundingSphere& sphere) const override;
   void computeBoundingCylinder(BoundingCylinder& cylinder) const override;
   void computeBoundingBox(AABB& bbox) const override;
+  void computeBoundingBox(OBB& bbox) const override;
   bool intersectsRay(const Eigen::Vector3d& origin, const Eigen::Vector3d& dir,
                      EigenSTL::vector_Vector3d* intersections = nullptr, unsigned int count = 0) const override;
 
@@ -514,6 +522,7 @@ public:
   void computeBoundingSphere(BoundingSphere& sphere) const override;
   void computeBoundingCylinder(BoundingCylinder& cylinder) const override;
   void computeBoundingBox(AABB& bbox) const override;
+  void computeBoundingBox(OBB& bbox) const override;
   bool intersectsRay(const Eigen::Vector3d& origin, const Eigen::Vector3d& dir,
                      EigenSTL::vector_Vector3d* intersections = nullptr, unsigned int count = 0) const override;
 

--- a/include/geometric_shapes/body_operations.h
+++ b/include/geometric_shapes/body_operations.h
@@ -66,6 +66,9 @@ void mergeBoundingSpheres(const std::vector<BoundingSphere>& spheres, BoundingSp
 /** \brief Compute an axis-aligned bounding box to enclose a set of bounding boxes. */
 void mergeBoundingBoxes(const std::vector<AABB>& boxes, AABB& mergedBox);
 
+/** \brief Compute an approximate oriented bounding box to enclose a set of bounding boxes. */
+void mergeBoundingBoxesApprox(const std::vector<OBB>& boxes, OBB& mergedBox);
+
 /** \brief Compute the bounding sphere for a set of \e bodies and store the resulting sphere in \e mergedSphere */
 void computeBoundingSphere(const std::vector<const Body*>& bodies, BoundingSphere& mergedSphere);
 }  // namespace bodies

--- a/include/geometric_shapes/obb.h
+++ b/include/geometric_shapes/obb.h
@@ -1,0 +1,132 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2021, Open Robotics
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of Open Robotics nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Author: Martin Pecka */
+
+#ifndef GEOMETRIC_SHAPES_OBB_H
+#define GEOMETRIC_SHAPES_OBB_H
+
+#include <memory>
+
+#include <Eigen/Core>
+#include <Eigen/Geometry>
+
+#include <geometric_shapes/aabb.h>
+
+namespace bodies
+{
+class OBBPrivate;
+
+/** \brief Represents an oriented bounding box. */
+class OBB
+{
+public:
+  OBB();
+  OBB(const OBB& other);
+  OBB(const Eigen::Isometry3d& pose, const Eigen::Vector3d& extents);
+  virtual ~OBB();
+
+  OBB& operator=(const OBB& other);
+
+  /**
+   * \brief Set both the pose and extents of the OBB.
+   * \param [in] pose New pose of the OBB.
+   * \param [in] extents New extents of the OBB.
+   */
+  void setPoseAndExtents(const Eigen::Isometry3d& pose, const Eigen::Vector3d& extents);
+
+  /**
+   * \brief Get the extents of the OBB.
+   * \return The extents.
+   */
+  Eigen::Vector3d getExtents() const;
+
+  /**
+   * \brief Get the extents of the OBB.
+   * \param extents [out] The extents.
+   */
+  void getExtents(Eigen::Vector3d& extents) const;
+
+  /**
+   * \brief Get the pose of the OBB.
+   * \return The pose.
+   */
+  Eigen::Isometry3d getPose() const;
+
+  /**
+   * \brief Get The pose of the OBB.
+   * \param pose The pose.
+   */
+  void getPose(Eigen::Isometry3d& pose) const;
+
+  /**
+   * \brief Convert this OBB to an axis-aligned BB.
+   * \return The AABB.
+   */
+  AABB toAABB() const;
+
+  /**
+   * \brief Convert this OBB to an axis-aligned BB.
+   * \param aabb The AABB.
+   */
+  void toAABB(AABB& aabb) const;
+
+  /**
+   * \brief Add the other OBB to this one and compute an approximate enclosing OBB.
+   * \param box The other box to add.
+   * \return Pointer to this OBB after the update.
+   */
+  OBB* extendApprox(const OBB& box);
+
+  /**
+   * \brief Check if this OBB contains the given point.
+   * \param point The point to check.
+   * \return Whether the point is inside or not.
+   */
+  bool contains(const Eigen::Vector3d& point);
+
+  /**
+   * \brief Check whether this and the given OBBs have nonempty intersection.
+   * \param other The other OBB to check.
+   * \return Whether the OBBs overlap.
+   */
+  bool overlaps(const OBB& other);
+
+protected:
+  /** \brief PIMPL pointer */
+  std::unique_ptr<OBBPrivate> obb_;
+};
+}  // namespace bodies
+
+#endif  // GEOMETRIC_SHAPES_OBB_H

--- a/package.xml
+++ b/package.xml
@@ -1,4 +1,4 @@
-<package>
+<package format="3">
   <name>geometric_shapes</name>
   <version>0.6.4</version>
   <description>Generic definitions of geometric shapes and bodies.</description>
@@ -19,7 +19,8 @@
   <build_depend>eigen</build_depend>
   <build_depend>eigen_stl_containers</build_depend>
   <build_depend>libconsole-bridge-dev</build_depend>
-  <build_depend>libfcl-dev</build_depend>
+  <build_depend condition="$ROS_DISTRO != noetic">libfcl-dev</build_depend>
+  <build_depend condition="$ROS_DISTRO == noetic">fcl</build_depend>
   <build_depend>libqhull</build_depend>
   <build_depend>octomap</build_depend>
   <build_depend>pkg-config</build_depend>
@@ -28,18 +29,31 @@
   <build_depend>shape_msgs</build_depend>
   <build_depend>visualization_msgs</build_depend>
 
-  <run_depend>assimp</run_depend>
-  <run_depend>boost</run_depend>
-  <run_depend>eigen</run_depend>
-  <run_depend>eigen_stl_containers</run_depend>
-  <run_depend>libconsole-bridge-dev</run_depend>
-  <run_depend>libfcl-dev</run_depend>
-  <run_depend>libqhull</run_depend>
-  <run_depend>octomap</run_depend>
-  <run_depend>random_numbers</run_depend>
-  <run_depend>resource_retriever</run_depend>
-  <run_depend>shape_msgs</run_depend>
-  <run_depend>visualization_msgs</run_depend>
+  <build_export_depend>assimp-dev</build_export_depend>
+  <build_export_depend>boost</build_export_depend>
+  <build_export_depend>eigen</build_export_depend>
+  <build_export_depend>eigen_stl_containers</build_export_depend>
+  <build_export_depend>libconsole-bridge-dev</build_export_depend>
+  <build_export_depend>libqhull</build_export_depend>
+  <build_export_depend>octomap</build_export_depend>
+  <build_export_depend>random_numbers</build_export_depend>
+  <build_export_depend>resource_retriever</build_export_depend>
+  <build_export_depend>shape_msgs</build_export_depend>
+  <build_export_depend>visualization_msgs</build_export_depend>
+
+  <exec_depend>assimp</exec_depend>
+  <exec_depend>boost</exec_depend>
+  <exec_depend>eigen</exec_depend>
+  <exec_depend>eigen_stl_containers</exec_depend>
+  <exec_depend>libconsole-bridge-dev</exec_depend>
+  <exec_depend condition="$ROS_DISTRO != noetic">libfcl-dev</exec_depend>
+  <exec_depend condition="$ROS_DISTRO == noetic">fcl</exec_depend>
+  <exec_depend>libqhull</exec_depend>
+  <exec_depend>octomap</exec_depend>
+  <exec_depend>random_numbers</exec_depend>
+  <exec_depend>resource_retriever</exec_depend>
+  <exec_depend>shape_msgs</exec_depend>
+  <exec_depend>visualization_msgs</exec_depend>
 
   <test_depend>rosunit</test_depend>
 </package>

--- a/package.xml
+++ b/package.xml
@@ -19,6 +19,7 @@
   <build_depend>eigen</build_depend>
   <build_depend>eigen_stl_containers</build_depend>
   <build_depend>libconsole-bridge-dev</build_depend>
+  <build_depend>libfcl-dev</build_depend>
   <build_depend>libqhull</build_depend>
   <build_depend>octomap</build_depend>
   <build_depend>pkg-config</build_depend>
@@ -32,6 +33,7 @@
   <run_depend>eigen</run_depend>
   <run_depend>eigen_stl_containers</run_depend>
   <run_depend>libconsole-bridge-dev</run_depend>
+  <run_depend>libfcl-dev</run_depend>
   <run_depend>libqhull</run_depend>
   <run_depend>octomap</run_depend>
   <run_depend>random_numbers</run_depend>

--- a/src/aabb.cpp
+++ b/src/aabb.cpp
@@ -43,7 +43,7 @@
 
 void bodies::AABB::extendWithTransformedBox(const Eigen::Isometry3d& transform, const Eigen::Vector3d& box)
 {
-#if FCL_MAJOR_VERSION == 0 && FCL_MINOR_VERSION == 5
+#if FCL_MAJOR_VERSION == 0 && FCL_MINOR_VERSION <= 5
   // Method adapted from FCL src/shape/geometric_shapes_utility.cpp#computeBV<AABB, Box>(...) (BSD-licensed code):
   // https://github.com/flexible-collision-library/fcl/blob/fcl-0.4/src/shape/geometric_shapes_utility.cpp#L292
   // We don't call their code because it would need creating temporary objects, and their method is in floats in FCL 0.5

--- a/src/aabb.cpp
+++ b/src/aabb.cpp
@@ -37,13 +37,13 @@
 #include <geometric_shapes/aabb.h>
 
 #include <fcl/config.h>
-#if FCL_MINOR_VERSION > 5
+#if FCL_MAJOR_VERSION > 0 || FCL_MINOR_VERSION > 5
 #include <fcl/geometry/shape/utility.h>
 #endif
 
 void bodies::AABB::extendWithTransformedBox(const Eigen::Isometry3d& transform, const Eigen::Vector3d& box)
 {
-#if FCL_MINOR_VERSION == 5
+#if FCL_MAJOR_VERSION == 0 && FCL_MINOR_VERSION == 5
   // Method adapted from FCL src/shape/geometric_shapes_utility.cpp#computeBV<AABB, Box>(...) (BSD-licensed code):
   // https://github.com/flexible-collision-library/fcl/blob/fcl-0.4/src/shape/geometric_shapes_utility.cpp#L292
   // We don't call their code because it would need creating temporary objects, and their method is in floats in FCL 0.5

--- a/src/aabb.cpp
+++ b/src/aabb.cpp
@@ -44,6 +44,13 @@ void bodies::AABB::extendWithTransformedBox(const Eigen::Isometry3d& transform, 
   //
   // Here's a nice explanation why it works: https://zeuxcg.org/2010/10/17/aabb-from-obb-with-component-wise-abs/
 
+  // TODO: In FCL 0.6, the inefficencies are gone and the AABB can be computed like this:
+  // #include <fcl/shape/geometric_shapes_utility.h>
+  // fcl::AABB aabb;
+  // fcl::computeBV(fcl::Box(box), transform, aabb);
+  // extend(aabb.min_);
+  // extend(aabb.max_);
+
   const Eigen::Matrix3d& r = transform.rotation();
   const Eigen::Vector3d& t = transform.translation();
 

--- a/src/aabb.cpp
+++ b/src/aabb.cpp
@@ -36,21 +36,19 @@
 
 #include <geometric_shapes/aabb.h>
 
+#include <fcl/config.h>
+#if FCL_MINOR_VERSION > 5
+#include <fcl/geometry/shape/utility.h>
+#endif
+
 void bodies::AABB::extendWithTransformedBox(const Eigen::Isometry3d& transform, const Eigen::Vector3d& box)
 {
+#if FCL_MINOR_VERSION == 5
   // Method adapted from FCL src/shape/geometric_shapes_utility.cpp#computeBV<AABB, Box>(...) (BSD-licensed code):
   // https://github.com/flexible-collision-library/fcl/blob/fcl-0.4/src/shape/geometric_shapes_utility.cpp#L292
-  // We don't call their code because it would need creating temporary objects, and their method is in floats.
+  // We don't call their code because it would need creating temporary objects, and their method is in floats in FCL 0.5
   //
   // Here's a nice explanation why it works: https://zeuxcg.org/2010/10/17/aabb-from-obb-with-component-wise-abs/
-
-  // TODO: In FCL 0.6, the inefficencies are gone and the AABB can be computed like this:
-  // #include <fcl/shape/geometric_shapes_utility.h>
-  // fcl::AABB aabb;
-  // fcl::computeBV(fcl::Box(box), transform, aabb);
-  // extend(aabb.min_);
-  // extend(aabb.max_);
-
   const Eigen::Matrix3d& r = transform.rotation();
   const Eigen::Vector3d& t = transform.translation();
 
@@ -61,4 +59,10 @@ void bodies::AABB::extendWithTransformedBox(const Eigen::Isometry3d& transform, 
   const Eigen::Vector3d v_delta(x_range, y_range, z_range);
   extend(t + v_delta);
   extend(t - v_delta);
+#else
+  fcl::AABBd aabb;
+  fcl::computeBV(fcl::Boxd(box), transform, aabb);
+  extend(aabb.min_);
+  extend(aabb.max_);
+#endif
 }

--- a/src/bodies.cpp
+++ b/src/bodies.cpp
@@ -247,6 +247,15 @@ void bodies::Sphere::computeBoundingBox(bodies::AABB& bbox) const
   bbox.extendWithTransformedBox(transform, Eigen::Vector3d(2 * radiusU_, 2 * radiusU_, 2 * radiusU_));
 }
 
+void bodies::Sphere::computeBoundingBox(bodies::OBB& bbox) const
+{
+  // it's a sphere, so we do not rotate the bounding box
+  Eigen::Isometry3d transform = Eigen::Isometry3d::Identity();
+  transform.translation() = getPose().translation();
+
+  bbox.setPoseAndExtents(transform, 2 * Eigen::Vector3d(radiusU_, radiusU_, radiusU_));
+}
+
 bool bodies::Sphere::samplePointInside(random_numbers::RandomNumberGenerator& rng, unsigned int max_attempts,
                                        Eigen::Vector3d& result) const
 {
@@ -453,6 +462,11 @@ void bodies::Cylinder::computeBoundingBox(bodies::AABB& bbox) const
   bbox.extend(pa + e);
   bbox.extend(pb - e);
   bbox.extend(pb + e);
+}
+
+void bodies::Cylinder::computeBoundingBox(bodies::OBB& bbox) const
+{
+  bbox.setPoseAndExtents(getPose(), 2 * Eigen::Vector3d(radiusU_, radiusU_, length2_));
 }
 
 bool bodies::Cylinder::intersectsRay(const Eigen::Vector3d& origin, const Eigen::Vector3d& dir,
@@ -683,6 +697,11 @@ void bodies::Box::computeBoundingBox(bodies::AABB& bbox) const
   bbox.setEmpty();
 
   bbox.extendWithTransformedBox(getPose(), 2 * Eigen::Vector3d(length2_, width2_, height2_));
+}
+
+void bodies::Box::computeBoundingBox(bodies::OBB& bbox) const
+{
+  bbox.setPoseAndExtents(getPose(), 2 * Eigen::Vector3d(length2_, width2_, height2_));
 }
 
 bool bodies::Box::intersectsRay(const Eigen::Vector3d& origin, const Eigen::Vector3d& dir,
@@ -1140,6 +1159,11 @@ void bodies::ConvexMesh::computeBoundingBox(bodies::AABB& bbox) const
 {
   bbox.setEmpty();
 
+  bounding_box_.computeBoundingBox(bbox);
+}
+
+void bodies::ConvexMesh::computeBoundingBox(bodies::OBB& bbox) const
+{
   bounding_box_.computeBoundingBox(bbox);
 }
 

--- a/src/body_operations.cpp
+++ b/src/body_operations.cpp
@@ -199,3 +199,9 @@ void bodies::mergeBoundingBoxes(const std::vector<bodies::AABB>& boxes, bodies::
   for (const auto& box : boxes)
     mergedBox.extend(box);
 }
+
+void bodies::mergeBoundingBoxesApprox(const std::vector<bodies::OBB>& boxes, bodies::OBB& mergedBox)
+{
+  for (const auto& box : boxes)
+    mergedBox.extendApprox(box);
+}

--- a/src/obb.cpp
+++ b/src/obb.cpp
@@ -2,7 +2,7 @@
 
 #include <fcl/config.h>
 
-#if FCL_MINOR_VERSION == 5
+#if FCL_MAJOR_VERSION == 0 && FCL_MINOR_VERSION == 5
 #include <fcl/BV/OBB.h>
 typedef fcl::Vec3f FCL_Vec3;
 typedef fcl::OBB FCL_OBB;
@@ -14,7 +14,7 @@ typedef fcl::OBB<double> FCL_OBB;
 
 namespace bodies
 {
-#if FCL_MINOR_VERSION == 5
+#if FCL_MAJOR_VERSION == 0 && FCL_MINOR_VERSION == 5
 inline FCL_Vec3 toFcl(const Eigen::Vector3d& eigenVec)
 {
   FCL_Vec3 result;
@@ -25,7 +25,7 @@ inline FCL_Vec3 toFcl(const Eigen::Vector3d& eigenVec)
 #define toFcl
 #endif
 
-#if FCL_MINOR_VERSION == 5
+#if FCL_MAJOR_VERSION == 0 && FCL_MINOR_VERSION == 5
 Eigen::Vector3d fromFcl(const FCL_Vec3& fclVec)
 {
   return Eigen::Map<const Eigen::MatrixXd>(fclVec.data.vs, 3, 1);
@@ -65,7 +65,7 @@ void OBB::setPoseAndExtents(const Eigen::Isometry3d& pose, const Eigen::Vector3d
 {
   const auto rotation = pose.linear();
 
-#if FCL_MINOR_VERSION == 5
+#if FCL_MAJOR_VERSION == 0 && FCL_MINOR_VERSION == 5
   obb_->axis[0] = toFcl(rotation.col(0));
   obb_->axis[1] = toFcl(rotation.col(1));
   obb_->axis[2] = toFcl(rotation.col(2));
@@ -96,7 +96,7 @@ void OBB::getPose(Eigen::Isometry3d& pose) const
   pose.translation() = fromFcl(obb_->To);
   // If all axes are zero, we report the rotation as identity
   // This happens if OBB is default-constructed
-#if FCL_MINOR_VERSION == 5
+#if FCL_MAJOR_VERSION == 0 && FCL_MINOR_VERSION == 5
   if (!obb_->axis[0].isZero() && !obb_->axis[3].isZero() && !obb_->axis[2].isZero())
   {
     pose.linear().col(0) = fromFcl(obb_->axis[0]);

--- a/src/obb.cpp
+++ b/src/obb.cpp
@@ -2,7 +2,7 @@
 
 #include <fcl/config.h>
 
-#if FCL_MAJOR_VERSION == 0 && FCL_MINOR_VERSION == 5
+#if FCL_MAJOR_VERSION == 0 && FCL_MINOR_VERSION <= 5
 #include <fcl/BV/OBB.h>
 typedef fcl::Vec3f FCL_Vec3;
 typedef fcl::OBB FCL_OBB;
@@ -14,7 +14,7 @@ typedef fcl::OBB<double> FCL_OBB;
 
 namespace bodies
 {
-#if FCL_MAJOR_VERSION == 0 && FCL_MINOR_VERSION == 5
+#if FCL_MAJOR_VERSION == 0 && FCL_MINOR_VERSION <= 5
 inline FCL_Vec3 toFcl(const Eigen::Vector3d& eigenVec)
 {
   FCL_Vec3 result;
@@ -25,7 +25,7 @@ inline FCL_Vec3 toFcl(const Eigen::Vector3d& eigenVec)
 #define toFcl
 #endif
 
-#if FCL_MAJOR_VERSION == 0 && FCL_MINOR_VERSION == 5
+#if FCL_MAJOR_VERSION == 0 && FCL_MINOR_VERSION <= 5
 Eigen::Vector3d fromFcl(const FCL_Vec3& fclVec)
 {
   return Eigen::Map<const Eigen::MatrixXd>(fclVec.data.vs, 3, 1);
@@ -65,7 +65,7 @@ void OBB::setPoseAndExtents(const Eigen::Isometry3d& pose, const Eigen::Vector3d
 {
   const auto rotation = pose.linear();
 
-#if FCL_MAJOR_VERSION == 0 && FCL_MINOR_VERSION == 5
+#if FCL_MAJOR_VERSION == 0 && FCL_MINOR_VERSION <= 5
   obb_->axis[0] = toFcl(rotation.col(0));
   obb_->axis[1] = toFcl(rotation.col(1));
   obb_->axis[2] = toFcl(rotation.col(2));
@@ -96,7 +96,7 @@ void OBB::getPose(Eigen::Isometry3d& pose) const
   pose.translation() = fromFcl(obb_->To);
   // If all axes are zero, we report the rotation as identity
   // This happens if OBB is default-constructed
-#if FCL_MAJOR_VERSION == 0 && FCL_MINOR_VERSION == 5
+#if FCL_MAJOR_VERSION == 0 && FCL_MINOR_VERSION <= 5
   if (!obb_->axis[0].isZero() && !obb_->axis[3].isZero() && !obb_->axis[2].isZero())
   {
     pose.linear().col(0) = fromFcl(obb_->axis[0]);

--- a/src/obb.cpp
+++ b/src/obb.cpp
@@ -1,27 +1,43 @@
 #include <geometric_shapes/obb.h>
 
+#include <fcl/config.h>
+
+#if FCL_MINOR_VERSION == 5
 #include <fcl/BV/OBB.h>
+typedef fcl::Vec3f FCL_Vec3;
+typedef fcl::OBB FCL_OBB;
+#else
+#include <fcl/math/bv/OBB.h>
+typedef fcl::Vector3d FCL_Vec3;
+typedef fcl::OBB<double> FCL_OBB;
+#endif
 
 namespace bodies
 {
-// TODO: In FCL 0.6, this code can be simplified a lot
-
-fcl::Vec3f toFcl(const Eigen::Vector3d& eigenVec)
+#if FCL_MINOR_VERSION == 5
+inline FCL_Vec3 toFcl(const Eigen::Vector3d& eigenVec)
 {
-  fcl::Vec3f result;
+  FCL_Vec3 result;
   Eigen::Map<Eigen::MatrixXd>(result.data.vs, 3, 1) = eigenVec;
   return result;
 }
+#else
+#define toFcl
+#endif
 
-Eigen::Vector3d fromFcl(const fcl::Vec3f& fclVec)
+#if FCL_MINOR_VERSION == 5
+Eigen::Vector3d fromFcl(const FCL_Vec3& fclVec)
 {
   return Eigen::Map<const Eigen::MatrixXd>(fclVec.data.vs, 3, 1);
 }
+#else
+#define fromFcl
+#endif
 
-class OBBPrivate : public fcl::OBB
+class OBBPrivate : public FCL_OBB
 {
 public:
-  using fcl::OBB::OBB;
+  using FCL_OBB::OBB;
 };
 
 OBB::OBB()
@@ -42,15 +58,20 @@ OBB::OBB(const Eigen::Isometry3d& pose, const Eigen::Vector3d& extents) : OBB()
 OBB& OBB::operator=(const OBB& other)
 {
   *obb_ = *other.obb_;
+  return *this;
 }
 
 void OBB::setPoseAndExtents(const Eigen::Isometry3d& pose, const Eigen::Vector3d& extents)
 {
   const auto rotation = pose.linear();
 
+#if FCL_MINOR_VERSION == 5
   obb_->axis[0] = toFcl(rotation.col(0));
   obb_->axis[1] = toFcl(rotation.col(1));
   obb_->axis[2] = toFcl(rotation.col(2));
+#else
+  obb_->axis = rotation;
+#endif
 
   obb_->To = toFcl(pose.translation());
 
@@ -73,9 +94,21 @@ void OBB::getPose(Eigen::Isometry3d& pose) const
 {
   pose = Eigen::Isometry3d::Identity();
   pose.translation() = fromFcl(obb_->To);
-  pose.linear().col(0) = fromFcl(obb_->axis[0]);
-  pose.linear().col(1) = fromFcl(obb_->axis[1]);
-  pose.linear().col(2) = fromFcl(obb_->axis[2]);
+  // If all axes are zero, we report the rotation as identity
+  // This happens if OBB is default-constructed
+#if FCL_MINOR_VERSION == 5
+  if (!obb_->axis[0].isZero() && !obb_->axis[3].isZero() && !obb_->axis[2].isZero())
+  {
+    pose.linear().col(0) = fromFcl(obb_->axis[0]);
+    pose.linear().col(1) = fromFcl(obb_->axis[1]);
+    pose.linear().col(2) = fromFcl(obb_->axis[2]);
+  }
+#else
+  if (!obb_->axis.isApprox(fcl::Matrix3d::Zero()))
+  {
+    pose.linear() = obb_->axis;
+  }
+#endif
 }
 
 Eigen::Isometry3d OBB::getPose() const

--- a/src/obb.cpp
+++ b/src/obb.cpp
@@ -1,0 +1,118 @@
+#include <geometric_shapes/obb.h>
+
+#include <fcl/BV/OBB.h>
+
+namespace bodies
+{
+// TODO: In FCL 0.6, this code can be simplified a lot
+
+fcl::Vec3f toFcl(const Eigen::Vector3d& eigenVec)
+{
+  fcl::Vec3f result;
+  Eigen::Map<Eigen::MatrixXd>(result.data.vs, 3, 1) = eigenVec;
+  return result;
+}
+
+Eigen::Vector3d fromFcl(const fcl::Vec3f& fclVec)
+{
+  return Eigen::Map<const Eigen::MatrixXd>(fclVec.data.vs, 3, 1);
+}
+
+class OBBPrivate : public fcl::OBB
+{
+public:
+  using fcl::OBB::OBB;
+};
+
+OBB::OBB()
+{
+  this->obb_.reset(new OBBPrivate);
+}
+
+OBB::OBB(const OBB& other) : OBB()
+{
+  *obb_ = *other.obb_;
+}
+
+OBB::OBB(const Eigen::Isometry3d& pose, const Eigen::Vector3d& extents) : OBB()
+{
+  setPoseAndExtents(pose, extents);
+}
+
+OBB& OBB::operator=(const OBB& other)
+{
+  *obb_ = *other.obb_;
+}
+
+void OBB::setPoseAndExtents(const Eigen::Isometry3d& pose, const Eigen::Vector3d& extents)
+{
+  const auto rotation = pose.linear();
+
+  obb_->axis[0] = toFcl(rotation.col(0));
+  obb_->axis[1] = toFcl(rotation.col(1));
+  obb_->axis[2] = toFcl(rotation.col(2));
+
+  obb_->To = toFcl(pose.translation());
+
+  obb_->extent = { extents[0] / 2.0, extents[1] / 2.0, extents[2] / 2.0 };
+}
+
+void OBB::getExtents(Eigen::Vector3d& extents) const
+{
+  extents = 2 * fromFcl(obb_->extent);
+}
+
+Eigen::Vector3d OBB::getExtents() const
+{
+  Eigen::Vector3d extents;
+  getExtents(extents);
+  return extents;
+}
+
+void OBB::getPose(Eigen::Isometry3d& pose) const
+{
+  pose = Eigen::Isometry3d::Identity();
+  pose.translation() = fromFcl(obb_->To);
+  pose.linear().col(0) = fromFcl(obb_->axis[0]);
+  pose.linear().col(1) = fromFcl(obb_->axis[1]);
+  pose.linear().col(2) = fromFcl(obb_->axis[2]);
+}
+
+Eigen::Isometry3d OBB::getPose() const
+{
+  Eigen::Isometry3d pose;
+  getPose(pose);
+  return pose;
+}
+
+AABB OBB::toAABB() const
+{
+  AABB result;
+  toAABB(result);
+  return result;
+}
+
+void OBB::toAABB(AABB& aabb) const
+{
+  aabb.extendWithTransformedBox(getPose(), getExtents());
+}
+
+OBB* OBB::extendApprox(const OBB& box)
+{
+  *this->obb_ += *box.obb_;
+  return this;
+}
+
+bool OBB::contains(const Eigen::Vector3d& point)
+{
+  return obb_->contain(toFcl(point));
+}
+
+bool OBB::overlaps(const bodies::OBB& other)
+{
+  return obb_->overlap(*other.obb_);
+}
+
+OBB::~OBB() = default;
+
+}  // namespace bodies

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -16,7 +16,7 @@ catkin_add_gtest(test_bounding_sphere test_bounding_sphere.cpp)
 target_link_libraries(test_bounding_sphere ${PROJECT_NAME} ${catkin_LIBRARIES} ${Boost_LIBRARIES})
 
 catkin_add_gtest(test_bounding_box test_bounding_box.cpp)
-target_link_libraries(test_bounding_box ${PROJECT_NAME} ${catkin_LIBRARIES} ${Boost_LIBRARIES})
+target_link_libraries(test_bounding_box ${PROJECT_NAME} ${catkin_LIBRARIES} ${Boost_LIBRARIES} ${LIBFCL_LIBRARIES})
 
 catkin_add_gtest(test_bounding_cylinder test_bounding_cylinder.cpp)
 target_link_libraries(test_bounding_cylinder ${PROJECT_NAME} ${catkin_LIBRARIES} ${Boost_LIBRARIES})

--- a/test/test_bounding_box.cpp
+++ b/test/test_bounding_box.cpp
@@ -47,6 +47,8 @@ TEST(SphereBoundingBox, Sphere1)
   bodies::Sphere body(&shape);
   bodies::AABB bbox;
   body.computeBoundingBox(bbox);
+  bodies::OBB obbox;
+  body.computeBoundingBox(obbox);
 
   EXPECT_NEAR(-1.0, bbox.min().x(), 1e-4);
   EXPECT_NEAR(-1.0, bbox.min().y(), 1e-4);
@@ -54,6 +56,15 @@ TEST(SphereBoundingBox, Sphere1)
   EXPECT_NEAR(1.0, bbox.max().x(), 1e-4);
   EXPECT_NEAR(1.0, bbox.max().y(), 1e-4);
   EXPECT_NEAR(1.0, bbox.max().z(), 1e-4);
+
+  EXPECT_NEAR(2.0, obbox.getExtents().x(), 1e-4);
+  EXPECT_NEAR(2.0, obbox.getExtents().y(), 1e-4);
+  EXPECT_NEAR(2.0, obbox.getExtents().z(), 1e-4);
+  EXPECT_NEAR(0.0, obbox.getPose().translation().x(), 1e-4);
+  EXPECT_NEAR(0.0, obbox.getPose().translation().y(), 1e-4);
+  EXPECT_NEAR(0.0, obbox.getPose().translation().z(), 1e-4);
+
+  EXPECT_TRUE(obbox.getPose().linear().isApprox(Eigen::Matrix3d::Identity(), 1e-4));
 }
 
 TEST(SphereBoundingBox, Sphere2)
@@ -66,6 +77,8 @@ TEST(SphereBoundingBox, Sphere2)
   body.setPose(pose);
   bodies::AABB bbox;
   body.computeBoundingBox(bbox);
+  bodies::OBB obbox;
+  body.computeBoundingBox(obbox);
 
   EXPECT_NEAR(-1.0, bbox.min().x(), 1e-4);
   EXPECT_NEAR(0.0, bbox.min().y(), 1e-4);
@@ -73,10 +86,17 @@ TEST(SphereBoundingBox, Sphere2)
   EXPECT_NEAR(3.0, bbox.max().x(), 1e-4);
   EXPECT_NEAR(4.0, bbox.max().y(), 1e-4);
   EXPECT_NEAR(5.0, bbox.max().z(), 1e-4);
+
+  EXPECT_NEAR(4.0, obbox.getExtents().x(), 1e-4);
+  EXPECT_NEAR(4.0, obbox.getExtents().y(), 1e-4);
+  EXPECT_NEAR(4.0, obbox.getExtents().z(), 1e-4);
+
+  EXPECT_TRUE(obbox.getPose().isApprox(pose, 1e-4));
 
   pose *= Eigen::AngleAxisd(M_PI_2, Eigen::Vector3d(1, 1, 1).normalized());
   body.setPose(pose);
   body.computeBoundingBox(bbox);
+  body.computeBoundingBox(obbox);
 
   EXPECT_NEAR(-1.0, bbox.min().x(), 1e-4);
   EXPECT_NEAR(0.0, bbox.min().y(), 1e-4);
@@ -84,6 +104,14 @@ TEST(SphereBoundingBox, Sphere2)
   EXPECT_NEAR(3.0, bbox.max().x(), 1e-4);
   EXPECT_NEAR(4.0, bbox.max().y(), 1e-4);
   EXPECT_NEAR(5.0, bbox.max().z(), 1e-4);
+
+  EXPECT_NEAR(4.0, obbox.getExtents().x(), 1e-4);
+  EXPECT_NEAR(4.0, obbox.getExtents().y(), 1e-4);
+  EXPECT_NEAR(4.0, obbox.getExtents().z(), 1e-4);
+
+  // oriented bounding box doesn't rotate with the sphere
+  EXPECT_TRUE(obbox.getPose().translation().isApprox(pose.translation(), 1e-4));
+  EXPECT_TRUE(obbox.getPose().linear().isApprox(Eigen::Matrix3d::Identity(), 1e-4));
 
   // verify the bounding box is rotation-invariant
 
@@ -101,7 +129,9 @@ TEST(SphereBoundingBox, Sphere2)
     pose.linear() = quat.toRotationMatrix();
     body.setPose(pose);
     bodies::AABB bbox2;
+    bodies::OBB obbox2;
     body.computeBoundingBox(bbox2);
+    body.computeBoundingBox(obbox2);
 
     EXPECT_NEAR(bbox2.min().x(), bbox.min().x(), 1e-4);
     EXPECT_NEAR(bbox2.min().y(), bbox.min().y(), 1e-4);
@@ -109,6 +139,12 @@ TEST(SphereBoundingBox, Sphere2)
     EXPECT_NEAR(bbox2.max().x(), bbox.max().x(), 1e-4);
     EXPECT_NEAR(bbox2.max().y(), bbox.max().y(), 1e-4);
     EXPECT_NEAR(bbox2.max().z(), bbox.max().z(), 1e-4);
+
+    EXPECT_NEAR(obbox.getExtents().x(), obbox2.getExtents().x(), 1e-4);
+    EXPECT_NEAR(obbox.getExtents().y(), obbox2.getExtents().y(), 1e-4);
+    EXPECT_NEAR(obbox.getExtents().z(), obbox2.getExtents().z(), 1e-4);
+
+    EXPECT_TRUE(obbox2.getPose().isApprox(obbox.getPose(), 1e-4));
   }
 }
 
@@ -118,6 +154,8 @@ TEST(BoxBoundingBox, Box1)
   bodies::Box body(&shape);
   bodies::AABB bbox;
   body.computeBoundingBox(bbox);
+  bodies::OBB obbox;
+  body.computeBoundingBox(obbox);
 
   EXPECT_NEAR(-0.5, bbox.min().x(), 1e-4);
   EXPECT_NEAR(-1.0, bbox.min().y(), 1e-4);
@@ -125,6 +163,15 @@ TEST(BoxBoundingBox, Box1)
   EXPECT_NEAR(0.5, bbox.max().x(), 1e-4);
   EXPECT_NEAR(1.0, bbox.max().y(), 1e-4);
   EXPECT_NEAR(1.5, bbox.max().z(), 1e-4);
+
+  EXPECT_NEAR(1.0, obbox.getExtents().x(), 1e-4);
+  EXPECT_NEAR(2.0, obbox.getExtents().y(), 1e-4);
+  EXPECT_NEAR(3.0, obbox.getExtents().z(), 1e-4);
+  EXPECT_NEAR(0.0, obbox.getPose().translation().x(), 1e-4);
+  EXPECT_NEAR(0.0, obbox.getPose().translation().y(), 1e-4);
+  EXPECT_NEAR(0.0, obbox.getPose().translation().z(), 1e-4);
+
+  EXPECT_TRUE(obbox.getPose().linear().isApprox(Eigen::Matrix3d::Identity(), 1e-4));
 }
 
 TEST(BoxBoundingBox, Box2)
@@ -137,6 +184,8 @@ TEST(BoxBoundingBox, Box2)
   body.setPose(pose);
   bodies::AABB bbox;
   body.computeBoundingBox(bbox);
+  bodies::OBB obbox;
+  body.computeBoundingBox(obbox);
 
   EXPECT_NEAR(0.5, bbox.min().x(), 1e-4);
   EXPECT_NEAR(1.0, bbox.min().y(), 1e-4);
@@ -145,9 +194,19 @@ TEST(BoxBoundingBox, Box2)
   EXPECT_NEAR(3.0, bbox.max().y(), 1e-4);
   EXPECT_NEAR(4.5, bbox.max().z(), 1e-4);
 
+  EXPECT_NEAR(1.0, obbox.getExtents().x(), 1e-4);
+  EXPECT_NEAR(2.0, obbox.getExtents().y(), 1e-4);
+  EXPECT_NEAR(3.0, obbox.getExtents().z(), 1e-4);
+  EXPECT_NEAR(1.0, obbox.getPose().translation().x(), 1e-4);
+  EXPECT_NEAR(2.0, obbox.getPose().translation().y(), 1e-4);
+  EXPECT_NEAR(3.0, obbox.getPose().translation().z(), 1e-4);
+
+  EXPECT_TRUE(obbox.getPose().linear().isApprox(Eigen::Matrix3d::Identity(), 1e-4));
+
   pose *= Eigen::AngleAxisd(M_PI_2, Eigen::Vector3d(1, 1, 1).normalized());
   body.setPose(pose);
   body.computeBoundingBox(bbox);
+  body.computeBoundingBox(obbox);
 
   EXPECT_NEAR(-0.7767, bbox.min().x(), 1e-4);
   EXPECT_NEAR(0.8452, bbox.min().y(), 1e-4);
@@ -155,6 +214,15 @@ TEST(BoxBoundingBox, Box2)
   EXPECT_NEAR(2.7767, bbox.max().x(), 1e-4);
   EXPECT_NEAR(3.1547, bbox.max().y(), 1e-4);
   EXPECT_NEAR(4.5326, bbox.max().z(), 1e-4);
+
+  EXPECT_NEAR(1.0, obbox.getExtents().x(), 1e-4);
+  EXPECT_NEAR(2.0, obbox.getExtents().y(), 1e-4);
+  EXPECT_NEAR(3.0, obbox.getExtents().z(), 1e-4);
+  EXPECT_NEAR(1.0, obbox.getPose().translation().x(), 1e-4);
+  EXPECT_NEAR(2.0, obbox.getPose().translation().y(), 1e-4);
+  EXPECT_NEAR(3.0, obbox.getPose().translation().z(), 1e-4);
+
+  EXPECT_TRUE(obbox.getPose().linear().isApprox(pose.linear(), 1e-4));
 }
 
 TEST(CylinderBoundingBox, Cylinder1)
@@ -163,6 +231,8 @@ TEST(CylinderBoundingBox, Cylinder1)
   bodies::Cylinder body(&shape);
   bodies::AABB bbox;
   body.computeBoundingBox(bbox);
+  bodies::OBB obbox;
+  body.computeBoundingBox(obbox);
 
   EXPECT_NEAR(-1.0, bbox.min().x(), 1e-4);
   EXPECT_NEAR(-1.0, bbox.min().y(), 1e-4);
@@ -170,6 +240,15 @@ TEST(CylinderBoundingBox, Cylinder1)
   EXPECT_NEAR(1.0, bbox.max().x(), 1e-4);
   EXPECT_NEAR(1.0, bbox.max().y(), 1e-4);
   EXPECT_NEAR(1.0, bbox.max().z(), 1e-4);
+
+  EXPECT_NEAR(2.0, obbox.getExtents().x(), 1e-4);
+  EXPECT_NEAR(2.0, obbox.getExtents().y(), 1e-4);
+  EXPECT_NEAR(2.0, obbox.getExtents().z(), 1e-4);
+  EXPECT_NEAR(0.0, obbox.getPose().translation().x(), 1e-4);
+  EXPECT_NEAR(0.0, obbox.getPose().translation().y(), 1e-4);
+  EXPECT_NEAR(0.0, obbox.getPose().translation().z(), 1e-4);
+
+  EXPECT_TRUE(obbox.getPose().linear().isApprox(Eigen::Matrix3d::Identity(), 1e-4));
 }
 
 TEST(CylinderBoundingBox, Cylinder2)
@@ -182,6 +261,8 @@ TEST(CylinderBoundingBox, Cylinder2)
   body.setPose(pose);
   bodies::AABB bbox;
   body.computeBoundingBox(bbox);
+  bodies::OBB obbox;
+  body.computeBoundingBox(obbox);
 
   EXPECT_NEAR(0.0, bbox.min().x(), 1e-4);
   EXPECT_NEAR(1.0, bbox.min().y(), 1e-4);
@@ -190,9 +271,19 @@ TEST(CylinderBoundingBox, Cylinder2)
   EXPECT_NEAR(3.0, bbox.max().y(), 1e-4);
   EXPECT_NEAR(4.0, bbox.max().z(), 1e-4);
 
+  EXPECT_NEAR(2.0, obbox.getExtents().x(), 1e-4);
+  EXPECT_NEAR(2.0, obbox.getExtents().y(), 1e-4);
+  EXPECT_NEAR(2.0, obbox.getExtents().z(), 1e-4);
+  EXPECT_NEAR(1.0, obbox.getPose().translation().x(), 1e-4);
+  EXPECT_NEAR(2.0, obbox.getPose().translation().y(), 1e-4);
+  EXPECT_NEAR(3.0, obbox.getPose().translation().z(), 1e-4);
+
+  EXPECT_TRUE(obbox.getPose().linear().isApprox(Eigen::Matrix3d::Identity(), 1e-4));
+
   pose *= Eigen::AngleAxisd(M_PI_2, Eigen::Vector3d(1, 1, 1).normalized());
   body.setPose(pose);
   body.computeBoundingBox(bbox);
+  body.computeBoundingBox(obbox);
 
   EXPECT_NEAR(-0.3238, bbox.min().x(), 1e-4);
   EXPECT_NEAR(0.7862, bbox.min().y(), 1e-4);
@@ -200,6 +291,15 @@ TEST(CylinderBoundingBox, Cylinder2)
   EXPECT_NEAR(2.3238, bbox.max().x(), 1e-4);
   EXPECT_NEAR(3.2138, bbox.max().y(), 1e-4);
   EXPECT_NEAR(4.2761, bbox.max().z(), 1e-4);
+
+  EXPECT_NEAR(2.0, obbox.getExtents().x(), 1e-4);
+  EXPECT_NEAR(2.0, obbox.getExtents().y(), 1e-4);
+  EXPECT_NEAR(2.0, obbox.getExtents().z(), 1e-4);
+  EXPECT_NEAR(1.0, obbox.getPose().translation().x(), 1e-4);
+  EXPECT_NEAR(2.0, obbox.getPose().translation().y(), 1e-4);
+  EXPECT_NEAR(3.0, obbox.getPose().translation().z(), 1e-4);
+
+  EXPECT_TRUE(obbox.getPose().linear().isApprox(pose.linear(), 1e-4));
 
   // verify the bounding box is yaw-invariant
 
@@ -212,6 +312,7 @@ TEST(CylinderBoundingBox, Cylinder2)
   body.computeBoundingBox(bbox);
 
   bodies::AABB bbox2;
+  bodies::OBB obbox2;
   for (size_t i = 0; i < 10; ++i)
   {
     const auto angle = gen.uniformReal(-M_PI, M_PI);
@@ -219,6 +320,7 @@ TEST(CylinderBoundingBox, Cylinder2)
     pose.linear() = (rollPitch * yaw).toRotationMatrix();
     body.setPose(pose);
     body.computeBoundingBox(bbox2);
+    body.computeBoundingBox(obbox2);
 
     EXPECT_NEAR(bbox2.min().x(), bbox.min().x(), 1e-4);
     EXPECT_NEAR(bbox2.min().y(), bbox.min().y(), 1e-4);
@@ -226,6 +328,16 @@ TEST(CylinderBoundingBox, Cylinder2)
     EXPECT_NEAR(bbox2.max().x(), bbox.max().x(), 1e-4);
     EXPECT_NEAR(bbox2.max().y(), bbox.max().y(), 1e-4);
     EXPECT_NEAR(bbox2.max().z(), bbox.max().z(), 1e-4);
+
+    EXPECT_NEAR(2.0, obbox2.getExtents().x(), 1e-4);
+    EXPECT_NEAR(2.0, obbox2.getExtents().y(), 1e-4);
+    EXPECT_NEAR(2.0, obbox2.getExtents().z(), 1e-4);
+    EXPECT_NEAR(1.0, obbox2.getPose().translation().x(), 1e-4);
+    EXPECT_NEAR(2.0, obbox2.getPose().translation().y(), 1e-4);
+    EXPECT_NEAR(3.0, obbox2.getPose().translation().z(), 1e-4);
+
+    // oriented bounding boxes are not yaw-invariant
+    EXPECT_TRUE(obbox2.getPose().linear().isApprox(pose.linear(), 1e-4));
   }
 }
 
@@ -323,6 +435,8 @@ TEST(MeshBoundingBox, Mesh1)
   bodies::ConvexMesh body(m);
   bodies::AABB bbox;
   body.computeBoundingBox(bbox);
+  bodies::OBB obbox;
+  body.computeBoundingBox(obbox);
 
   EXPECT_NEAR(-1.0, bbox.min().x(), 1e-4);
   EXPECT_NEAR(-1.0, bbox.min().y(), 1e-4);
@@ -330,6 +444,15 @@ TEST(MeshBoundingBox, Mesh1)
   EXPECT_NEAR(1.0, bbox.max().x(), 1e-4);
   EXPECT_NEAR(1.0, bbox.max().y(), 1e-4);
   EXPECT_NEAR(1.0, bbox.max().z(), 1e-4);
+
+  EXPECT_NEAR(2.0, obbox.getExtents().x(), 1e-4);
+  EXPECT_NEAR(2.0, obbox.getExtents().y(), 1e-4);
+  EXPECT_NEAR(2.0, obbox.getExtents().z(), 1e-4);
+  EXPECT_NEAR(0.0, obbox.getPose().translation().x(), 1e-4);
+  EXPECT_NEAR(0.0, obbox.getPose().translation().y(), 1e-4);
+  EXPECT_NEAR(0.0, obbox.getPose().translation().z(), 1e-4);
+
+  EXPECT_TRUE(obbox.getPose().linear().isApprox(Eigen::Matrix3d::Identity(), 1e-4));
   delete m;
 }
 
@@ -344,6 +467,8 @@ TEST(MeshBoundingBox, Mesh2)
   body.setPose(pose);
   bodies::AABB bbox;
   body.computeBoundingBox(bbox);
+  bodies::OBB obbox;
+  body.computeBoundingBox(obbox);
 
   EXPECT_NEAR(0.5, bbox.min().x(), 1e-4);
   EXPECT_NEAR(1.0, bbox.min().y(), 1e-4);
@@ -352,9 +477,19 @@ TEST(MeshBoundingBox, Mesh2)
   EXPECT_NEAR(3.0, bbox.max().y(), 1e-4);
   EXPECT_NEAR(4.5, bbox.max().z(), 1e-4);
 
+  EXPECT_NEAR(1.0, obbox.getExtents().x(), 1e-4);
+  EXPECT_NEAR(2.0, obbox.getExtents().y(), 1e-4);
+  EXPECT_NEAR(3.0, obbox.getExtents().z(), 1e-4);
+  EXPECT_NEAR(1.0, obbox.getPose().translation().x(), 1e-4);
+  EXPECT_NEAR(2.0, obbox.getPose().translation().y(), 1e-4);
+  EXPECT_NEAR(3.0, obbox.getPose().translation().z(), 1e-4);
+
+  EXPECT_TRUE(obbox.getPose().linear().isApprox(Eigen::Matrix3d::Identity(), 1e-4));
+
   pose *= Eigen::AngleAxisd(M_PI_2, Eigen::Vector3d(1, 1, 1).normalized());
   body.setPose(pose);
   body.computeBoundingBox(bbox);
+  body.computeBoundingBox(obbox);
 
   EXPECT_NEAR(-0.7767, bbox.min().x(), 1e-4);
   EXPECT_NEAR(0.8452, bbox.min().y(), 1e-4);
@@ -362,6 +497,15 @@ TEST(MeshBoundingBox, Mesh2)
   EXPECT_NEAR(2.7767, bbox.max().x(), 1e-4);
   EXPECT_NEAR(3.1547, bbox.max().y(), 1e-4);
   EXPECT_NEAR(4.5326, bbox.max().z(), 1e-4);
+
+  EXPECT_NEAR(1.0, obbox.getExtents().x(), 1e-4);
+  EXPECT_NEAR(2.0, obbox.getExtents().y(), 1e-4);
+  EXPECT_NEAR(3.0, obbox.getExtents().z(), 1e-4);
+  EXPECT_NEAR(1.0, obbox.getPose().translation().x(), 1e-4);
+  EXPECT_NEAR(2.0, obbox.getPose().translation().y(), 1e-4);
+  EXPECT_NEAR(3.0, obbox.getPose().translation().z(), 1e-4);
+
+  EXPECT_TRUE(obbox.getPose().linear().isApprox(pose.linear(), 1e-4));
 
   delete m;
 }
@@ -381,6 +525,34 @@ TEST(MergeBoundingBoxes, Merge1)
   EXPECT_NEAR(1.0, bbox.max().x(), 1e-4);
   EXPECT_NEAR(1.0, bbox.max().y(), 1e-4);
   EXPECT_NEAR(1.0, bbox.max().z(), 1e-4);
+}
+
+TEST(MergeBoundingBoxes, OBBApprox1)
+{
+  std::vector<bodies::OBB> boxes;
+  auto pose = Eigen::Isometry3d::Identity();
+
+  pose.translation() = -0.5 * Eigen::Vector3d::Ones();
+  boxes.emplace_back(pose, Eigen::Vector3d(1, 1, 1));
+  pose.translation() = 0.5 * Eigen::Vector3d::Ones();
+  boxes.emplace_back(pose, Eigen::Vector3d(1, 1, 1));
+
+  bodies::OBB bbox;
+  bodies::mergeBoundingBoxesApprox(boxes, bbox);
+
+  // the resulting bounding box is not tight, so we only do some sanity checks
+
+  EXPECT_GE(4.0, bbox.getExtents().x());
+  EXPECT_GE(4.0, bbox.getExtents().y());
+  EXPECT_GE(4.0, bbox.getExtents().z());
+  EXPECT_LE(2.0, bbox.getExtents().x());
+  EXPECT_LE(2.0, bbox.getExtents().y());
+  EXPECT_LE(2.0, bbox.getExtents().z());
+
+  EXPECT_TRUE(bbox.contains(boxes[0].getPose().translation()));
+  EXPECT_TRUE(bbox.contains(boxes[1].getPose().translation()));
+  EXPECT_TRUE(bbox.overlaps(boxes[0]));
+  EXPECT_TRUE(bbox.overlaps(boxes[1]));
 }
 
 int main(int argc, char** argv)


### PR DESCRIPTION
Added support for oriented bounding boxes. Depends on #104.

Please note that this PR adds dependency on FCL. I checked how many dependees of geometric_shapes there are which do not depend on fcl, and only collada_urdf seems to get an unnecessary transitive dependency on FCL. moveit_core depends on FCL.

The OBBs for single bodies are all the tightest you can get (they have some degrees of freedom though, e.g. for sphere and cylinder). For spheres, the axis-aligned BB is returned. For cylinder, the BB rotates around z axis with the cylinder. The mesh OBB can be suboptimal since it is initialized with the AABB.

Once you start merging OBBs, the result is only an approximate OBB (which is what FCL computes). As I get it, the optimal (minimum volume) OBB computation is heavy and is tackled using iterative methods in other libraries. I haven't yet implemented the optimal version, and I probably even won't do it. However, if you think it might be valuable in the future, we can add the function header and leave it unimplemented (or throwing an exception/assert).