### PR TITLE
Throw runtime exception when a shape or body should have a negative dimension.

### DIFF
--- a/src/bodies.cpp
+++ b/src/bodies.cpp
@@ -146,9 +146,10 @@ std::vector<double> bodies::Sphere::getDimensions() const
 
 void bodies::Sphere::updateInternalData()
 {
-  radiusU_ = radius_ * scale_ + padding_;
-  if (radiusU_ < 0)
+  const auto tmpRadiusU = radius_ * scale_ + padding_;
+  if (tmpRadiusU < 0)
     throw std::runtime_error("Sphere radius must be non-negative.");
+  radiusU_ = tmpRadiusU;
   radius2_ = radiusU_ * radiusU_;
   center_ = pose_.translation();
 }
@@ -310,13 +311,15 @@ std::vector<double> bodies::Cylinder::getDimensions() const
 
 void bodies::Cylinder::updateInternalData()
 {
-  radiusU_ = radius_ * scale_ + padding_;
-  if (radiusU_ < 0)
+  const auto tmpRadiusU = radius_ * scale_ + padding_;
+  if (tmpRadiusU < 0)
     throw std::runtime_error("Cylinder radius must be non-negative.");
-  radius2_ = radiusU_ * radiusU_;
-  length2_ = scale_ * length_ / 2.0 + padding_;
-  if (length2_ < 0)
+  const auto tmpLength2 = scale_ * length_ / 2.0 + padding_;
+  if (tmpLength2 < 0)
     throw std::runtime_error("Cylinder length must be non-negative.");
+  radiusU_ = tmpRadiusU;
+  length2_ = tmpLength2;
+  radius2_ = radiusU_ * radiusU_;
   center_ = pose_.translation();
   radiusBSqr_ = length2_ * length2_ + radius2_;
   radiusB_ = sqrt(radiusBSqr_);
@@ -543,12 +546,16 @@ std::vector<double> bodies::Box::getDimensions() const
 void bodies::Box::updateInternalData()
 {
   double s2 = scale_ / 2.0;
-  length2_ = length_ * s2 + padding_;
-  width2_ = width_ * s2 + padding_;
-  height2_ = height_ * s2 + padding_;
+  const auto tmpLength2 = length_ * s2 + padding_;
+  const auto tmpWidth2 = width_ * s2 + padding_;
+  const auto tmpHeight2 = height_ * s2 + padding_;
 
-  if (length2_ < 0 || width2_ < 0 || height2_ < 0)
+  if (tmpLength2 < 0 || tmpWidth2 < 0 || tmpHeight2 < 0)
     throw std::runtime_error("Box dimensions must be non-negative.");
+
+  length2_ = tmpLength2;
+  width2_ = tmpWidth2;
+  height2_ = tmpHeight2;
 
   center_ = pose_.translation();
 

--- a/src/bodies.cpp
+++ b/src/bodies.cpp
@@ -147,6 +147,8 @@ std::vector<double> bodies::Sphere::getDimensions() const
 void bodies::Sphere::updateInternalData()
 {
   radiusU_ = radius_ * scale_ + padding_;
+  if (radiusU_ < 0)
+    throw std::runtime_error("Sphere radius must be non-negative.");
   radius2_ = radiusU_ * radiusU_;
   center_ = pose_.translation();
 }
@@ -309,8 +311,12 @@ std::vector<double> bodies::Cylinder::getDimensions() const
 void bodies::Cylinder::updateInternalData()
 {
   radiusU_ = radius_ * scale_ + padding_;
+  if (radiusU_ < 0)
+    throw std::runtime_error("Cylinder radius must be non-negative.");
   radius2_ = radiusU_ * radiusU_;
   length2_ = scale_ * length_ / 2.0 + padding_;
+  if (length2_ < 0)
+    throw std::runtime_error("Cylinder length must be non-negative.");
   center_ = pose_.translation();
   radiusBSqr_ = length2_ * length2_ + radius2_;
   radiusB_ = sqrt(radiusBSqr_);
@@ -540,6 +546,9 @@ void bodies::Box::updateInternalData()
   length2_ = length_ * s2 + padding_;
   width2_ = width_ * s2 + padding_;
   height2_ = height_ * s2 + padding_;
+
+  if (length2_ < 0 || width2_ < 0 || height2_ < 0)
+    throw std::runtime_error("Box dimensions must be non-negative.");
 
   center_ = pose_.translation();
 

--- a/src/shapes.cpp
+++ b/src/shapes.cpp
@@ -101,6 +101,8 @@ Sphere::Sphere() : Shape()
 
 Sphere::Sphere(double r) : Shape()
 {
+  if (r < 0)
+    throw std::runtime_error("Sphere radius must be non-negative.");
   type = SPHERE;
   radius = r;
 }
@@ -113,6 +115,8 @@ Cylinder::Cylinder() : Shape()
 
 Cylinder::Cylinder(double r, double l) : Shape()
 {
+  if (r < 0 || l < 0)
+    throw std::runtime_error("Cylinder dimensions must be non-negative.");
   type = CYLINDER;
   length = l;
   radius = r;
@@ -126,6 +130,8 @@ Cone::Cone() : Shape()
 
 Cone::Cone(double r, double l) : Shape()
 {
+  if (r < 0 || l < 0)
+    throw std::runtime_error("Cone dimensions must be non-negative.");
   type = CONE;
   length = l;
   radius = r;
@@ -139,6 +145,8 @@ Box::Box() : Shape()
 
 Box::Box(double x, double y, double z) : Shape()
 {
+  if (x < 0 || y < 0 || z < 0)
+    throw std::runtime_error("Box dimensions must be non-negative.");
   type = BOX;
   size[0] = x;
   size[1] = y;
@@ -285,18 +293,24 @@ void Shape::padd(double padding)
 void Sphere::scaleAndPadd(double scale, double padding)
 {
   radius = radius * scale + padding;
+  if (radius < 0)
+    throw std::runtime_error("Sphere radius must be non-negative.");
 }
 
 void Cylinder::scaleAndPadd(double scale, double padding)
 {
   radius = radius * scale + padding;
   length = length * scale + 2.0 * padding;
+  if (radius < 0 || length < 0)
+    throw std::runtime_error("Cylinder dimensions must be non-negative.");
 }
 
 void Cone::scaleAndPadd(double scale, double padding)
 {
   radius = radius * scale + padding;
   length = length * scale + 2.0 * padding;
+  if (radius < 0 || length < 0)
+    throw std::runtime_error("Cone dimensions must be non-negative.");
 }
 
 void Box::scaleAndPadd(double scale, double padding)
@@ -305,6 +319,8 @@ void Box::scaleAndPadd(double scale, double padding)
   size[0] = size[0] * scale + p2;
   size[1] = size[1] * scale + p2;
   size[2] = size[2] * scale + p2;
+  if (size[0] < 0 || size[1] < 0 || size[2] < 0)
+    throw std::runtime_error("Box dimensions must be non-negative.");
 }
 
 void Mesh::scaleAndPadd(double scale, double padding)

--- a/src/shapes.cpp
+++ b/src/shapes.cpp
@@ -292,35 +292,43 @@ void Shape::padd(double padding)
 
 void Sphere::scaleAndPadd(double scale, double padding)
 {
-  radius = radius * scale + padding;
-  if (radius < 0)
+  const auto tmpRadius = radius * scale + padding;
+  if (tmpRadius < 0)
     throw std::runtime_error("Sphere radius must be non-negative.");
+  radius = tmpRadius;
 }
 
 void Cylinder::scaleAndPadd(double scale, double padding)
 {
-  radius = radius * scale + padding;
-  length = length * scale + 2.0 * padding;
-  if (radius < 0 || length < 0)
+  const auto tmpRadius = radius * scale + padding;
+  const auto tmpLength = length * scale + 2.0 * padding;
+  if (tmpRadius < 0 || tmpLength < 0)
     throw std::runtime_error("Cylinder dimensions must be non-negative.");
+  radius = tmpRadius;
+  length = tmpLength;
 }
 
 void Cone::scaleAndPadd(double scale, double padding)
 {
-  radius = radius * scale + padding;
-  length = length * scale + 2.0 * padding;
-  if (radius < 0 || length < 0)
+  const auto tmpRadius = radius * scale + padding;
+  const auto tmpLength = length * scale + 2.0 * padding;
+  if (tmpRadius < 0 || tmpLength < 0)
     throw std::runtime_error("Cone dimensions must be non-negative.");
+  radius = tmpRadius;
+  length = tmpLength;
 }
 
 void Box::scaleAndPadd(double scale, double padding)
 {
   double p2 = padding * 2.0;
-  size[0] = size[0] * scale + p2;
-  size[1] = size[1] * scale + p2;
-  size[2] = size[2] * scale + p2;
-  if (size[0] < 0 || size[1] < 0 || size[2] < 0)
+  const auto tmpSize0 = size[0] * scale + p2;
+  const auto tmpSize1 = size[1] * scale + p2;
+  const auto tmpSize2 = size[2] * scale + p2;
+  if (tmpSize0 < 0 || tmpSize1 < 0 || tmpSize2 < 0)
     throw std::runtime_error("Box dimensions must be non-negative.");
+  size[0] = tmpSize0;
+  size[1] = tmpSize1;
+  size[2] = tmpSize2;
 }
 
 void Mesh::scaleAndPadd(double scale, double padding)


### PR DESCRIPTION
Meshes are exceptions - you might want to give it a negative scale to mirror it. Although I'm not sure all member functions would tackle negative scale or large negative padding correctly.