### PR TITLE
Fixed Box::intersectsRay to return both intersections.

### DIFF
--- a/src/bodies.cpp
+++ b/src/bodies.cpp
@@ -700,7 +700,7 @@ bool bodies::Box::intersectsRay(const Eigen::Vector3d& origin, const Eigen::Vect
     if (tmax - tmin > detail::ZERO)
     {
       intersections->push_back(tmin * dir + origin);
-      if (count > 1)
+      if (count == 0 || count > 1)
         intersections->push_back(tmax * dir + origin);
     }
     else


### PR DESCRIPTION
Box::intersectsRay was always returning only the first collision when  `collision` arg was set to zero.
    
This is wrong according to function docs, so I corrected that.