### PR TITLE
Fixed computation of intersectsRay() for Cylinder, Box and ConvexMesh

### DIFF
--- a/include/geometric_shapes/bodies.h
+++ b/include/geometric_shapes/bodies.h
@@ -496,12 +496,10 @@ protected:
 
   // pose/padding/scaling-dependent values & values computed for convenience and fast upcoming computations
   Eigen::Vector3d center_;
-  Eigen::Vector3d normalL_;
-  Eigen::Vector3d normalW_;
-  Eigen::Vector3d normalH_;
+  Eigen::Matrix3d invRot_;
 
-  Eigen::Vector3d corner1_;
-  Eigen::Vector3d corner2_;
+  Eigen::Vector3d corner1_;  //!< The translated, but not rotated min corner
+  Eigen::Vector3d corner2_;  //!< The translated, but not rotated max corner
 
   double length2_;
   double width2_;

--- a/include/geometric_shapes/bodies.h
+++ b/include/geometric_shapes/bodies.h
@@ -327,7 +327,7 @@ public:
   {
     type_ = shapes::SPHERE;
     shapes::Sphere shape(sphere.radius);
-    setDimensions(&shape);
+    setDimensionsDirty(&shape);
 
     Eigen::Isometry3d pose = Eigen::Isometry3d::Identity();
     pose.translation() = sphere.center;
@@ -389,7 +389,7 @@ public:
   {
     type_ = shapes::CYLINDER;
     shapes::Cylinder shape(cylinder.radius, cylinder.length);
-    setDimensions(&shape);
+    setDimensionsDirty(&shape);
     setPose(cylinder.pose);
   }
 
@@ -458,7 +458,7 @@ public:
   {
     type_ = shapes::BOX;
     shapes::Box shape(aabb.sizes()[0], aabb.sizes()[1], aabb.sizes()[2]);
-    setDimensions(&shape);
+    setDimensionsDirty(&shape);
 
     Eigen::Isometry3d pose = Eigen::Isometry3d::Identity();
     pose.translation() = aabb.center();

--- a/include/geometric_shapes/bodies.h
+++ b/include/geometric_shapes/bodies.h
@@ -569,7 +569,12 @@ protected:
   /** \brief (Used mainly for debugging) Count the number of vertices behind a plane*/
   unsigned int countVerticesBehindPlane(const Eigen::Vector4f& planeNormal) const;
 
-  /** \brief Check if a point is inside a set of planes that make up a convex mesh*/
+  /** \brief Check if the point is inside all halfspaces this mesh consists of (mesh_data_->planes_).
+   *
+   * \note The point is expected to have pose_ "cancelled" (have inverse pose of this mesh applied to it).
+   * \note Scale and padding of the mesh are taken into account.
+   * \note There is a 1e-9 margin "outside" the planes where points are still considered to be inside.
+   */
   bool isPointInsidePlanes(const Eigen::Vector3d& point) const;
 
   struct MeshData
@@ -578,6 +583,7 @@ protected:
     EigenSTL::vector_Vector3d vertices_;
     std::vector<unsigned int> triangles_;
     std::map<unsigned int, unsigned int> plane_for_triangle_;
+    std::map<unsigned int, unsigned int> triangle_for_plane_;
     Eigen::Vector3d mesh_center_;
     double mesh_radiusB_;
     Eigen::Vector3d box_offset_;

--- a/include/geometric_shapes/bodies.h
+++ b/include/geometric_shapes/bodies.h
@@ -496,7 +496,9 @@ protected:
 
   // pose/padding/scaling-dependent values & values computed for convenience and fast upcoming computations
   Eigen::Vector3d center_;
-  Eigen::Matrix3d invRot_;
+  Eigen::Vector3d normalL_;
+  Eigen::Vector3d normalW_;
+  Eigen::Vector3d normalH_;
 
   Eigen::Vector3d corner1_;  //!< The translated, but not rotated min corner
   Eigen::Vector3d corner2_;  //!< The translated, but not rotated max corner
@@ -528,9 +530,7 @@ public:
     setDimensions(shape);
   }
 
-  virtual ~ConvexMesh()
-  {
-  }
+  virtual ~ConvexMesh();
 
   /** \brief Returns an empty vector */
   virtual std::vector<double> getDimensions() const;
@@ -583,7 +583,6 @@ protected:
     EigenSTL::vector_Vector3d vertices_;
     std::vector<unsigned int> triangles_;
     std::map<unsigned int, unsigned int> plane_for_triangle_;
-    std::map<unsigned int, unsigned int> triangle_for_plane_;
     Eigen::Vector3d mesh_center_;
     double mesh_radiusB_;
     Eigen::Vector3d box_offset_;

--- a/src/bodies.cpp
+++ b/src/bodies.cpp
@@ -680,6 +680,12 @@ bool bodies::Box::intersectsRay(const Eigen::Vector3d& origin, const Eigen::Vect
     tmax = (corner1_.x() - o.x()) * divx;
     tmin = (corner2_.x() - o.x()) * divx;
   }
+  // this prevents nans spreading in the computation; the other dimensions do not need this check because all the
+  // comparisons guarding change of tmin/tmax will come false in case a nan enters them
+  if (std::isnan(tmin))
+    tmin = -std::numeric_limits<float>::infinity();
+  if (std::isnan(tmax))
+    tmax = std::numeric_limits<float>::infinity();
 
   divy = 1 / d.y();
   if (d.y() >= 0)

--- a/src/bodies.cpp
+++ b/src/bodies.cpp
@@ -360,7 +360,7 @@ bool bodies::Cylinder::samplePointInside(random_numbers::RandomNumberGenerator& 
   // sample e height
   double z = rng.uniformReal(-length2_, length2_);
 
-  result = Eigen::Vector3d(x, y, z);
+  result = pose_ * Eigen::Vector3d(x, y, z);
   return true;
 }
 

--- a/src/bodies.cpp
+++ b/src/bodies.cpp
@@ -653,9 +653,11 @@ bool bodies::Box::intersectsRay(const Eigen::Vector3d& origin, const Eigen::Vect
   // Brian Smits. Efficient bounding box intersection. Ray tracing news 15(1), 2002
   float tmin, tmax, tymin, tymax, tzmin, tzmax;
   float divx, divy, divz;
-  const Eigen::Matrix3d invRot(pose_.linear().transpose());
-  const Eigen::Vector3d o(invRot * (origin - center_) + center_);
-  const Eigen::Vector3d d(invRot * dirNorm);
+
+  // The implemented method only works for axis-aligned boxes. So we treat ours as such, cancel its rotation, and
+  // rotate the origin and dir instead. corner1_ and corner2_ are corners with canceled rotation.
+  const Eigen::Vector3d o(invRot_ * (origin - center_) + center_);
+  const Eigen::Vector3d d(invRot_ * dirNorm);
 
   divx = 1 / d.x();
   if (divx >= 0)

--- a/src/bodies.cpp
+++ b/src/bodies.cpp
@@ -727,9 +727,16 @@ bool bodies::Box::intersectsRay(const Eigen::Vector3d& origin, const Eigen::Vect
   {
     if (tmax - tmin > detail::ZERO)
     {
-      intersections->push_back(tmin * dirNorm + origin);
-      if (count == 0 || count > 1)
+      if (tmin > detail::ZERO)
+      {
+        intersections->push_back(tmin * dirNorm + origin);
+        if (count == 0 || count > 1)
+          intersections->push_back(tmax * dirNorm + origin);
+      }
+      else
+      {
         intersections->push_back(tmax * dirNorm + origin);
+      }
     }
     else
       intersections->push_back(tmax * dirNorm + origin);

--- a/src/bodies.cpp
+++ b/src/bodies.cpp
@@ -651,9 +651,6 @@ void bodies::Box::computeBoundingBox(bodies::AABB& bbox) const
   bbox.extendWithTransformedBox(getPose(), 2 * Eigen::Vector3d(length2_, width2_, height2_));
 }
 
-// for some reason, the O2 optimization screws up this function which then gives wrong results
-#pragma GCC push_options
-#pragma GCC optimize("O1")
 bool bodies::Box::intersectsRay(const Eigen::Vector3d& origin, const Eigen::Vector3d& dir,
                                 EigenSTL::vector_Vector3d* intersections, unsigned int count) const
 {
@@ -751,7 +748,6 @@ bool bodies::Box::intersectsRay(const Eigen::Vector3d& origin, const Eigen::Vect
 
   return true;
 }
-#pragma GCC pop_options
 
 bool bodies::ConvexMesh::containsPoint(const Eigen::Vector3d& p, bool /* verbose */) const
 {

--- a/src/bodies.cpp
+++ b/src/bodies.cpp
@@ -1268,8 +1268,17 @@ bool bodies::ConvexMesh::intersectsRay(const Eigen::Vector3d& origin, const Eige
   {
     std::sort(ipts.begin(), ipts.end(), detail::interscOrder());
     const unsigned int n = count > 0 ? std::min<unsigned int>(count, ipts.size()) : ipts.size();
-    for (unsigned int i = 0; i < n; ++i)
-      intersections->push_back(ipts[i].pt);
+    // If a ray hits exactly the boundary between two triangles, it is reported twice;
+    // We only want return the intersection once; the loop makes use of the fact that ipts is
+    // already sorted by distance, so if some points are duplicate, they are examined successively.
+    for (const auto& p : ipts)
+    {
+      if (intersections->size() == n)
+        break;
+      if (!intersections->empty() && (p.pt - intersections->back()).squaredNorm() < pow(detail::ZERO, 2))
+        continue;
+      intersections->push_back(p.pt);
+    }
   }
 
   return result;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -29,3 +29,6 @@ target_link_libraries(test_loaded_meshes ${PROJECT_NAME} ${catkin_LIBRARIES} ${B
 
 catkin_add_gtest(test_shapes test_shapes.cpp)
 target_link_libraries(test_shapes ${PROJECT_NAME} ${catkin_LIBRARIES} ${Boost_LIBRARIES})
+
+catkin_add_gtest(test_ray_intersection test_ray_intersection.cpp)
+target_link_libraries(test_ray_intersection ${PROJECT_NAME} ${catkin_LIBRARIES} ${Boost_LIBRARIES})

--- a/test/test_point_inclusion.cpp
+++ b/test/test_point_inclusion.cpp
@@ -173,40 +173,6 @@ TEST(SpherePointContainment, ComplexOutside)
   EXPECT_FALSE(contains);
 }
 
-TEST(SphereRayIntersection, SimpleRay1)
-{
-  shapes::Sphere shape(1.0);
-  bodies::Body* sphere = new bodies::Sphere(&shape);
-  sphere->setScale(1.05);
-
-  Eigen::Vector3d ray_o(5, 0, 0);
-  Eigen::Vector3d ray_d(-1, 0, 0);
-  EigenSTL::vector_Vector3d p;
-  bool intersect = sphere->intersectsRay(ray_o, ray_d, &p);
-
-  delete sphere;
-  EXPECT_TRUE(intersect);
-  EXPECT_EQ(2, (int)p.size());
-  EXPECT_NEAR(p[0].x(), 1.05, 1e-6);
-  EXPECT_NEAR(p[1].x(), -1.05, 1e-6);
-}
-
-TEST(SphereRayIntersection, SimpleRay2)
-{
-  shapes::Sphere shape(1.0);
-  bodies::Body* sphere = new bodies::Sphere(&shape);
-  sphere->setScale(1.05);
-
-  Eigen::Vector3d ray_o(5, 0, 0);
-  Eigen::Vector3d ray_d(1, 0, 0);
-  EigenSTL::vector_Vector3d p;
-  bool intersect = sphere->intersectsRay(ray_o, ray_d, &p);
-
-  delete sphere;
-  EXPECT_FALSE(intersect);
-  EXPECT_EQ(0, (int)p.size());
-}
-
 TEST(BoxPointContainment, Basic)
 {
   shapes::Box shape(2.0, 2.0, 2.0);
@@ -330,69 +296,6 @@ TEST(BoxPointContainment, ComplexOutside)
   bool contains = box->containsPoint(1.5, 1.5, 1.5);
   delete box;
   EXPECT_FALSE(contains);
-}
-
-TEST(BoxRayIntersection, SimpleRay1)
-{
-  shapes::Box shape(1.0, 1.0, 3.0);
-  bodies::Body* box = new bodies::Box(&shape);
-  box->setScale(0.95);
-
-  Eigen::Vector3d ray_o(10, 0.449, 0);
-  Eigen::Vector3d ray_d(-1, 0, 0);
-  EigenSTL::vector_Vector3d p;
-
-  bool intersect = box->intersectsRay(ray_o, ray_d, &p);
-
-  //    for (unsigned int i = 0; i < p.size() ; ++i)
-  //        printf("intersection at %f, %f, %f\n", p[i].x(), p[i].y(), p[i].z());
-
-  delete box;
-  EXPECT_TRUE(intersect);
-}
-
-TEST(BoxRayIntersection, SimpleRay2)
-{
-  shapes::Box shape(0.9, 0.01, 1.2);
-  bodies::Body* box = new bodies::Box(&shape);
-
-  Eigen::Isometry3d pose(Eigen::AngleAxisd(0, Eigen::Vector3d::UnitX()));
-  pose.translation() = Eigen::Vector3d(0, 0.005, 0.6);
-  box->setPose(pose);
-
-  Eigen::Vector3d ray_o(0, 5, 1.6);
-  Eigen::Vector3d ray_d(0, -5.195, -0.77);
-  EigenSTL::vector_Vector3d p;
-
-  bool intersect = box->intersectsRay(ray_o, ray_d, &p);
-  EXPECT_TRUE(intersect);
-
-  intersect = box->intersectsRay(ray_o, ray_d.normalized(), &p);
-  EXPECT_TRUE(intersect);
-
-  delete box;
-}
-
-TEST(BoxRayIntersection, SimpleRay3)
-{
-  shapes::Box shape(0.02, 0.4, 1.2);
-  bodies::Body* box = new bodies::Box(&shape);
-
-  Eigen::Isometry3d pose(Eigen::AngleAxisd(0, Eigen::Vector3d::UnitX()));
-  pose.translation() = Eigen::Vector3d(0.45, -0.195, 0.6);
-  box->setPose(pose);
-
-  Eigen::Vector3d ray_o(0, -2, 1.11);
-  Eigen::Vector3d ray_d(0, 1.8, -0.669);
-  EigenSTL::vector_Vector3d p;
-
-  bool intersect = box->intersectsRay(ray_o, ray_d, &p);
-  EXPECT_FALSE(intersect);
-
-  intersect = box->intersectsRay(ray_o, ray_d.normalized(), &p);
-  EXPECT_FALSE(intersect);
-
-  delete box;
 }
 
 TEST(CylinderPointContainment, Basic)

--- a/test/test_point_inclusion.cpp
+++ b/test/test_point_inclusion.cpp
@@ -57,6 +57,17 @@ double largestComponentForLength2D(const double length)
   return sq2;
 }
 
+Eigen::Isometry3d getRandomPose(random_numbers::RandomNumberGenerator& g)
+{
+  const Eigen::Vector3d t(g.uniformReal(-100, 100), g.uniformReal(-100, 100), g.uniformReal(-100, 100));
+
+  double quat[4];
+  g.quaternion(quat);
+  const Eigen::Quaterniond r({ quat[3], quat[0], quat[1], quat[2] });
+
+  return Eigen::Isometry3d::TranslationType(t) * r;
+}
+
 TEST(SpherePointContainment, Basic)
 {
   shapes::Sphere shape(1.0);
@@ -132,10 +143,7 @@ TEST(SpherePointContainment, SimpleInside)
   Eigen::Vector3d p;
   for (int i = 0; i < 1000; ++i)
   {
-    std::srand(static_cast<unsigned int>(r.uniformInteger(0, std::numeric_limits<int>::max())));
-    const Eigen::Isometry3d pos(
-        Eigen::Isometry3d::TranslationType(Eigen::Vector3d::Random() * r.uniformReal(-100, 100)) *
-        Eigen::Quaterniond::UnitRandom());
+    const Eigen::Isometry3d pos = getRandomPose(r);
     sphere->setPose(pos);
     sphere->setScale(r.uniformReal(0.1, 100.0));
     sphere->setPadding(r.uniformReal(-0.001, 10.0));
@@ -296,10 +304,7 @@ TEST(BoxPointContainment, Sampled)
   Eigen::Vector3d p;
   for (int i = 0; i < 1000; ++i)
   {
-    std::srand(static_cast<unsigned int>(r.uniformInteger(0, std::numeric_limits<int>::max())));
-    const Eigen::Isometry3d pos(
-        Eigen::Isometry3d::TranslationType(Eigen::Vector3d::Random() * r.uniformReal(-100, 100)) *
-        Eigen::Quaterniond::UnitRandom());
+    const Eigen::Isometry3d pos = getRandomPose(r);
     box.setPose(pos);
     box.setScale(r.uniformReal(0.1, 100.0));
     box.setPadding(r.uniformReal(-0.001, 10.0));
@@ -434,10 +439,7 @@ TEST(CylinderPointContainment, Sampled)
   Eigen::Vector3d p;
   for (int i = 0; i < 1000; ++i)
   {
-    std::srand(static_cast<unsigned int>(r.uniformInteger(0, std::numeric_limits<int>::max())));
-    const Eigen::Isometry3d pos(
-        Eigen::Isometry3d::TranslationType(Eigen::Vector3d::Random() * r.uniformReal(-100, 100)) *
-        Eigen::Quaterniond::UnitRandom());
+    const Eigen::Isometry3d pos = getRandomPose(r);
     cylinder.setPose(pos);
     cylinder.setScale(r.uniformReal(0.1, 100.0));
     cylinder.setPadding(r.uniformReal(-0.001, 10.0));

--- a/test/test_ray_intersection.cpp
+++ b/test/test_ray_intersection.cpp
@@ -42,101 +42,118 @@
 #include <gtest/gtest.h>
 #include "resources/config.h"
 
+#define EXPECT_VECTORS_EQUAL(v1, v2, error)                                                                            \
+  EXPECT_NEAR((v1)[0], (v2)[0], (error));                                                                              \
+  EXPECT_NEAR((v1)[1], (v2)[1], (error));                                                                              \
+  EXPECT_NEAR((v1)[2], (v2)[2], (error));
+
+#define CHECK_NO_INTERSECTION(body, origin, direction)                                                                 \
+  {                                                                                                                    \
+    EigenSTL::vector_Vector3d intersections;                                                                           \
+    Eigen::Vector3d o origin;                                                                                          \
+    Eigen::Vector3d d direction;                                                                                       \
+    const auto result = (body).intersectsRay(o, d, &intersections, 2);                                                 \
+    EXPECT_FALSE(result);                                                                                              \
+    EXPECT_EQ(0, intersections.size());                                                                                \
+  }
+
+#define CHECK_INTERSECTS(body, origin, direction, numIntersections)                                                    \
+  {                                                                                                                    \
+    EigenSTL::vector_Vector3d intersections;                                                                           \
+    Eigen::Vector3d o origin;                                                                                          \
+    Eigen::Vector3d d direction;                                                                                       \
+    const auto result = (body).intersectsRay(o, d, &intersections, 2);                                                 \
+    EXPECT_TRUE(result);                                                                                               \
+    ASSERT_EQ((numIntersections), intersections.size());                                                               \
+  }
+
+#define CHECK_INTERSECTS_ONCE(body, origin, direction, intersection, error)                                            \
+  {                                                                                                                    \
+    EigenSTL::vector_Vector3d intersections;                                                                           \
+    Eigen::Vector3d o origin;                                                                                          \
+    Eigen::Vector3d d direction;                                                                                       \
+    Eigen::Vector3d i intersection;                                                                                    \
+    const auto result = (body).intersectsRay(o, d, &intersections, 2);                                                 \
+    EXPECT_TRUE(result);                                                                                               \
+    ASSERT_EQ(1, intersections.size());                                                                                \
+    EXPECT_VECTORS_EQUAL(intersections.at(0), i, (error));                                                             \
+  }
+
+#define CHECK_INTERSECTS_TWICE(body, origin, direction, intersc1, intersc2, error)                                     \
+  {                                                                                                                    \
+    EigenSTL::vector_Vector3d intersections;                                                                           \
+    Eigen::Vector3d o origin;                                                                                          \
+    Eigen::Vector3d d direction;                                                                                       \
+    Eigen::Vector3d i1 intersc1;                                                                                       \
+    Eigen::Vector3d i2 intersc2;                                                                                       \
+    const auto result = (body).intersectsRay(o, d, &intersections, 2);                                                 \
+    EXPECT_TRUE(result);                                                                                               \
+    ASSERT_EQ(2, intersections.size());                                                                                \
+    if (fabs(static_cast<double>((intersections.at(0) - i1).norm())) < (error))                                        \
+    {                                                                                                                  \
+      EXPECT_VECTORS_EQUAL(intersections.at(0), i1, (error));                                                          \
+      EXPECT_VECTORS_EQUAL(intersections.at(1), i2, (error));                                                          \
+    }                                                                                                                  \
+    else                                                                                                               \
+    {                                                                                                                  \
+      EXPECT_VECTORS_EQUAL(intersections.at(0), i2, (error));                                                          \
+      EXPECT_VECTORS_EQUAL(intersections.at(1), i1, (error));                                                          \
+    }                                                                                                                  \
+  }
+
 TEST(SphereRayIntersection, SimpleRay1)
 {
   shapes::Sphere shape(1.0);
-  bodies::Body* sphere = new bodies::Sphere(&shape);
-  sphere->setScale(1.05);
+  bodies::Sphere sphere(&shape);
+  sphere.setScale(1.05);
 
-  Eigen::Vector3d ray_o(5, 0, 0);
-  Eigen::Vector3d ray_d(-1, 0, 0);
-  EigenSTL::vector_Vector3d p;
-  bool intersect = sphere->intersectsRay(ray_o, ray_d, &p);
-
-  delete sphere;
-  EXPECT_TRUE(intersect);
-  EXPECT_EQ(2, (int)p.size());
-  EXPECT_NEAR(p[0].x(), 1.05, 1e-6);
-  EXPECT_NEAR(p[1].x(), -1.05, 1e-6);
+  CHECK_INTERSECTS_TWICE(sphere, (5, 0, 0), (-1, 0, 0), (1.05, 0, 0), (-1.05, 0, 0), 1e-6)
 }
 
 TEST(SphereRayIntersection, SimpleRay2)
 {
   shapes::Sphere shape(1.0);
-  bodies::Body* sphere = new bodies::Sphere(&shape);
-  sphere->setScale(1.05);
+  bodies::Sphere sphere(&shape);
+  sphere.setScale(1.05);
 
-  Eigen::Vector3d ray_o(5, 0, 0);
-  Eigen::Vector3d ray_d(1, 0, 0);
-  EigenSTL::vector_Vector3d p;
-  bool intersect = sphere->intersectsRay(ray_o, ray_d, &p);
-
-  delete sphere;
-  EXPECT_FALSE(intersect);
-  EXPECT_EQ(0, (int)p.size());
+  CHECK_NO_INTERSECTION(sphere, (5, 0, 0), (1, 0, 0))
 }
 
 TEST(BoxRayIntersection, SimpleRay1)
 {
   shapes::Box shape(1.0, 1.0, 3.0);
-  bodies::Body* box = new bodies::Box(&shape);
-  box->setScale(0.95);
+  bodies::Box box(&shape);
+  box.setScale(0.95);
 
-  Eigen::Vector3d ray_o(10, 0.449, 0);
-  Eigen::Vector3d ray_d(-1, 0, 0);
-  EigenSTL::vector_Vector3d p;
-
-  bool intersect = box->intersectsRay(ray_o, ray_d, &p);
-
-  //    for (unsigned int i = 0; i < p.size() ; ++i)
-  //        printf("intersection at %f, %f, %f\n", p[i].x(), p[i].y(), p[i].z());
-
-  delete box;
-  EXPECT_TRUE(intersect);
+  CHECK_INTERSECTS_TWICE(box, (10, 0.449, 0), (-1, 0, 0), (0.475, 0.449, 0), (-0.475, 0.449, 0), 1e-4)
 }
 
 TEST(BoxRayIntersection, SimpleRay2)
 {
   shapes::Box shape(0.9, 0.01, 1.2);
-  bodies::Body* box = new bodies::Box(&shape);
+  bodies::Box box(&shape);
 
   Eigen::Isometry3d pose(Eigen::AngleAxisd(0, Eigen::Vector3d::UnitX()));
   pose.translation() = Eigen::Vector3d(0, 0.005, 0.6);
-  box->setPose(pose);
+  box.setPose(pose);
 
-  Eigen::Vector3d ray_o(0, 5, 1.6);
-  Eigen::Vector3d ray_d(0, -5.195, -0.77);
-  EigenSTL::vector_Vector3d p;
+  const Eigen::Vector3d ray_d(0, -5.195, -0.77);
 
-  bool intersect = box->intersectsRay(ray_o, ray_d, &p);
-  EXPECT_TRUE(intersect);
-
-  intersect = box->intersectsRay(ray_o, ray_d.normalized(), &p);
-  EXPECT_TRUE(intersect);
-
-  delete box;
+  CHECK_INTERSECTS(box, (0, 5, 1.6), (ray_d.normalized()), 2)
 }
 
 TEST(BoxRayIntersection, SimpleRay3)
 {
   shapes::Box shape(0.02, 0.4, 1.2);
-  bodies::Body* box = new bodies::Box(&shape);
+  bodies::Box box(&shape);
 
   Eigen::Isometry3d pose(Eigen::AngleAxisd(0, Eigen::Vector3d::UnitX()));
   pose.translation() = Eigen::Vector3d(0.45, -0.195, 0.6);
-  box->setPose(pose);
+  box.setPose(pose);
 
-  Eigen::Vector3d ray_o(0, -2, 1.11);
-  Eigen::Vector3d ray_d(0, 1.8, -0.669);
-  EigenSTL::vector_Vector3d p;
+  const Eigen::Vector3d ray_d(0, 1.8, -0.669);
 
-  bool intersect = box->intersectsRay(ray_o, ray_d, &p);
-  EXPECT_FALSE(intersect);
-
-  intersect = box->intersectsRay(ray_o, ray_d.normalized(), &p);
-  EXPECT_FALSE(intersect);
-
-  delete box;
+  CHECK_NO_INTERSECTION(box, (0, -2, 1.11), (ray_d.normalized()))
 }
 
 int main(int argc, char** argv)

--- a/test/test_ray_intersection.cpp
+++ b/test/test_ray_intersection.cpp
@@ -43,6 +43,17 @@
 #include <gtest/gtest.h>
 #include "resources/config.h"
 
+Eigen::Isometry3d getRandomPose(random_numbers::RandomNumberGenerator& g)
+{
+  const Eigen::Vector3d t(g.uniformReal(-100, 100), g.uniformReal(-100, 100), g.uniformReal(-100, 100));
+
+  double quat[4];
+  g.quaternion(quat);
+  const Eigen::Quaterniond r({ quat[3], quat[0], quat[1], quat[2] });
+
+  return Eigen::Isometry3d::TranslationType(t) * r;
+}
+
 #define EXPECT_VECTORS_EQUAL(v1, v2, error)                                                                            \
   EXPECT_NEAR((v1)[0], (v2)[0], (error));                                                                              \
   EXPECT_NEAR((v1)[1], (v2)[1], (error));                                                                              \
@@ -55,7 +66,7 @@
     Eigen::Vector3d d direction;                                                                                       \
     const auto result = (body).intersectsRay(o, d, &intersections, 2);                                                 \
     EXPECT_FALSE(result);                                                                                              \
-    EXPECT_EQ(0u, intersections.size());                                                                                \
+    EXPECT_EQ(0u, intersections.size());                                                                               \
   }
 
 #define CHECK_INTERSECTS(body, origin, direction, numIntersections)                                                    \
@@ -216,10 +227,7 @@ TEST(SphereRayIntersection, OriginInside)
   random_numbers::RandomNumberGenerator g(0u);
   for (size_t i = 0; i < 1000; ++i)
   {
-    std::srand(static_cast<unsigned int>(g.uniformInteger(0, std::numeric_limits<int>::max())));
-    const Eigen::Isometry3d pos(
-        Eigen::Isometry3d::TranslationType(Eigen::Vector3d::Random() * g.uniformReal(-100, 100)) *
-        Eigen::Quaterniond::UnitRandom());
+    const Eigen::Isometry3d pos = getRandomPose(g);
     sphere.setPose(pos);
     sphere.setScale(g.uniformReal(0.5, 100.0));
     sphere.setPadding(g.uniformReal(-0.1, 100.0));
@@ -302,10 +310,7 @@ TEST(SphereRayIntersection, OriginOutside)
   random_numbers::RandomNumberGenerator g(0u);
   for (size_t i = 0; i < 1000; ++i)
   {
-    std::srand(static_cast<unsigned int>(g.uniformInteger(0, std::numeric_limits<int>::max())));
-    const Eigen::Isometry3d pos(
-        Eigen::Isometry3d::TranslationType(Eigen::Vector3d::Random() * g.uniformReal(-100, 100)) *
-        Eigen::Quaterniond::UnitRandom());
+    const Eigen::Isometry3d pos = getRandomPose(g);
     sphere.setPose(pos);
     sphere.setScale(g.uniformReal(0.5, 100.0));
     sphere.setPadding(g.uniformReal(-0.1, 100.0));
@@ -507,10 +512,7 @@ TEST(CylinderRayIntersection, OriginInside)
   random_numbers::RandomNumberGenerator g(0u);
   for (size_t i = 0; i < 1000; ++i)
   {
-    std::srand(static_cast<unsigned int>(g.uniformInteger(0, std::numeric_limits<int>::max())));
-    const Eigen::Isometry3d pos(
-        Eigen::Isometry3d::TranslationType(Eigen::Vector3d::Random() * g.uniformReal(-100, 100)) *
-        Eigen::Quaterniond::UnitRandom());
+    const Eigen::Isometry3d pos = getRandomPose(g);
     cylinder.setPose(pos);
     cylinder.setScale(g.uniformReal(0.5, 100.0));
     cylinder.setPadding(g.uniformReal(-0.1, 100.0));
@@ -599,10 +601,7 @@ TEST(CylinderRayIntersection, OriginOutside)
   random_numbers::RandomNumberGenerator g(0u);
   for (size_t i = 0; i < 1000; ++i)
   {
-    std::srand(static_cast<unsigned int>(g.uniformInteger(0, std::numeric_limits<int>::max())));
-    const Eigen::Isometry3d pos(
-        Eigen::Isometry3d::TranslationType(Eigen::Vector3d::Random() * g.uniformReal(-100, 100)) *
-        Eigen::Quaterniond::UnitRandom());
+    const Eigen::Isometry3d pos = getRandomPose(g);
     cylinder.setPose(pos);
     cylinder.setScale(g.uniformReal(0.5, 100.0));
     cylinder.setPadding(g.uniformReal(-0.1, 100.0));
@@ -857,10 +856,7 @@ TEST(BoxRayIntersection, OriginInside)
   random_numbers::RandomNumberGenerator g(0u);
   for (size_t i = 0; i < 1000; ++i)
   {
-    std::srand(static_cast<unsigned int>(g.uniformInteger(0, std::numeric_limits<int>::max())));
-    const Eigen::Isometry3d pos(
-        Eigen::Isometry3d::TranslationType(Eigen::Vector3d::Random() * g.uniformReal(-100, 100)) *
-        Eigen::Quaterniond::UnitRandom());
+    const Eigen::Isometry3d pos = getRandomPose(g);
     box.setPose(pos);
     box.setScale(g.uniformReal(0.5, 100.0));
     box.setPadding(g.uniformReal(-0.1, 100.0));
@@ -952,10 +948,7 @@ TEST(BoxRayIntersection, OriginOutsideIntersects)
   random_numbers::RandomNumberGenerator g(0u);
   for (size_t i = 0; i < 1000; ++i)
   {
-    std::srand(static_cast<unsigned int>(g.uniformInteger(0, std::numeric_limits<int>::max())));
-    const Eigen::Isometry3d pos(
-        Eigen::Isometry3d::TranslationType(Eigen::Vector3d::Random() * g.uniformReal(-100, 100)) *
-        Eigen::Quaterniond::UnitRandom());
+    const Eigen::Isometry3d pos = getRandomPose(g);
     box.setPose(pos);
     box.setScale(g.uniformReal(0.5, 100.0));
     box.setPadding(g.uniformReal(-0.1, 100.0));
@@ -1196,10 +1189,7 @@ TEST(ConvexMeshRayIntersection, OriginInside)
   random_numbers::RandomNumberGenerator g(0u);
   for (size_t i = 0; i < 1000; ++i)
   {
-    std::srand(static_cast<unsigned int>(g.uniformInteger(0, std::numeric_limits<int>::max())));
-    const Eigen::Isometry3d pos(
-        Eigen::Isometry3d::TranslationType(Eigen::Vector3d::Random() * g.uniformReal(-100, 100)) *
-        Eigen::Quaterniond::UnitRandom());
+    const Eigen::Isometry3d pos = getRandomPose(g);
     mesh.setPose(pos);
     mesh.setScale(g.uniformReal(0.5, 100.0));
     mesh.setPadding(g.uniformReal(-0.1, 100.0));
@@ -1293,10 +1283,7 @@ TEST(ConvexMeshRayIntersection, OriginOutsideIntersects)
   random_numbers::RandomNumberGenerator g(0u);
   for (size_t i = 0; i < 1000; ++i)
   {
-    std::srand(static_cast<unsigned int>(g.uniformInteger(0, std::numeric_limits<int>::max())));
-    const Eigen::Isometry3d pos(
-        Eigen::Isometry3d::TranslationType(Eigen::Vector3d::Random() * g.uniformReal(-100, 100)) *
-        Eigen::Quaterniond::UnitRandom());
+    const Eigen::Isometry3d pos = getRandomPose(g);
     mesh.setPose(pos);
     mesh.setScale(g.uniformReal(0.5, 100.0));
     mesh.setPadding(g.uniformReal(-0.1, 100.0));

--- a/test/test_ray_intersection.cpp
+++ b/test/test_ray_intersection.cpp
@@ -1,0 +1,146 @@
+/*********************************************************************
+* Software License Agreement (BSD License)
+*
+*  Copyright (c) 2019, Open Robotics
+*  All rights reserved.
+*
+*  Redistribution and use in source and binary forms, with or without
+*  modification, are permitted provided that the following conditions
+*  are met:
+*
+*   * Redistributions of source code must retain the above copyright
+*     notice, this list of conditions and the following disclaimer.
+*   * Redistributions in binary form must reproduce the above
+*     copyright notice, this list of conditions and the following
+*     disclaimer in the documentation and/or other materials provided
+*     with the distribution.
+*   * Neither the name of the Willow Garage nor the names of its
+*     contributors may be used to endorse or promote products derived
+*     from this software without specific prior written permission.
+*
+*  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+*  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+*  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+*  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+*  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+*  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+*  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+*  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+*  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+*  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+*  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+*  POSSIBILITY OF SUCH DAMAGE.
+*********************************************************************/
+
+/** \Author Ioan Sucan */
+/** \Author Martin Pecka */
+
+#include <geometric_shapes/bodies.h>
+#include <geometric_shapes/shape_operations.h>
+#include <geometric_shapes/body_operations.h>
+#include <boost/filesystem.hpp>
+#include <gtest/gtest.h>
+#include "resources/config.h"
+
+TEST(SphereRayIntersection, SimpleRay1)
+{
+  shapes::Sphere shape(1.0);
+  bodies::Body* sphere = new bodies::Sphere(&shape);
+  sphere->setScale(1.05);
+
+  Eigen::Vector3d ray_o(5, 0, 0);
+  Eigen::Vector3d ray_d(-1, 0, 0);
+  EigenSTL::vector_Vector3d p;
+  bool intersect = sphere->intersectsRay(ray_o, ray_d, &p);
+
+  delete sphere;
+  EXPECT_TRUE(intersect);
+  EXPECT_EQ(2, (int)p.size());
+  EXPECT_NEAR(p[0].x(), 1.05, 1e-6);
+  EXPECT_NEAR(p[1].x(), -1.05, 1e-6);
+}
+
+TEST(SphereRayIntersection, SimpleRay2)
+{
+  shapes::Sphere shape(1.0);
+  bodies::Body* sphere = new bodies::Sphere(&shape);
+  sphere->setScale(1.05);
+
+  Eigen::Vector3d ray_o(5, 0, 0);
+  Eigen::Vector3d ray_d(1, 0, 0);
+  EigenSTL::vector_Vector3d p;
+  bool intersect = sphere->intersectsRay(ray_o, ray_d, &p);
+
+  delete sphere;
+  EXPECT_FALSE(intersect);
+  EXPECT_EQ(0, (int)p.size());
+}
+
+TEST(BoxRayIntersection, SimpleRay1)
+{
+  shapes::Box shape(1.0, 1.0, 3.0);
+  bodies::Body* box = new bodies::Box(&shape);
+  box->setScale(0.95);
+
+  Eigen::Vector3d ray_o(10, 0.449, 0);
+  Eigen::Vector3d ray_d(-1, 0, 0);
+  EigenSTL::vector_Vector3d p;
+
+  bool intersect = box->intersectsRay(ray_o, ray_d, &p);
+
+  //    for (unsigned int i = 0; i < p.size() ; ++i)
+  //        printf("intersection at %f, %f, %f\n", p[i].x(), p[i].y(), p[i].z());
+
+  delete box;
+  EXPECT_TRUE(intersect);
+}
+
+TEST(BoxRayIntersection, SimpleRay2)
+{
+  shapes::Box shape(0.9, 0.01, 1.2);
+  bodies::Body* box = new bodies::Box(&shape);
+
+  Eigen::Isometry3d pose(Eigen::AngleAxisd(0, Eigen::Vector3d::UnitX()));
+  pose.translation() = Eigen::Vector3d(0, 0.005, 0.6);
+  box->setPose(pose);
+
+  Eigen::Vector3d ray_o(0, 5, 1.6);
+  Eigen::Vector3d ray_d(0, -5.195, -0.77);
+  EigenSTL::vector_Vector3d p;
+
+  bool intersect = box->intersectsRay(ray_o, ray_d, &p);
+  EXPECT_TRUE(intersect);
+
+  intersect = box->intersectsRay(ray_o, ray_d.normalized(), &p);
+  EXPECT_TRUE(intersect);
+
+  delete box;
+}
+
+TEST(BoxRayIntersection, SimpleRay3)
+{
+  shapes::Box shape(0.02, 0.4, 1.2);
+  bodies::Body* box = new bodies::Box(&shape);
+
+  Eigen::Isometry3d pose(Eigen::AngleAxisd(0, Eigen::Vector3d::UnitX()));
+  pose.translation() = Eigen::Vector3d(0.45, -0.195, 0.6);
+  box->setPose(pose);
+
+  Eigen::Vector3d ray_o(0, -2, 1.11);
+  Eigen::Vector3d ray_d(0, 1.8, -0.669);
+  EigenSTL::vector_Vector3d p;
+
+  bool intersect = box->intersectsRay(ray_o, ray_d, &p);
+  EXPECT_FALSE(intersect);
+
+  intersect = box->intersectsRay(ray_o, ray_d.normalized(), &p);
+  EXPECT_FALSE(intersect);
+
+  delete box;
+}
+
+int main(int argc, char** argv)
+{
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/test/test_ray_intersection.cpp
+++ b/test/test_ray_intersection.cpp
@@ -39,6 +39,7 @@
 #include <geometric_shapes/shape_operations.h>
 #include <geometric_shapes/body_operations.h>
 #include <boost/filesystem.hpp>
+#include <random_numbers/random_numbers.h>
 #include <gtest/gtest.h>
 #include "resources/config.h"
 
@@ -54,7 +55,7 @@
     Eigen::Vector3d d direction;                                                                                       \
     const auto result = (body).intersectsRay(o, d, &intersections, 2);                                                 \
     EXPECT_FALSE(result);                                                                                              \
-    EXPECT_EQ(0, intersections.size());                                                                                \
+    EXPECT_EQ(0u, intersections.size());                                                                                \
   }
 
 #define CHECK_INTERSECTS(body, origin, direction, numIntersections)                                                    \
@@ -64,7 +65,7 @@
     Eigen::Vector3d d direction;                                                                                       \
     const auto result = (body).intersectsRay(o, d, &intersections, 2);                                                 \
     EXPECT_TRUE(result);                                                                                               \
-    ASSERT_EQ((numIntersections), intersections.size());                                                               \
+    EXPECT_EQ(static_cast<size_t>((numIntersections)), intersections.size());                                          \
   }
 
 #define CHECK_INTERSECTS_ONCE(body, origin, direction, intersection, error)                                            \
@@ -75,8 +76,11 @@
     Eigen::Vector3d i intersection;                                                                                    \
     const auto result = (body).intersectsRay(o, d, &intersections, 2);                                                 \
     EXPECT_TRUE(result);                                                                                               \
-    ASSERT_EQ(1, intersections.size());                                                                                \
-    EXPECT_VECTORS_EQUAL(intersections.at(0), i, (error));                                                             \
+    EXPECT_EQ(1u, intersections.size());                                                                               \
+    if (intersections.size() == 1u)                                                                                    \
+    {                                                                                                                  \
+      EXPECT_VECTORS_EQUAL(intersections.at(0), i, (error));                                                           \
+    }                                                                                                                  \
   }
 
 #define CHECK_INTERSECTS_TWICE(body, origin, direction, intersc1, intersc2, error)                                     \
@@ -88,18 +92,292 @@
     Eigen::Vector3d i2 intersc2;                                                                                       \
     const auto result = (body).intersectsRay(o, d, &intersections, 2);                                                 \
     EXPECT_TRUE(result);                                                                                               \
-    ASSERT_EQ(2, intersections.size());                                                                                \
-    if (fabs(static_cast<double>((intersections.at(0) - i1).norm())) < (error))                                        \
+    EXPECT_EQ(2u, intersections.size());                                                                               \
+    if (intersections.size() == 2u)                                                                                    \
     {                                                                                                                  \
-      EXPECT_VECTORS_EQUAL(intersections.at(0), i1, (error));                                                          \
-      EXPECT_VECTORS_EQUAL(intersections.at(1), i2, (error));                                                          \
-    }                                                                                                                  \
-    else                                                                                                               \
-    {                                                                                                                  \
-      EXPECT_VECTORS_EQUAL(intersections.at(0), i2, (error));                                                          \
-      EXPECT_VECTORS_EQUAL(intersections.at(1), i1, (error));                                                          \
+      if (fabs(static_cast<double>((intersections.at(0) - i1).norm())) < (error))                                      \
+      {                                                                                                                \
+        EXPECT_VECTORS_EQUAL(intersections.at(0), i1, (error));                                                        \
+        EXPECT_VECTORS_EQUAL(intersections.at(1), i2, (error));                                                        \
+      }                                                                                                                \
+      else                                                                                                             \
+      {                                                                                                                \
+        EXPECT_VECTORS_EQUAL(intersections.at(0), i2, (error));                                                        \
+        EXPECT_VECTORS_EQUAL(intersections.at(1), i1, (error));                                                        \
+      }                                                                                                                \
     }                                                                                                                  \
   }
+
+TEST(SphereRayIntersection, OriginInside)
+{
+  shapes::Sphere shape(1.0);
+  bodies::Sphere sphere(&shape);
+
+  // clang-format off
+  CHECK_INTERSECTS_ONCE(sphere, (0, 0, 0), ( 1,  0,  0), ( 1,  0,  0), 1e-6)
+  CHECK_INTERSECTS_ONCE(sphere, (0, 0, 0), (-1,  0,  0), (-1,  0,  0), 1e-6)
+  CHECK_INTERSECTS_ONCE(sphere, (0, 0, 0), ( 0,  1,  0), ( 0,  1,  0), 1e-6)
+  CHECK_INTERSECTS_ONCE(sphere, (0, 0, 0), ( 0, -1,  0), ( 0, -1,  0), 1e-6)
+  CHECK_INTERSECTS_ONCE(sphere, (0, 0, 0), ( 0,  0,  1), ( 0,  0,  1), 1e-6)
+  CHECK_INTERSECTS_ONCE(sphere, (0, 0, 0), ( 0,  0, -1), ( 0,  0, -1), 1e-6)
+  // clang-format on
+
+  // scaling
+
+  sphere.setScale(1.1);
+  // clang-format off
+  CHECK_INTERSECTS_ONCE(sphere, (0, 0, 0), ( 1,  0,  0), ( 1.1,    0,    0), 1e-6)
+  CHECK_INTERSECTS_ONCE(sphere, (0, 0, 0), (-1,  0,  0), (-1.1,    0,    0), 1e-6)
+  CHECK_INTERSECTS_ONCE(sphere, (0, 0, 0), ( 0,  1,  0), ( 0,    1.1,    0), 1e-6)
+  CHECK_INTERSECTS_ONCE(sphere, (0, 0, 0), ( 0, -1,  0), ( 0,   -1.1,    0), 1e-6)
+  CHECK_INTERSECTS_ONCE(sphere, (0, 0, 0), ( 0,  0,  1), ( 0,      0,  1.1), 1e-6)
+  CHECK_INTERSECTS_ONCE(sphere, (0, 0, 0), ( 0,  0, -1), ( 0,      0, -1.1), 1e-6)
+  // clang-format on
+
+  // move origin within the sphere
+
+  // clang-format off
+  CHECK_INTERSECTS_ONCE(sphere, (0.5, 0  , 0  ), ( 1,  0,  0), ( 1.1,    0,    0), 1e-6)
+  CHECK_INTERSECTS_ONCE(sphere, (0.5, 0  , 0  ), (-1,  0,  0), (-1.1,    0,    0), 1e-6)
+  CHECK_INTERSECTS_ONCE(sphere, (0  , 0.5, 0  ), ( 0,  1,  0), ( 0,    1.1,    0), 1e-6)
+  CHECK_INTERSECTS_ONCE(sphere, (0  , 0.5, 0  ), ( 0, -1,  0), ( 0,   -1.1,    0), 1e-6)
+  CHECK_INTERSECTS_ONCE(sphere, (0  , 0  , 0.5), ( 0,  0,  1), ( 0,      0,  1.1), 1e-6)
+  CHECK_INTERSECTS_ONCE(sphere, (0  , 0  , 0.5), ( 0,  0, -1), ( 0,      0, -1.1), 1e-6)
+  // clang-format on
+
+  // move sphere
+
+  Eigen::Isometry3d pose = Eigen::Translation3d(0.5, 0, 0) * Eigen::Quaterniond::Identity();
+  sphere.setPose(pose);
+  // clang-format off
+  CHECK_INTERSECTS_ONCE(sphere, (0, 0, 0), ( 1, 0, 0), ( 1.6, 0, 0), 1e-6)
+  CHECK_INTERSECTS_ONCE(sphere, (0, 0, 0), (-1, 0, 0), (-0.6, 0, 0), 1e-6)
+  // clang-format on
+
+  pose = Eigen::Translation3d(0, 0.5, 0) * Eigen::Quaterniond::Identity();
+  sphere.setPose(pose);
+  // clang-format off
+  CHECK_INTERSECTS_ONCE(sphere, (0, 0, 0), ( 0,  1, 0), (0,  1.6, 0), 1e-6)
+  CHECK_INTERSECTS_ONCE(sphere, (0, 0, 0), ( 0, -1, 0), (0, -0.6, 0), 1e-6)
+  // clang-format on
+
+  pose = Eigen::Translation3d(0, 0, 0.5) * Eigen::Quaterniond::Identity();
+  sphere.setPose(pose);
+  // clang-format off
+  CHECK_INTERSECTS_ONCE(sphere, (0, 0, 0), ( 0, 0,  1), (0, 0,  1.6), 1e-6)
+  CHECK_INTERSECTS_ONCE(sphere, (0, 0, 0), ( 0, 0, -1), (0, 0, -0.6), 1e-6)
+  // clang-format on
+
+  // 3D diagonal
+
+  sphere.setPose(Eigen::Isometry3d::Identity());
+  sphere.setScale(1.0);
+  sphere.setPadding(0.1);
+
+  const auto sq3 = sqrt(pow(1 + 0.1, 2) / 3);
+  const auto dir3 = Eigen::Vector3d::Ones().normalized();
+  // clang-format off
+  CHECK_INTERSECTS_ONCE(sphere, (   0,    0,    0), ( dir3), ( sq3,  sq3,  sq3), 1e-4)
+  CHECK_INTERSECTS_ONCE(sphere, ( 0.5,  0.5,  0.5), ( dir3), ( sq3,  sq3,  sq3), 1e-4)
+  CHECK_INTERSECTS_ONCE(sphere, (-0.5, -0.5, -0.5), ( dir3), ( sq3,  sq3,  sq3), 1e-4)
+  CHECK_INTERSECTS_ONCE(sphere, (   0,    0,    0), (-dir3), (-sq3, -sq3, -sq3), 1e-4)
+  CHECK_INTERSECTS_ONCE(sphere, ( 0.5,  0.5,  0.5), (-dir3), (-sq3, -sq3, -sq3), 1e-4)
+  CHECK_INTERSECTS_ONCE(sphere, (-0.5, -0.5, -0.5), (-dir3), (-sq3, -sq3, -sq3), 1e-4)
+  // clang-format on
+
+  // 2D diagonal
+
+  const auto sq2 = sqrt(pow(1 + 0.1, 2) / 2);
+  const auto dir2 = 1 / sqrt(2);
+  // clang-format off
+  CHECK_INTERSECTS_ONCE(sphere, (   0,    0,    0), ( dir2,  dir2,     0), ( sq2,  sq2,    0), 1e-4)
+  CHECK_INTERSECTS_ONCE(sphere, (   0,    0,    0), (-dir2, -dir2,     0), (-sq2, -sq2,    0), 1e-4)
+  CHECK_INTERSECTS_ONCE(sphere, ( 0.5,  0.5,    0), ( dir2,  dir2,     0), ( sq2,  sq2,    0), 1e-4)
+  CHECK_INTERSECTS_ONCE(sphere, ( 0.5,  0.5,    0), (-dir2, -dir2,     0), (-sq2, -sq2,    0), 1e-4)
+  CHECK_INTERSECTS_ONCE(sphere, (-0.5, -0.5,    0), ( dir2,  dir2,     0), ( sq2,  sq2,    0), 1e-4)
+  CHECK_INTERSECTS_ONCE(sphere, (-0.5, -0.5,    0), (-dir2, -dir2,     0), (-sq2, -sq2,    0), 1e-4)
+
+  CHECK_INTERSECTS_ONCE(sphere, (   0,    0,    0), (    0,  dir2,  dir2), (   0,  sq2,  sq2), 1e-4)
+  CHECK_INTERSECTS_ONCE(sphere, (   0,    0,    0), (    0, -dir2, -dir2), (   0, -sq2, -sq2), 1e-4)
+  CHECK_INTERSECTS_ONCE(sphere, (   0,  0.5,  0.5), (    0,  dir2,  dir2), (   0,  sq2,  sq2), 1e-4)
+  CHECK_INTERSECTS_ONCE(sphere, (   0,  0.5,  0.5), (    0, -dir2, -dir2), (   0, -sq2, -sq2), 1e-4)
+  CHECK_INTERSECTS_ONCE(sphere, (   0, -0.5, -0.5), (    0,  dir2,  dir2), (   0,  sq2,  sq2), 1e-4)
+  CHECK_INTERSECTS_ONCE(sphere, (   0, -0.5, -0.5), (    0, -dir2, -dir2), (   0, -sq2, -sq2), 1e-4)
+
+  CHECK_INTERSECTS_ONCE(sphere, (   0,    0,    0), ( dir2,     0,  dir2), ( sq2,    0,  sq2), 1e-4)
+  CHECK_INTERSECTS_ONCE(sphere, (   0,    0,    0), (-dir2,     0, -dir2), (-sq2,    0, -sq2), 1e-4)
+  CHECK_INTERSECTS_ONCE(sphere, ( 0.5,    0,  0.5), ( dir2,     0,  dir2), ( sq2,    0,  sq2), 1e-4)
+  CHECK_INTERSECTS_ONCE(sphere, ( 0.5,    0,  0.5), (-dir2,     0, -dir2), (-sq2,    0, -sq2), 1e-4)
+  CHECK_INTERSECTS_ONCE(sphere, (-0.5,    0, -0.5), ( dir2,     0,  dir2), ( sq2,    0,  sq2), 1e-4)
+  CHECK_INTERSECTS_ONCE(sphere, (-0.5,    0, -0.5), (-dir2,     0, -dir2), (-sq2,    0, -sq2), 1e-4)
+  // clang-format on
+
+  // any random rays that start inside the sphere should have exactly one intersection with it
+  random_numbers::RandomNumberGenerator g(0u);
+  for (size_t i = 0; i < 1000; ++i)
+  {
+    std::srand(static_cast<unsigned int>(g.uniformInteger(0, std::numeric_limits<int>::max())));
+    const Eigen::Isometry3d pos(
+        Eigen::Isometry3d::TranslationType(Eigen::Vector3d::Random() * g.uniformReal(-100, 100)) *
+        Eigen::Quaterniond::UnitRandom());
+    sphere.setPose(pos);
+    sphere.setScale(g.uniformReal(0.5, 100.0));
+    sphere.setPadding(g.uniformReal(-0.1, 100.0));
+
+    Eigen::Vector3d origin;
+    sphere.samplePointInside(g, 10, origin);
+
+    // get the scaled sphere
+    bodies::BoundingSphere s;
+    sphere.computeBoundingSphere(s);
+
+    const Eigen::Vector3d dir = Eigen::Vector3d::Random().normalized();
+
+    EigenSTL::vector_Vector3d intersections;
+    if (sphere.intersectsRay(origin, dir, &intersections, 2))
+    {
+      EXPECT_EQ(1u, intersections.size());
+      if (intersections.size() == 1)
+      {
+        EXPECT_NEAR(s.radius, (s.center - intersections[0]).norm(), 1e-6);
+        // verify the point lies on the ray
+        EXPECT_NEAR(0.0, (Eigen::ParametrizedLine<double, 3>(origin, dir).distance(intersections[0])), 1e-6);
+        EXPECT_LT(0.0, (intersections[0] - origin).normalized().dot(dir));
+      }
+    }
+    else
+    {
+      GTEST_NONFATAL_FAILURE_(("No intersection in iteration " + std::to_string(i)).c_str());
+    }
+  }
+}
+
+TEST(SphereRayIntersection, OriginOutside)
+{
+  shapes::Sphere shape(1.0);
+  bodies::Sphere sphere(&shape);
+
+  // clang-format off
+  CHECK_INTERSECTS_TWICE(sphere, (-2,  0,  0), ( 1,  0,  0), ( 1,  0,  0), (-1,  0,  0), 1e-6)
+  CHECK_INTERSECTS_TWICE(sphere, ( 2,  0,  0), (-1,  0,  0), (-1,  0,  0), ( 1,  0,  0), 1e-6)
+  CHECK_INTERSECTS_TWICE(sphere, ( 0, -2,  0), ( 0,  1,  0), ( 0,  1,  0), ( 0, -1,  0), 1e-6)
+  CHECK_INTERSECTS_TWICE(sphere, ( 0,  2,  0), ( 0, -1,  0), ( 0, -1,  0), ( 0,  1,  0), 1e-6)
+  CHECK_INTERSECTS_TWICE(sphere, ( 0,  0, -2), ( 0,  0,  1), ( 0,  0,  1), ( 0,  0, -1), 1e-6)
+  CHECK_INTERSECTS_TWICE(sphere, ( 0,  0,  2), ( 0,  0, -1), ( 0,  0, -1), ( 0,  0,  1), 1e-6)
+  // clang-format on
+
+  // test hitting the surface
+  // clang-format off
+  CHECK_INTERSECTS_ONCE(sphere, (-1, -1,  0), ( 0,  1,  0), (-1,  0,  0), 1e-6)
+  CHECK_INTERSECTS_ONCE(sphere, (-1,  1,  0), ( 0, -1,  0), (-1,  0,  0), 1e-6)
+  CHECK_INTERSECTS_ONCE(sphere, ( 1, -1,  0), ( 0,  1,  0), ( 1,  0,  0), 1e-6)
+  CHECK_INTERSECTS_ONCE(sphere, ( 1,  1,  0), ( 0, -1,  0), ( 1,  0,  0), 1e-6)
+  CHECK_INTERSECTS_ONCE(sphere, ( 0, -1, -1), ( 0,  0,  1), ( 0, -1,  0), 1e-6)
+  CHECK_INTERSECTS_ONCE(sphere, ( 0, -1,  1), ( 0,  0, -1), ( 0, -1,  0), 1e-6)
+  CHECK_INTERSECTS_ONCE(sphere, ( 0,  1, -1), ( 0,  0,  1), ( 0,  1,  0), 1e-6)
+  CHECK_INTERSECTS_ONCE(sphere, ( 0,  1,  1), ( 0,  0, -1), ( 0,  1,  0), 1e-6)
+  CHECK_INTERSECTS_ONCE(sphere, (-1,  0, -1), ( 1,  0,  0), ( 0,  0, -1), 1e-6)
+  CHECK_INTERSECTS_ONCE(sphere, ( 1,  0, -1), (-1,  0,  0), ( 0,  0, -1), 1e-6)
+  CHECK_INTERSECTS_ONCE(sphere, (-1,  0,  1), ( 1,  0,  0), ( 0,  0,  1), 1e-6)
+  CHECK_INTERSECTS_ONCE(sphere, ( 1,  0,  1), (-1,  0,  0), ( 0,  0,  1), 1e-6)
+  // clang-format on
+
+  // test missing the surface
+  // clang-format off
+  CHECK_NO_INTERSECTION(sphere, (-1.1,   -1,    0), ( 0,  1,  0))
+  CHECK_NO_INTERSECTION(sphere, (-1.1,    1,    0), ( 0, -1,  0))
+  CHECK_NO_INTERSECTION(sphere, ( 1.1,   -1,    0), ( 0,  1,  0))
+  CHECK_NO_INTERSECTION(sphere, ( 1.1,    1,    0), ( 0, -1,  0))
+  CHECK_NO_INTERSECTION(sphere, (   0, -1.1,   -1), ( 0,  0,  1))
+  CHECK_NO_INTERSECTION(sphere, (   0, -1.1,    1), ( 0,  0, -1))
+  CHECK_NO_INTERSECTION(sphere, (   0,  1.1,   -1), ( 0,  0,  1))
+  CHECK_NO_INTERSECTION(sphere, (   0,  1.1,    1), ( 0,  0, -1))
+  CHECK_NO_INTERSECTION(sphere, (  -1,    0, -1.1), ( 1,  0,  0))
+  CHECK_NO_INTERSECTION(sphere, (   1,    0, -1.1), (-1,  0,  0))
+  CHECK_NO_INTERSECTION(sphere, (  -1,    0,  1.1), ( 1,  0,  0))
+  CHECK_NO_INTERSECTION(sphere, (   1,    0,  1.1), (-1,  0,  0))
+  // clang-format on
+
+  // generate some random rays outside the sphere and test them
+  random_numbers::RandomNumberGenerator g(0u);
+  for (size_t i = 0; i < 1000; ++i)
+  {
+    std::srand(static_cast<unsigned int>(g.uniformInteger(0, std::numeric_limits<int>::max())));
+    const Eigen::Isometry3d pos(
+        Eigen::Isometry3d::TranslationType(Eigen::Vector3d::Random() * g.uniformReal(-100, 100)) *
+        Eigen::Quaterniond::UnitRandom());
+    sphere.setPose(pos);
+    sphere.setScale(g.uniformReal(0.5, 100.0));
+    sphere.setPadding(g.uniformReal(-0.1, 100.0));
+
+    // choose a random direction
+    const Eigen::Vector3d dir = Eigen::Vector3d::Random().normalized();
+
+    // get the scaled dimensions of the sphere
+    bodies::BoundingSphere s;
+    sphere.computeBoundingSphere(s);
+
+    // create origin outside the sphere in the opposite direction than the chosen one
+    const Eigen::Vector3d origin = s.center + -dir * 1.5 * s.radius;
+
+    // a ray constructed in this way should intersect twice (through the sphere center)
+    EigenSTL::vector_Vector3d intersections;
+    if (sphere.intersectsRay(origin, dir, &intersections, 2))
+    {
+      EXPECT_EQ(2u, intersections.size());
+      if (intersections.size() == 2)
+      {
+        EXPECT_NEAR(s.radius, (s.center - intersections[0]).norm(), 1e-4);
+        EXPECT_NEAR(s.radius, (s.center - intersections[1]).norm(), 1e-4);
+
+        // verify the point lies on the ray
+        EXPECT_NEAR(0.0, (Eigen::ParametrizedLine<double, 3>(origin, dir).distance(intersections[0])), 1e-6);
+        EXPECT_LT(0.0, (intersections[0] - origin).normalized().dot(dir));
+        EXPECT_NEAR(0.0, (Eigen::ParametrizedLine<double, 3>(origin, dir).distance(intersections[1])), 1e-6);
+        EXPECT_LT(0.0, (intersections[1] - origin).normalized().dot(dir));
+      }
+    }
+    else
+    {
+      GTEST_NONFATAL_FAILURE_(("No intersection in iteration " + std::to_string(i)).c_str());
+    }
+
+    // check that the opposite ray misses
+    CHECK_NO_INTERSECTION(sphere, (origin), (-dir))
+
+    // shift the ray a bit sideways
+
+    // choose a perpendicular direction
+    Eigen::Vector3d perpDir = dir.cross(Eigen::Vector3d({ dir.z(), dir.z(), -dir.x() - dir.y() }));
+    if (perpDir.norm() < 1e-6)
+      perpDir = dir.cross(Eigen::Vector3d({ -dir.y() - dir.z(), dir.x(), dir.x() }));
+    perpDir.normalize();
+
+    // now move origin "sideways" but still only so much that the ray will hit the sphere
+    const Eigen::Vector3d origin2 = origin + g.uniformReal(1e-6, s.radius - 1e-4) * perpDir;
+
+    intersections.clear();
+    if (sphere.intersectsRay(origin2, dir, &intersections, 2))
+    {
+      EXPECT_EQ(2u, intersections.size());
+      if (intersections.size() == 2)
+      {
+        EXPECT_NEAR(s.radius, (s.center - intersections[0]).norm(), 1e-4);
+        EXPECT_NEAR(s.radius, (s.center - intersections[1]).norm(), 1e-4);
+
+        // verify the point lies on the ray
+        EXPECT_NEAR(0.0, (Eigen::ParametrizedLine<double, 3>(origin2, dir).distance(intersections[0])), 1e-6);
+        EXPECT_LT(0.0, (intersections[0] - origin2).normalized().dot(dir));
+        EXPECT_NEAR(0.0, (Eigen::ParametrizedLine<double, 3>(origin2, dir).distance(intersections[1])), 1e-6);
+        EXPECT_LT(0.0, (intersections[1] - origin2).normalized().dot(dir));
+      }
+    }
+    else
+    {
+      GTEST_NONFATAL_FAILURE_(("No intersection in iteration " + std::to_string(i)).c_str());
+    }
+  }
+}
 
 TEST(SphereRayIntersection, SimpleRay1)
 {
@@ -117,6 +395,310 @@ TEST(SphereRayIntersection, SimpleRay2)
   sphere.setScale(1.05);
 
   CHECK_NO_INTERSECTION(sphere, (5, 0, 0), (1, 0, 0))
+}
+
+TEST(CylinderRayIntersection, OriginInside)
+{
+  shapes::Cylinder shape(1.0, 2.0);
+  bodies::Cylinder cylinder(&shape);
+
+  // clang-format off
+  CHECK_INTERSECTS_ONCE(cylinder, (0, 0, 0), ( 1,  0,  0), ( 1,  0,  0), 1e-6)
+  CHECK_INTERSECTS_ONCE(cylinder, (0, 0, 0), (-1,  0,  0), (-1,  0,  0), 1e-6)
+  CHECK_INTERSECTS_ONCE(cylinder, (0, 0, 0), ( 0,  1,  0), ( 0,  1,  0), 1e-6)
+  CHECK_INTERSECTS_ONCE(cylinder, (0, 0, 0), ( 0, -1,  0), ( 0, -1,  0), 1e-6)
+  CHECK_INTERSECTS_ONCE(cylinder, (0, 0, 0), ( 0,  0,  1), ( 0,  0,  1), 1e-6)
+  CHECK_INTERSECTS_ONCE(cylinder, (0, 0, 0), ( 0,  0, -1), ( 0,  0, -1), 1e-6)
+  // clang-format on
+
+  // scaling
+
+  cylinder.setScale(1.1);
+  // clang-format off
+  CHECK_INTERSECTS_ONCE(cylinder, (0, 0, 0), ( 1,  0,  0), ( 1.1,    0,    0), 1e-6)
+  CHECK_INTERSECTS_ONCE(cylinder, (0, 0, 0), (-1,  0,  0), (-1.1,    0,    0), 1e-6)
+  CHECK_INTERSECTS_ONCE(cylinder, (0, 0, 0), ( 0,  1,  0), ( 0,    1.1,    0), 1e-6)
+  CHECK_INTERSECTS_ONCE(cylinder, (0, 0, 0), ( 0, -1,  0), ( 0,   -1.1,    0), 1e-6)
+  CHECK_INTERSECTS_ONCE(cylinder, (0, 0, 0), ( 0,  0,  1), ( 0,      0,  1.1), 1e-6)
+  CHECK_INTERSECTS_ONCE(cylinder, (0, 0, 0), ( 0,  0, -1), ( 0,      0, -1.1), 1e-6)
+  // clang-format on
+
+  // move origin within the cylinder
+
+  // clang-format off
+  CHECK_INTERSECTS_ONCE(cylinder, (0.5, 0  , 0  ), ( 1,  0,  0), ( 1.1,    0,    0), 1e-6)
+  CHECK_INTERSECTS_ONCE(cylinder, (0.5, 0  , 0  ), (-1,  0,  0), (-1.1,    0,    0), 1e-6)
+  CHECK_INTERSECTS_ONCE(cylinder, (0  , 0.5, 0  ), ( 0,  1,  0), ( 0,    1.1,    0), 1e-6)
+  CHECK_INTERSECTS_ONCE(cylinder, (0  , 0.5, 0  ), ( 0, -1,  0), ( 0,   -1.1,    0), 1e-6)
+  CHECK_INTERSECTS_ONCE(cylinder, (0  , 0  , 0.5), ( 0,  0,  1), ( 0,      0,  1.1), 1e-6)
+  CHECK_INTERSECTS_ONCE(cylinder, (0  , 0  , 0.5), ( 0,  0, -1), ( 0,      0, -1.1), 1e-6)
+  // clang-format on
+
+  // move cylinder
+
+  Eigen::Isometry3d pose = Eigen::Translation3d(0.5, 0, 0) * Eigen::Quaterniond::Identity();
+  cylinder.setPose(pose);
+  // clang-format off
+  CHECK_INTERSECTS_ONCE(cylinder, (0, 0, 0), ( 1, 0, 0), ( 1.6, 0, 0), 1e-6)
+  CHECK_INTERSECTS_ONCE(cylinder, (0, 0, 0), (-1, 0, 0), (-0.6, 0, 0), 1e-6)
+  // clang-format on
+
+  pose = Eigen::Translation3d(0, 0.5, 0) * Eigen::Quaterniond::Identity();
+  cylinder.setPose(pose);
+  // clang-format off
+  CHECK_INTERSECTS_ONCE(cylinder, (0, 0, 0), ( 0,  1, 0), (0,  1.6, 0), 1e-6)
+  CHECK_INTERSECTS_ONCE(cylinder, (0, 0, 0), ( 0, -1, 0), (0, -0.6, 0), 1e-6)
+  // clang-format on
+
+  pose = Eigen::Translation3d(0, 0, 0.5) * Eigen::Quaterniond::Identity();
+  cylinder.setPose(pose);
+  // clang-format off
+  CHECK_INTERSECTS_ONCE(cylinder, (0, 0, 0), ( 0, 0,  1), (0, 0,  1.6), 1e-6)
+  CHECK_INTERSECTS_ONCE(cylinder, (0, 0, 0), ( 0, 0, -1), (0, 0, -0.6), 1e-6)
+  // clang-format on
+
+  // 3D diagonal
+
+  cylinder.setPose(Eigen::Isometry3d::Identity());
+  cylinder.setScale(1.0);
+  cylinder.setPadding(0.1);
+
+  // diagonal distance to the base boundary
+  const auto sq2 = sqrt(pow(1 + 0.1, 2) / 2);
+  // direction towards the very "corner" of the cylinder
+  const auto dir3 = Eigen::Vector3d({ sq2, sq2, 1.1 }).normalized();
+  // clang-format off
+  CHECK_INTERSECTS_ONCE(cylinder, ( 0,  0,  0), ( dir3), ( sq2,  sq2,  1.1), 1e-4)
+  CHECK_INTERSECTS_ONCE(cylinder, (  dir3 / 2), ( dir3), ( sq2,  sq2,  1.1), 1e-4)
+  CHECK_INTERSECTS_ONCE(cylinder, ( -dir3 / 2), ( dir3), ( sq2,  sq2,  1.1), 1e-4)
+  CHECK_INTERSECTS_ONCE(cylinder, ( 0,  0,  0), (-dir3), (-sq2, -sq2, -1.1), 1e-4)
+  CHECK_INTERSECTS_ONCE(cylinder, (  dir3 / 2), (-dir3), (-sq2, -sq2, -1.1), 1e-4)
+  CHECK_INTERSECTS_ONCE(cylinder, ( -dir3 / 2), (-dir3), (-sq2, -sq2, -1.1), 1e-4)
+  // clang-format on
+
+  // 2D diagonal
+
+  // coordinate of the diagonal direction in the base
+  const auto dir2 = 1 / sqrt(2);
+  // clang-format off
+  CHECK_INTERSECTS_ONCE(cylinder, (   0,    0,    0), ( dir2,  dir2,     0), ( sq2,  sq2,    0), 1e-4)
+  CHECK_INTERSECTS_ONCE(cylinder, (   0,    0,    0), (-dir2, -dir2,     0), (-sq2, -sq2,    0), 1e-4)
+  CHECK_INTERSECTS_ONCE(cylinder, ( 0.5,  0.5,    0), ( dir2,  dir2,     0), ( sq2,  sq2,    0), 1e-4)
+  CHECK_INTERSECTS_ONCE(cylinder, ( 0.5,  0.5,    0), (-dir2, -dir2,     0), (-sq2, -sq2,    0), 1e-4)
+  CHECK_INTERSECTS_ONCE(cylinder, (-0.5, -0.5,    0), ( dir2,  dir2,     0), ( sq2,  sq2,    0), 1e-4)
+  CHECK_INTERSECTS_ONCE(cylinder, (-0.5, -0.5,    0), (-dir2, -dir2,     0), (-sq2, -sq2,    0), 1e-4)
+
+  CHECK_INTERSECTS_ONCE(cylinder, (   0,    0,    0), (    0,  dir2,  dir2), (   0,  1.1,  1.1), 1e-4)
+  CHECK_INTERSECTS_ONCE(cylinder, (   0,    0,    0), (    0, -dir2, -dir2), (   0, -1.1, -1.1), 1e-4)
+  CHECK_INTERSECTS_ONCE(cylinder, (   0,  0.5,  0.5), (    0,  dir2,  dir2), (   0,  1.1,  1.1), 1e-4)
+  CHECK_INTERSECTS_ONCE(cylinder, (   0,  0.5,  0.5), (    0, -dir2, -dir2), (   0, -1.1, -1.1), 1e-4)
+  CHECK_INTERSECTS_ONCE(cylinder, (   0, -0.5, -0.5), (    0,  dir2,  dir2), (   0,  1.1,  1.1), 1e-4)
+  CHECK_INTERSECTS_ONCE(cylinder, (   0, -0.5, -0.5), (    0, -dir2, -dir2), (   0, -1.1, -1.1), 1e-4)
+
+  CHECK_INTERSECTS_ONCE(cylinder, (   0,    0,    0), ( dir2,     0,  dir2), ( 1.1,    0,  1.1), 1e-4)
+  CHECK_INTERSECTS_ONCE(cylinder, (   0,    0,    0), (-dir2,     0, -dir2), (-1.1,    0, -1.1), 1e-4)
+  CHECK_INTERSECTS_ONCE(cylinder, ( 0.5,    0,  0.5), ( dir2,     0,  dir2), ( 1.1,    0,  1.1), 1e-4)
+  CHECK_INTERSECTS_ONCE(cylinder, ( 0.5,    0,  0.5), (-dir2,     0, -dir2), (-1.1,    0, -1.1), 1e-4)
+  CHECK_INTERSECTS_ONCE(cylinder, (-0.5,    0, -0.5), ( dir2,     0,  dir2), ( 1.1,    0,  1.1), 1e-4)
+  CHECK_INTERSECTS_ONCE(cylinder, (-0.5,    0, -0.5), (-dir2,     0, -dir2), (-1.1,    0, -1.1), 1e-4)
+  // clang-format on
+
+  // any random rays that start inside the cylinder should have exactly one intersection with it
+  random_numbers::RandomNumberGenerator g(0u);
+  for (size_t i = 0; i < 1000; ++i)
+  {
+    std::srand(static_cast<unsigned int>(g.uniformInteger(0, std::numeric_limits<int>::max())));
+    const Eigen::Isometry3d pos(
+        Eigen::Isometry3d::TranslationType(Eigen::Vector3d::Random() * g.uniformReal(-100, 100)) *
+        Eigen::Quaterniond::UnitRandom());
+    cylinder.setPose(pos);
+    cylinder.setScale(g.uniformReal(0.5, 100.0));
+    cylinder.setPadding(g.uniformReal(-0.1, 100.0));
+
+    Eigen::Vector3d origin;
+    cylinder.samplePointInside(g, 10, origin);
+
+    // get the bounding sphere of the scaled cylinder
+    bodies::BoundingSphere s;
+    cylinder.computeBoundingSphere(s);
+
+    const Eigen::Vector3d dir = Eigen::Vector3d::Random().normalized();
+
+    EigenSTL::vector_Vector3d intersections;
+    if (cylinder.intersectsRay(origin, dir, &intersections, 2))
+    {
+      EXPECT_EQ(1u, intersections.size());
+      if (intersections.size() == 1)
+      {
+        EXPECT_GE(s.radius, (s.center - intersections[0]).norm());
+        // verify the point lies on the ray
+        EXPECT_NEAR(0.0, (Eigen::ParametrizedLine<double, 3>(origin, dir).distance(intersections[0])), 1e-6);
+        EXPECT_LT(0.0, (intersections[0] - origin).normalized().dot(dir));
+      }
+    }
+    else
+    {
+      GTEST_NONFATAL_FAILURE_(("No intersection in iteration " + std::to_string(i)).c_str());
+    }
+  }
+}
+
+TEST(CylinderRayIntersection, OriginOutside)
+{
+  shapes::Cylinder shape(1.0, 2.0);
+  bodies::Cylinder cylinder(&shape);
+  cylinder.setScale(1.5);
+  cylinder.setPadding(0.5);
+
+  // clang-format off
+  CHECK_INTERSECTS_TWICE(cylinder, (-4,  0,  0), ( 1,  0,  0), ( 2,  0,  0), (-2,  0,  0), 1e-6)
+  CHECK_INTERSECTS_TWICE(cylinder, ( 4,  0,  0), (-1,  0,  0), (-2,  0,  0), ( 2,  0,  0), 1e-6)
+  CHECK_INTERSECTS_TWICE(cylinder, ( 0, -4,  0), ( 0,  1,  0), ( 0,  2,  0), ( 0, -2,  0), 1e-6)
+  CHECK_INTERSECTS_TWICE(cylinder, ( 0,  4,  0), ( 0, -1,  0), ( 0, -2,  0), ( 0,  2,  0), 1e-6)
+  CHECK_INTERSECTS_TWICE(cylinder, ( 0,  0, -4), ( 0,  0,  1), ( 0,  0,  2), ( 0,  0, -2), 1e-6)
+  CHECK_INTERSECTS_TWICE(cylinder, ( 0,  0,  4), ( 0,  0, -1), ( 0,  0, -2), ( 0,  0,  2), 1e-6)
+  // clang-format on
+
+  // test hitting the surface
+  // clang-format off
+  CHECK_INTERSECTS_ONCE(cylinder, (-2, -2,  0), ( 0,  1,  0), (-2,  0,  0), 1e-6)
+  CHECK_INTERSECTS_ONCE(cylinder, (-2,  2,  0), ( 0, -1,  0), (-2,  0,  0), 1e-6)
+  CHECK_INTERSECTS_ONCE(cylinder, ( 2, -2,  0), ( 0,  1,  0), ( 2,  0,  0), 1e-6)
+  CHECK_INTERSECTS_ONCE(cylinder, ( 2,  2,  0), ( 0, -1,  0), ( 2,  0,  0), 1e-6)
+  CHECK_INTERSECTS_ONCE(cylinder, (-2, -2,  0), ( 1,  0,  0), ( 0, -2,  0), 1e-6)
+  CHECK_INTERSECTS_ONCE(cylinder, ( 2, -2,  0), (-1,  0,  0), ( 0, -2,  0), 1e-6)
+  CHECK_INTERSECTS_ONCE(cylinder, (-2,  2,  0), ( 1,  0,  0), ( 0,  2,  0), 1e-6)
+  CHECK_INTERSECTS_ONCE(cylinder, ( 2,  2,  0), (-1,  0,  0), ( 0,  2,  0), 1e-6)
+  CHECK_INTERSECTS_TWICE(cylinder, ( 0, -2, -3), ( 0,  0,  1), ( 0, -2, -2), ( 0, -2,  2), 1e-6)
+  CHECK_INTERSECTS_TWICE(cylinder, ( 0, -2,  3), ( 0,  0, -1), ( 0, -2,  2), ( 0, -2, -2), 1e-6)
+  CHECK_INTERSECTS_TWICE(cylinder, ( 0,  2, -3), ( 0,  0,  1), ( 0,  2, -2), ( 0,  2,  2), 1e-6)
+  CHECK_INTERSECTS_TWICE(cylinder, ( 0,  2,  3), ( 0,  0, -1), ( 0,  2,  2), ( 0,  2, -2), 1e-6)
+  CHECK_INTERSECTS_TWICE(cylinder, (-2,  0, -3), ( 0,  0,  1), (-2,  0, -2), (-2,  0,  2), 1e-6)
+  CHECK_INTERSECTS_TWICE(cylinder, (-2,  0,  3), ( 0,  0, -1), (-2,  0,  2), (-2,  0, -2), 1e-6)
+  CHECK_INTERSECTS_TWICE(cylinder, ( 2,  0, -3), ( 0,  0,  1), ( 2,  0, -2), ( 2,  0,  2), 1e-6)
+  CHECK_INTERSECTS_TWICE(cylinder, ( 2,  0,  3), ( 0,  0, -1), ( 2,  0,  2), ( 2,  0, -2), 1e-6)
+  // clang-format on
+
+  // test missing the surface
+  // clang-format off
+  CHECK_NO_INTERSECTION(cylinder, (-2.1,   -1,    0), ( 0,  1,  0))
+  CHECK_NO_INTERSECTION(cylinder, (-2.1,    1,    0), ( 0, -1,  0))
+  CHECK_NO_INTERSECTION(cylinder, ( 2.1,   -1,    0), ( 0,  1,  0))
+  CHECK_NO_INTERSECTION(cylinder, ( 2.1,    1,    0), ( 0, -1,  0))
+  CHECK_NO_INTERSECTION(cylinder, (   0, -2.1,   -2), ( 0,  0,  1))
+  CHECK_NO_INTERSECTION(cylinder, (   0, -2.1,    2), ( 0,  0, -1))
+  CHECK_NO_INTERSECTION(cylinder, (   0,  2.1,   -2), ( 0,  0,  1))
+  CHECK_NO_INTERSECTION(cylinder, (   0,  2.1,    2), ( 0,  0, -1))
+  CHECK_NO_INTERSECTION(cylinder, (  -2,    0, -2.1), ( 1,  0,  0))
+  CHECK_NO_INTERSECTION(cylinder, (   2,    0, -2.1), (-1,  0,  0))
+  CHECK_NO_INTERSECTION(cylinder, (  -2,    0,  2.1), ( 1,  0,  0))
+  CHECK_NO_INTERSECTION(cylinder, (   2,    0,  2.1), (-1,  0,  0))
+  // clang-format on
+
+  // generate some random rays outside the cylinder and test them
+  random_numbers::RandomNumberGenerator g(0u);
+  for (size_t i = 0; i < 1000; ++i)
+  {
+    std::srand(static_cast<unsigned int>(g.uniformInteger(0, std::numeric_limits<int>::max())));
+    const Eigen::Isometry3d pos(
+        Eigen::Isometry3d::TranslationType(Eigen::Vector3d::Random() * g.uniformReal(-100, 100)) *
+        Eigen::Quaterniond::UnitRandom());
+    cylinder.setPose(pos);
+    cylinder.setScale(g.uniformReal(0.5, 100.0));
+    cylinder.setPadding(g.uniformReal(-0.1, 100.0));
+
+    // choose a random direction
+    const Eigen::Vector3d dir = Eigen::Vector3d::Random().normalized();
+
+    // get the bounding sphere of the cylinder
+    bodies::BoundingSphere s;
+    cylinder.computeBoundingSphere(s);
+
+    // create origin outside the cylinder in the opposite direction than the chosen one
+    const Eigen::Vector3d origin = s.center + -dir * 1.5 * s.radius;
+
+    // a ray constructed in this way should intersect twice (through the cylinder center)
+    EigenSTL::vector_Vector3d intersections;
+    if (cylinder.intersectsRay(origin, dir, &intersections, 2))
+    {
+      EXPECT_EQ(2u, intersections.size());
+      if (intersections.size() == 2)
+      {
+        EXPECT_GE(s.radius, (s.center - intersections[0]).norm());
+        EXPECT_GE(s.radius, (s.center - intersections[1]).norm());
+
+        // verify the point lies on the ray
+        EXPECT_NEAR(0.0, (Eigen::ParametrizedLine<double, 3>(origin, dir).distance(intersections[0])), 1e-6);
+        EXPECT_LT(0.0, (intersections[0] - origin).normalized().dot(dir));
+        EXPECT_NEAR(0.0, (Eigen::ParametrizedLine<double, 3>(origin, dir).distance(intersections[1])), 1e-6);
+        EXPECT_LT(0.0, (intersections[1] - origin).normalized().dot(dir));
+      }
+    }
+    else
+    {
+      GTEST_NONFATAL_FAILURE_(("No intersection in iteration " + std::to_string(i)).c_str());
+    }
+
+    // check that the opposite ray misses
+    CHECK_NO_INTERSECTION(cylinder, (origin), (-dir))
+
+    // shift the ray a bit sideways
+
+    // choose a perpendicular direction
+    Eigen::Vector3d perpDir = dir.cross(Eigen::Vector3d({ dir.z(), dir.z(), -dir.x() - dir.y() }));
+    if (perpDir.norm() < 1e-6)
+      perpDir = dir.cross(Eigen::Vector3d({ -dir.y() - dir.z(), dir.x(), dir.x() }));
+    perpDir.normalize();
+
+    // get the scaled cylinder
+    bodies::BoundingCylinder c;
+    cylinder.computeBoundingCylinder(c);
+
+    // now move origin "sideways" but still only so much that the ray will hit the cylinder
+    auto minRadius = (std::min)(c.radius, c.length);
+    const Eigen::Vector3d origin2 = origin + g.uniformReal(1e-6, minRadius - 1e-4) * perpDir;
+
+    intersections.clear();
+    if (cylinder.intersectsRay(origin2, dir, &intersections, 2))
+    {
+      EXPECT_EQ(2u, intersections.size());
+      if (intersections.size() == 2)
+      {
+        EXPECT_GT(s.radius, (s.center - intersections[0]).norm());
+        EXPECT_GT(s.radius, (s.center - intersections[1]).norm());
+        EXPECT_LT(minRadius, (s.center - intersections[0]).norm());
+        EXPECT_LT(minRadius, (s.center - intersections[1]).norm());
+
+        // verify the point lies on the ray
+        EXPECT_NEAR(0.0, (Eigen::ParametrizedLine<double, 3>(origin2, dir).distance(intersections[0])), 1e-6);
+        EXPECT_LT(0.0, (intersections[0] - origin2).normalized().dot(dir));
+        EXPECT_NEAR(0.0, (Eigen::ParametrizedLine<double, 3>(origin2, dir).distance(intersections[1])), 1e-6);
+        EXPECT_LT(0.0, (intersections[1] - origin2).normalized().dot(dir));
+      }
+    }
+    else
+    {
+      GTEST_NONFATAL_FAILURE_(("No intersection in iteration " + std::to_string(i)).c_str());
+    }
+  }
+}
+
+TEST(CylinderRayIntersection, SimpleRay1)
+{
+  shapes::Cylinder shape(1.0, 2.0);
+  bodies::Cylinder cylinder(&shape);
+  cylinder.setScale(1.05);
+
+  CHECK_INTERSECTS_TWICE(cylinder, (5, 0, 0), (-1, 0, 0), (1.05, 0, 0), (-1.05, 0, 0), 1e-6)
+}
+
+TEST(CylinderRayIntersection, SimpleRay2)
+{
+  shapes::Cylinder shape(1.0, 2.0);
+  bodies::Cylinder cylinder(&shape);
+  cylinder.setScale(1.05);
+
+  CHECK_NO_INTERSECTION(cylinder, (5, 0, 0), (1, 0, 0))
 }
 
 TEST(BoxRayIntersection, SimpleRay1)
@@ -154,6 +736,651 @@ TEST(BoxRayIntersection, SimpleRay3)
   const Eigen::Vector3d ray_d(0, 1.8, -0.669);
 
   CHECK_NO_INTERSECTION(box, (0, -2, 1.11), (ray_d.normalized()))
+}
+
+TEST(BoxRayIntersection, Regression109)
+{
+  shapes::Box shape(1.0, 1.0, 1.0);
+  bodies::Box box(&shape);
+
+  // rotates the box so that the original (0.5, 0.5, 0.5) corner gets elsewhere and is no longer the
+  // maximal corner
+  const auto rot = Eigen::AngleAxisd(M_PI * 2 / 3, Eigen::Vector3d(1.0, -1.0, 1.0).normalized());
+  box.setPose(Eigen::Isometry3d(rot));
+
+  CHECK_INTERSECTS_TWICE(box, (-2, 0, 0), (1, 0, 0), (0.5, 0, 0), (-0.5, 0, 0), 1e-6)
+}
+
+TEST(BoxRayIntersection, OriginInside)
+{
+  shapes::Box shape(2.0, 2.0, 2.0);
+  bodies::Box box(&shape);
+
+  // clang-format off
+  CHECK_INTERSECTS_ONCE(box, (0, 0, 0), ( 1,  0,  0), ( 1,  0,  0), 1e-6)
+  CHECK_INTERSECTS_ONCE(box, (0, 0, 0), (-1,  0,  0), (-1,  0,  0), 1e-6)
+  CHECK_INTERSECTS_ONCE(box, (0, 0, 0), ( 0,  1,  0), ( 0,  1,  0), 1e-6)
+  CHECK_INTERSECTS_ONCE(box, (0, 0, 0), ( 0, -1,  0), ( 0, -1,  0), 1e-6)
+  CHECK_INTERSECTS_ONCE(box, (0, 0, 0), ( 0,  0,  1), ( 0,  0,  1), 1e-6)
+  CHECK_INTERSECTS_ONCE(box, (0, 0, 0), ( 0,  0, -1), ( 0,  0, -1), 1e-6)
+  // clang-format on
+
+  // scaling
+
+  box.setScale(1.1);
+  // clang-format off
+  CHECK_INTERSECTS_ONCE(box, (0, 0, 0), ( 1,  0,  0), ( 1.1,    0,    0), 1e-6)
+  CHECK_INTERSECTS_ONCE(box, (0, 0, 0), (-1,  0,  0), (-1.1,    0,    0), 1e-6)
+  CHECK_INTERSECTS_ONCE(box, (0, 0, 0), ( 0,  1,  0), ( 0,    1.1,    0), 1e-6)
+  CHECK_INTERSECTS_ONCE(box, (0, 0, 0), ( 0, -1,  0), ( 0,   -1.1,    0), 1e-6)
+  CHECK_INTERSECTS_ONCE(box, (0, 0, 0), ( 0,  0,  1), ( 0,      0,  1.1), 1e-6)
+  CHECK_INTERSECTS_ONCE(box, (0, 0, 0), ( 0,  0, -1), ( 0,      0, -1.1), 1e-6)
+  // clang-format on
+
+  // move origin within the box
+
+  // clang-format off
+  CHECK_INTERSECTS_ONCE(box, (0.5, 0  , 0  ), ( 1,  0,  0), ( 1.1,    0,    0), 1e-6)
+  CHECK_INTERSECTS_ONCE(box, (0.5, 0  , 0  ), (-1,  0,  0), (-1.1,    0,    0), 1e-6)
+  CHECK_INTERSECTS_ONCE(box, (0  , 0.5, 0  ), ( 0,  1,  0), ( 0,    1.1,    0), 1e-6)
+  CHECK_INTERSECTS_ONCE(box, (0  , 0.5, 0  ), ( 0, -1,  0), ( 0,   -1.1,    0), 1e-6)
+  CHECK_INTERSECTS_ONCE(box, (0  , 0  , 0.5), ( 0,  0,  1), ( 0,      0,  1.1), 1e-6)
+  CHECK_INTERSECTS_ONCE(box, (0  , 0  , 0.5), ( 0,  0, -1), ( 0,      0, -1.1), 1e-6)
+  // clang-format on
+
+  // move box
+
+  Eigen::Isometry3d pose(Eigen::Translation3d(0.5, 0, 0));
+  box.setPose(pose);
+  // clang-format off
+  CHECK_INTERSECTS_ONCE(box, (0, 0, 0), ( 1, 0, 0), ( 1.6, 0, 0), 1e-6)
+  CHECK_INTERSECTS_ONCE(box, (0, 0, 0), (-1, 0, 0), (-0.6, 0, 0), 1e-6)
+  // clang-format on
+
+  pose = Eigen::Translation3d(0, 0.5, 0);
+  box.setPose(pose);
+  // clang-format off
+  CHECK_INTERSECTS_ONCE(box, (0, 0, 0), ( 0,  1, 0), (0,  1.6, 0), 1e-6)
+  CHECK_INTERSECTS_ONCE(box, (0, 0, 0), ( 0, -1, 0), (0, -0.6, 0), 1e-6)
+  // clang-format on
+
+  pose = Eigen::Translation3d(0, 0, 0.5);
+  box.setPose(pose);
+  // clang-format off
+  CHECK_INTERSECTS_ONCE(box, (0, 0, 0), ( 0, 0,  1), (0, 0,  1.6), 1e-6)
+  CHECK_INTERSECTS_ONCE(box, (0, 0, 0), ( 0, 0, -1), (0, 0, -0.6), 1e-6)
+  // clang-format on
+
+  // 3D diagonal
+
+  box.setPose(Eigen::Isometry3d::Identity());
+  box.setScale(1.0);
+  box.setPadding(0.1);
+
+  const auto dir3 = Eigen::Vector3d::Ones().normalized();
+  // clang-format off
+  CHECK_INTERSECTS_ONCE(box, (   0,    0,    0), ( dir3), ( 1.1,  1.1,  1.1), 1e-4)
+  CHECK_INTERSECTS_ONCE(box, ( 0.5,  0.5,  0.5), ( dir3), ( 1.1,  1.1,  1.1), 1e-4)
+  CHECK_INTERSECTS_ONCE(box, (-0.5, -0.5, -0.5), ( dir3), ( 1.1,  1.1,  1.1), 1e-4)
+  CHECK_INTERSECTS_ONCE(box, (   0,    0,    0), (-dir3), (-1.1, -1.1, -1.1), 1e-4)
+  CHECK_INTERSECTS_ONCE(box, ( 0.5,  0.5,  0.5), (-dir3), (-1.1, -1.1, -1.1), 1e-4)
+  CHECK_INTERSECTS_ONCE(box, (-0.5, -0.5, -0.5), (-dir3), (-1.1, -1.1, -1.1), 1e-4)
+  // clang-format on
+
+  // 2D diagonal
+
+  const auto dir2 = 1 / sqrt(2);
+  // clang-format off
+  CHECK_INTERSECTS_ONCE(box, (   0,    0,    0), ( dir2,  dir2,     0), ( 1.1,  1.1,    0), 1e-4)
+  CHECK_INTERSECTS_ONCE(box, (   0,    0,    0), (-dir2, -dir2,     0), (-1.1, -1.1,    0), 1e-4)
+  CHECK_INTERSECTS_ONCE(box, ( 0.5,  0.5,    0), ( dir2,  dir2,     0), ( 1.1,  1.1,    0), 1e-4)
+  CHECK_INTERSECTS_ONCE(box, ( 0.5,  0.5,    0), (-dir2, -dir2,     0), (-1.1, -1.1,    0), 1e-4)
+  CHECK_INTERSECTS_ONCE(box, (-0.5, -0.5,    0), ( dir2,  dir2,     0), ( 1.1,  1.1,    0), 1e-4)
+  CHECK_INTERSECTS_ONCE(box, (-0.5, -0.5,    0), (-dir2, -dir2,     0), (-1.1, -1.1,    0), 1e-4)
+
+  CHECK_INTERSECTS_ONCE(box, (   0,    0,    0), (    0,  dir2,  dir2), (   0,  1.1,  1.1), 1e-4)
+  CHECK_INTERSECTS_ONCE(box, (   0,    0,    0), (    0, -dir2, -dir2), (   0, -1.1, -1.1), 1e-4)
+  CHECK_INTERSECTS_ONCE(box, (   0,  0.5,  0.5), (    0,  dir2,  dir2), (   0,  1.1,  1.1), 1e-4)
+  CHECK_INTERSECTS_ONCE(box, (   0,  0.5,  0.5), (    0, -dir2, -dir2), (   0, -1.1, -1.1), 1e-4)
+  CHECK_INTERSECTS_ONCE(box, (   0, -0.5, -0.5), (    0,  dir2,  dir2), (   0,  1.1,  1.1), 1e-4)
+  CHECK_INTERSECTS_ONCE(box, (   0, -0.5, -0.5), (    0, -dir2, -dir2), (   0, -1.1, -1.1), 1e-4)
+
+  CHECK_INTERSECTS_ONCE(box, (   0,    0,    0), ( dir2,     0,  dir2), ( 1.1,    0,  1.1), 1e-4)
+  CHECK_INTERSECTS_ONCE(box, (   0,    0,    0), (-dir2,     0, -dir2), (-1.1,    0, -1.1), 1e-4)
+  CHECK_INTERSECTS_ONCE(box, ( 0.5,    0,  0.5), ( dir2,     0,  dir2), ( 1.1,    0,  1.1), 1e-4)
+  CHECK_INTERSECTS_ONCE(box, ( 0.5,    0,  0.5), (-dir2,     0, -dir2), (-1.1,    0, -1.1), 1e-4)
+  CHECK_INTERSECTS_ONCE(box, (-0.5,    0, -0.5), ( dir2,     0,  dir2), ( 1.1,    0,  1.1), 1e-4)
+  CHECK_INTERSECTS_ONCE(box, (-0.5,    0, -0.5), (-dir2,     0, -dir2), (-1.1,    0, -1.1), 1e-4)
+  // clang-format on
+
+  // any random rays that start inside the box should have exactly one intersection with it
+  random_numbers::RandomNumberGenerator g(0u);
+  for (size_t i = 0; i < 1000; ++i)
+  {
+    std::srand(static_cast<unsigned int>(g.uniformInteger(0, std::numeric_limits<int>::max())));
+    const Eigen::Isometry3d pos(
+        Eigen::Isometry3d::TranslationType(Eigen::Vector3d::Random() * g.uniformReal(-100, 100)) *
+        Eigen::Quaterniond::UnitRandom());
+    box.setPose(pos);
+    box.setScale(g.uniformReal(0.5, 100.0));
+    box.setPadding(g.uniformReal(-0.1, 100.0));
+
+    // get the scaled dimensions of the box
+    Eigen::Vector3d sizes = { box.getDimensions()[0], box.getDimensions()[1], box.getDimensions()[2] };
+    sizes *= box.getScale();
+    sizes += 2 * box.getPadding() * Eigen::Vector3d::Ones();
+
+    // radii of the inscribed and bounding spheres
+    const auto minRadius = sizes.minCoeff() / 2;
+    const auto maxRadius = (sizes / 2).norm();
+
+    const Eigen::Vector3d boxCenter = box.getPose().translation();
+
+    Eigen::Vector3d origin;
+    box.samplePointInside(g, 10, origin);
+
+    const Eigen::Vector3d dir = Eigen::Vector3d::Random().normalized();
+
+    EigenSTL::vector_Vector3d intersections;
+    if (box.intersectsRay(origin, dir, &intersections, 2))
+    {
+      EXPECT_EQ(1u, intersections.size());
+      if (intersections.size() == 1)
+      {
+        // just approximate verification that the point is between inscribed and bounding sphere
+        EXPECT_GE(maxRadius, (boxCenter - intersections[0]).norm());
+        EXPECT_LE(minRadius, (boxCenter - intersections[0]).norm());
+        // verify the point lies on the ray
+        EXPECT_NEAR(0.0, (Eigen::ParametrizedLine<double, 3>(origin, dir).distance(intersections[0])), 1e-6);
+        EXPECT_LT(0.0, (intersections[0] - origin).normalized().dot(dir));
+      }
+    }
+    else
+    {
+      GTEST_NONFATAL_FAILURE_(("No intersection in iteration " + std::to_string(i)).c_str());
+    }
+  }
+}
+
+TEST(BoxRayIntersection, OriginOutsideIntersects)
+{
+  shapes::Box shape(2.0, 2.0, 2.0);
+  bodies::Box box(&shape);
+
+  // clang-format off
+  CHECK_INTERSECTS_TWICE(box, (-2, 0, 0), ( 1,  0,  0), ( 1,  0,  0), (-1,  0,  0), 1e-6)
+  CHECK_INTERSECTS_TWICE(box, ( 2, 0, 0), (-1,  0,  0), (-1,  0,  0), ( 1,  0,  0), 1e-6)
+  CHECK_INTERSECTS_TWICE(box, (0, -2, 0), ( 0,  1,  0), ( 0,  1,  0), ( 0, -1,  0), 1e-6)
+  CHECK_INTERSECTS_TWICE(box, (0,  2, 0), ( 0, -1,  0), ( 0, -1,  0), ( 0,  1,  0), 1e-6)
+  CHECK_INTERSECTS_TWICE(box, (0, 0, -2), ( 0,  0,  1), ( 0,  0,  1), ( 0,  0, -1), 1e-6)
+  CHECK_INTERSECTS_TWICE(box, (0, 0,  2), ( 0,  0, -1), ( 0,  0, -1), ( 0,  0,  1), 1e-6)
+  // clang-format on
+
+  // test hitting the surface
+  // clang-format off
+  CHECK_INTERSECTS_TWICE(box, (-1, -2,  0), ( 0,  1,  0), (-1, -1,  0), (-1,  1,  0), 1e-6)
+  CHECK_INTERSECTS_TWICE(box, (-1,  2,  0), ( 0, -1,  0), (-1,  1,  0), (-1, -1,  0), 1e-6)
+  CHECK_INTERSECTS_TWICE(box, ( 1, -2,  0), ( 0,  1,  0), ( 1, -1,  0), ( 1,  1,  0), 1e-6)
+  CHECK_INTERSECTS_TWICE(box, ( 1,  2,  0), ( 0, -1,  0), ( 1,  1,  0), ( 1, -1,  0), 1e-6)
+  CHECK_INTERSECTS_TWICE(box, ( 0, -1, -2), ( 0,  0,  1), ( 0, -1, -1), ( 0, -1,  1), 1e-6)
+  CHECK_INTERSECTS_TWICE(box, ( 0, -1,  2), ( 0,  0, -1), ( 0, -1,  1), ( 0, -1, -1), 1e-6)
+  CHECK_INTERSECTS_TWICE(box, ( 0,  1, -2), ( 0,  0,  1), ( 0,  1, -1), ( 0,  1,  1), 1e-6)
+  CHECK_INTERSECTS_TWICE(box, ( 0,  1,  2), ( 0,  0, -1), ( 0,  1,  1), ( 0,  1, -1), 1e-6)
+  CHECK_INTERSECTS_TWICE(box, (-2,  0, -1), ( 1,  0,  0), (-1,  0, -1), ( 1,  0, -1), 1e-6)
+  CHECK_INTERSECTS_TWICE(box, ( 2,  0, -1), (-1,  0,  0), ( 1,  0, -1), (-1,  0, -1), 1e-6)
+  CHECK_INTERSECTS_TWICE(box, (-2,  0,  1), ( 1,  0,  0), (-1,  0,  1), ( 1,  0,  1), 1e-6)
+  CHECK_INTERSECTS_TWICE(box, ( 2,  0,  1), (-1,  0,  0), ( 1,  0,  1), (-1,  0,  1), 1e-6)
+  // clang-format on
+
+  // test missing the surface
+  // clang-format off
+  CHECK_NO_INTERSECTION(box, (-1.1,   -2,    0), ( 0,  1,  0))
+  CHECK_NO_INTERSECTION(box, (-1.1,    2,    0), ( 0, -1,  0))
+  CHECK_NO_INTERSECTION(box, ( 1.1,   -2,    0), ( 0,  1,  0))
+  CHECK_NO_INTERSECTION(box, ( 1.1,    2,    0), ( 0, -1,  0))
+  CHECK_NO_INTERSECTION(box, (   0, -1.1,   -2), ( 0,  0,  1))
+  CHECK_NO_INTERSECTION(box, (   0, -1.1,    2), ( 0,  0, -1))
+  CHECK_NO_INTERSECTION(box, (   0,  1.1,   -2), ( 0,  0,  1))
+  CHECK_NO_INTERSECTION(box, (   0,  1.1,    2), ( 0,  0, -1))
+  CHECK_NO_INTERSECTION(box, (  -2,    0, -1.1), ( 1,  0,  0))
+  CHECK_NO_INTERSECTION(box, (   2,    0, -1.1), (-1,  0,  0))
+  CHECK_NO_INTERSECTION(box, (  -2,    0,  1.1), ( 1,  0,  0))
+  CHECK_NO_INTERSECTION(box, (   2,    0,  1.1), (-1,  0,  0))
+  // clang-format on
+
+  // generate some random rays outside the box and test them
+  random_numbers::RandomNumberGenerator g(0u);
+  for (size_t i = 0; i < 1000; ++i)
+  {
+    std::srand(static_cast<unsigned int>(g.uniformInteger(0, std::numeric_limits<int>::max())));
+    const Eigen::Isometry3d pos(
+        Eigen::Isometry3d::TranslationType(Eigen::Vector3d::Random() * g.uniformReal(-100, 100)) *
+        Eigen::Quaterniond::UnitRandom());
+    box.setPose(pos);
+    box.setScale(g.uniformReal(0.5, 100.0));
+    box.setPadding(g.uniformReal(-0.1, 100.0));
+
+    // choose a random direction
+    const Eigen::Vector3d dir = Eigen::Vector3d::Random().normalized();
+
+    // get the scaled dimensions of the box
+    Eigen::Vector3d sizes = { box.getDimensions()[0], box.getDimensions()[1], box.getDimensions()[2] };
+    sizes *= box.getScale();
+    sizes += 2 * box.getPadding() * Eigen::Vector3d::Ones();
+
+    // radii of the inscribed and bounding spheres
+    const auto minRadius = sizes.minCoeff() / 2;
+    const auto maxRadius = (sizes / 2).norm();
+
+    const Eigen::Vector3d boxCenter = box.getPose().translation();
+
+    // create origin outside the box in the opposite direction than the chosen one
+    const Eigen::Vector3d origin = boxCenter + -dir * 1.5 * maxRadius;
+
+    // a ray constructed in this way should intersect twice (through the box center)
+    EigenSTL::vector_Vector3d intersections;
+    if (box.intersectsRay(origin, dir, &intersections, 2))
+    {
+      EXPECT_EQ(2u, intersections.size());
+      if (intersections.size() == 2)
+      {
+        // just approximate verification that the point is between inscribed and bounding sphere
+        EXPECT_GE(maxRadius, (boxCenter - intersections[0]).norm());
+        EXPECT_LE(minRadius, (boxCenter - intersections[0]).norm());
+        EXPECT_GE(maxRadius, (boxCenter - intersections[1]).norm());
+        EXPECT_LE(minRadius, (boxCenter - intersections[1]).norm());
+
+        // verify the point lies on the ray
+        EXPECT_NEAR(0.0, (Eigen::ParametrizedLine<double, 3>(origin, dir).distance(intersections[0])), 1e-6);
+        EXPECT_LT(0.0, (intersections[0] - origin).normalized().dot(dir));
+        EXPECT_NEAR(0.0, (Eigen::ParametrizedLine<double, 3>(origin, dir).distance(intersections[1])), 1e-6);
+        EXPECT_LT(0.0, (intersections[1] - origin).normalized().dot(dir));
+      }
+    }
+    else
+    {
+      GTEST_NONFATAL_FAILURE_(("No intersection in iteration " + std::to_string(i)).c_str());
+    }
+
+    // check that the opposite ray misses
+    CHECK_NO_INTERSECTION(box, (origin), (-dir))
+
+    // shift the ray a bit sideways
+
+    // choose a perpendicular direction
+    Eigen::Vector3d perpDir = dir.cross(Eigen::Vector3d({ dir.z(), dir.z(), -dir.x() - dir.y() }));
+    if (perpDir.norm() < 1e-6)
+      perpDir = dir.cross(Eigen::Vector3d({ -dir.y() - dir.z(), dir.x(), dir.x() }));
+    perpDir.normalize();
+
+    // now move origin "sideways" but still only so much that the ray will hit the box
+    const Eigen::Vector3d origin2 = origin + g.uniformReal(1e-6, minRadius - 1e-4) * perpDir;
+
+    intersections.clear();
+    if (box.intersectsRay(origin2, dir, &intersections, 2))
+    {
+      EXPECT_EQ(2u, intersections.size());
+      if (intersections.size() == 2)
+      {
+        // just approximate verification that the point is between inscribed and bounding sphere
+        EXPECT_GE(maxRadius, (boxCenter - intersections[0]).norm());
+        EXPECT_LE(minRadius, (boxCenter - intersections[0]).norm());
+        EXPECT_GE(maxRadius, (boxCenter - intersections[1]).norm());
+        EXPECT_LE(minRadius, (boxCenter - intersections[1]).norm());
+
+        // verify the point lies on the ray
+        EXPECT_NEAR(0.0, (Eigen::ParametrizedLine<double, 3>(origin2, dir).distance(intersections[0])), 1e-6);
+        EXPECT_LT(0.0, (intersections[0] - origin2).normalized().dot(dir));
+        EXPECT_NEAR(0.0, (Eigen::ParametrizedLine<double, 3>(origin2, dir).distance(intersections[1])), 1e-6);
+        EXPECT_LT(0.0, (intersections[1] - origin2).normalized().dot(dir));
+      }
+    }
+    else
+    {
+      GTEST_NONFATAL_FAILURE_(("No intersection in iteration " + std::to_string(i)).c_str());
+    }
+  }
+}
+
+TEST(ConvexMeshRayIntersection, SimpleRay1)
+{
+  shapes::Box box(1.0, 1.0, 3.0);
+  shapes::Mesh* shape = shapes::createMeshFromShape(&box);
+  bodies::ConvexMesh mesh(shape);
+  delete shape;
+  mesh.setScale(0.95);
+
+  CHECK_INTERSECTS_TWICE(mesh, (10, 0.449, 0), (-1, 0, 0), (0.475, 0.449, 0), (-0.475, 0.449, 0), 1e-4)
+}
+
+TEST(ConvexMeshRayIntersection, SimpleRay2)
+{
+  shapes::Box box(0.9, 0.01, 1.2);
+  shapes::Mesh* shape = shapes::createMeshFromShape(&box);
+  bodies::ConvexMesh mesh(shape);
+  delete shape;
+
+  Eigen::Isometry3d pose(Eigen::AngleAxisd(0, Eigen::Vector3d::UnitX()));
+  pose.translation() = Eigen::Vector3d(0, 0.005, 0.6);
+  mesh.setPose(pose);
+
+  const Eigen::Vector3d ray_d(0, -5.195, -0.77);
+
+  CHECK_INTERSECTS(mesh, (0, 5, 1.6), (ray_d.normalized()), 2)
+}
+
+TEST(ConvexMeshRayIntersection, SimpleRay3)
+{
+  shapes::Box box(0.02, 0.4, 1.2);
+  shapes::Mesh* shape = shapes::createMeshFromShape(&box);
+  bodies::ConvexMesh mesh(shape);
+  delete shape;
+
+  Eigen::Isometry3d pose(Eigen::AngleAxisd(0, Eigen::Vector3d::UnitX()));
+  pose.translation() = Eigen::Vector3d(0.45, -0.195, 0.6);
+  mesh.setPose(pose);
+
+  const Eigen::Vector3d ray_d(0, 1.8, -0.669);
+
+  CHECK_NO_INTERSECTION(mesh, (0, -2, 1.11), (ray_d.normalized()))
+}
+
+TEST(ConvexMeshRayIntersection, OriginInside)
+{
+  shapes::Box box(2.0, 2.0, 2.0);
+  shapes::Mesh* shape = shapes::createMeshFromShape(&box);
+  bodies::ConvexMesh mesh(shape);
+  delete shape;
+
+  // clang-format off
+  CHECK_INTERSECTS_ONCE(mesh, (0, 0, 0), ( 1,  0,  0), ( 1,  0,  0), 1e-6)
+  CHECK_INTERSECTS_ONCE(mesh, (0, 0, 0), (-1,  0,  0), (-1,  0,  0), 1e-6)
+  CHECK_INTERSECTS_ONCE(mesh, (0, 0, 0), ( 0,  1,  0), ( 0,  1,  0), 1e-6)
+  CHECK_INTERSECTS_ONCE(mesh, (0, 0, 0), ( 0, -1,  0), ( 0, -1,  0), 1e-6)
+  CHECK_INTERSECTS_ONCE(mesh, (0, 0, 0), ( 0,  0,  1), ( 0,  0,  1), 1e-6)
+  CHECK_INTERSECTS_ONCE(mesh, (0, 0, 0), ( 0,  0, -1), ( 0,  0, -1), 1e-6)
+  // clang-format on
+
+  // scaling
+
+  mesh.setScale(1.1);
+  // clang-format off
+  CHECK_INTERSECTS_ONCE(mesh, (0, 0, 0), ( 1,  0,  0), ( 1.1,    0,    0), 1e-6)
+  CHECK_INTERSECTS_ONCE(mesh, (0, 0, 0), (-1,  0,  0), (-1.1,    0,    0), 1e-6)
+  CHECK_INTERSECTS_ONCE(mesh, (0, 0, 0), ( 0,  1,  0), ( 0,    1.1,    0), 1e-6)
+  CHECK_INTERSECTS_ONCE(mesh, (0, 0, 0), ( 0, -1,  0), ( 0,   -1.1,    0), 1e-6)
+  CHECK_INTERSECTS_ONCE(mesh, (0, 0, 0), ( 0,  0,  1), ( 0,      0,  1.1), 1e-6)
+  CHECK_INTERSECTS_ONCE(mesh, (0, 0, 0), ( 0,  0, -1), ( 0,      0, -1.1), 1e-6)
+  // clang-format on
+
+  // move origin within the mesh
+
+  // clang-format off
+  CHECK_INTERSECTS_ONCE(mesh, (0.5, 0  , 0  ), ( 1,  0,  0), ( 1.1,    0,    0), 1e-6)
+  CHECK_INTERSECTS_ONCE(mesh, (0.5, 0  , 0  ), (-1,  0,  0), (-1.1,    0,    0), 1e-6)
+  CHECK_INTERSECTS_ONCE(mesh, (0  , 0.5, 0  ), ( 0,  1,  0), ( 0,    1.1,    0), 1e-6)
+  CHECK_INTERSECTS_ONCE(mesh, (0  , 0.5, 0  ), ( 0, -1,  0), ( 0,   -1.1,    0), 1e-6)
+  CHECK_INTERSECTS_ONCE(mesh, (0  , 0  , 0.5), ( 0,  0,  1), ( 0,      0,  1.1), 1e-6)
+  CHECK_INTERSECTS_ONCE(mesh, (0  , 0  , 0.5), ( 0,  0, -1), ( 0,      0, -1.1), 1e-6)
+  // clang-format on
+
+  // move mesh
+
+  Eigen::Isometry3d pose(Eigen::Translation3d(0.5, 0, 0));
+  mesh.setPose(pose);
+  // clang-format off
+  CHECK_INTERSECTS_ONCE(mesh, (0, 0, 0), ( 1, 0, 0), ( 1.6, 0, 0), 1e-6)
+  CHECK_INTERSECTS_ONCE(mesh, (0, 0, 0), (-1, 0, 0), (-0.6, 0, 0), 1e-6)
+  // clang-format on
+
+  pose = Eigen::Translation3d(0, 0.5, 0);
+  mesh.setPose(pose);
+  // clang-format off
+  CHECK_INTERSECTS_ONCE(mesh, (0, 0, 0), ( 0,  1, 0), (0,  1.6, 0), 1e-6)
+  CHECK_INTERSECTS_ONCE(mesh, (0, 0, 0), ( 0, -1, 0), (0, -0.6, 0), 1e-6)
+  // clang-format on
+
+  pose = Eigen::Translation3d(0, 0, 0.5);
+  mesh.setPose(pose);
+  // clang-format off
+  CHECK_INTERSECTS_ONCE(mesh, (0, 0, 0), ( 0, 0,  1), (0, 0,  1.6), 1e-6)
+  CHECK_INTERSECTS_ONCE(mesh, (0, 0, 0), ( 0, 0, -1), (0, 0, -0.6), 1e-6)
+  // clang-format on
+
+  // 3D diagonal
+
+  mesh.setPose(Eigen::Isometry3d::Identity());
+  mesh.setScale(1.0);
+  mesh.setPadding(0.1);
+
+  // half-size of the scaled and padded mesh (mesh scaling isn't "linear" in padding)
+  const double s = 1.0 + 0.1 / sqrt(3);
+
+  const auto dir3 = Eigen::Vector3d::Ones().normalized();
+  // clang-format off
+  CHECK_INTERSECTS_ONCE(mesh, (   0,    0,    0), ( dir3), ( s,  s,  s), 1e-4)
+  CHECK_INTERSECTS_ONCE(mesh, ( 0.5,  0.5,  0.5), ( dir3), ( s,  s,  s), 1e-4)
+  CHECK_INTERSECTS_ONCE(mesh, (-0.5, -0.5, -0.5), ( dir3), ( s,  s,  s), 1e-4)
+  CHECK_INTERSECTS_ONCE(mesh, (   0,    0,    0), (-dir3), (-s, -s, -s), 1e-4)
+  CHECK_INTERSECTS_ONCE(mesh, ( 0.5,  0.5,  0.5), (-dir3), (-s, -s, -s), 1e-4)
+  CHECK_INTERSECTS_ONCE(mesh, (-0.5, -0.5, -0.5), (-dir3), (-s, -s, -s), 1e-4)
+  // clang-format on
+
+  // 2D diagonal
+
+  const auto dir2 = 1 / sqrt(2);
+  // clang-format off
+  CHECK_INTERSECTS_ONCE(mesh, (   0,    0,    0), ( dir2,  dir2,     0), ( s,  s,  0), 1e-4)
+  CHECK_INTERSECTS_ONCE(mesh, (   0,    0,    0), (-dir2, -dir2,     0), (-s, -s,  0), 1e-4)
+  CHECK_INTERSECTS_ONCE(mesh, ( 0.5,  0.5,    0), ( dir2,  dir2,     0), ( s,  s,  0), 1e-4)
+  CHECK_INTERSECTS_ONCE(mesh, ( 0.5,  0.5,    0), (-dir2, -dir2,     0), (-s, -s,  0), 1e-4)
+  CHECK_INTERSECTS_ONCE(mesh, (-0.5, -0.5,    0), ( dir2,  dir2,     0), ( s,  s,  0), 1e-4)
+  CHECK_INTERSECTS_ONCE(mesh, (-0.5, -0.5,    0), (-dir2, -dir2,     0), (-s, -s,  0), 1e-4)
+
+  CHECK_INTERSECTS_ONCE(mesh, (   0,    0,    0), (    0,  dir2,  dir2), ( 0,  s,  s), 1e-4)
+  CHECK_INTERSECTS_ONCE(mesh, (   0,    0,    0), (    0, -dir2, -dir2), ( 0, -s, -s), 1e-4)
+  CHECK_INTERSECTS_ONCE(mesh, (   0,  0.5,  0.5), (    0,  dir2,  dir2), ( 0,  s,  s), 1e-4)
+  CHECK_INTERSECTS_ONCE(mesh, (   0,  0.5,  0.5), (    0, -dir2, -dir2), ( 0, -s, -s), 1e-4)
+  CHECK_INTERSECTS_ONCE(mesh, (   0, -0.5, -0.5), (    0,  dir2,  dir2), ( 0,  s,  s), 1e-4)
+  CHECK_INTERSECTS_ONCE(mesh, (   0, -0.5, -0.5), (    0, -dir2, -dir2), ( 0, -s, -s), 1e-4)
+
+  CHECK_INTERSECTS_ONCE(mesh, (   0,    0,    0), ( dir2,     0,  dir2), ( s,  0,  s), 1e-4)
+  CHECK_INTERSECTS_ONCE(mesh, (   0,    0,    0), (-dir2,     0, -dir2), (-s,  0, -s), 1e-4)
+  CHECK_INTERSECTS_ONCE(mesh, ( 0.5,    0,  0.5), ( dir2,     0,  dir2), ( s,  0,  s), 1e-4)
+  CHECK_INTERSECTS_ONCE(mesh, ( 0.5,    0,  0.5), (-dir2,     0, -dir2), (-s,  0, -s), 1e-4)
+  CHECK_INTERSECTS_ONCE(mesh, (-0.5,    0, -0.5), ( dir2,     0,  dir2), ( s,  0,  s), 1e-4)
+  CHECK_INTERSECTS_ONCE(mesh, (-0.5,    0, -0.5), (-dir2,     0, -dir2), (-s,  0, -s), 1e-4)
+  // clang-format on
+
+  // any random rays that start inside the mesh should have exactly one intersection with it
+  random_numbers::RandomNumberGenerator g(0u);
+  for (size_t i = 0; i < 1000; ++i)
+  {
+    std::srand(static_cast<unsigned int>(g.uniformInteger(0, std::numeric_limits<int>::max())));
+    const Eigen::Isometry3d pos(
+        Eigen::Isometry3d::TranslationType(Eigen::Vector3d::Random() * g.uniformReal(-100, 100)) *
+        Eigen::Quaterniond::UnitRandom());
+    mesh.setPose(pos);
+    mesh.setScale(g.uniformReal(0.5, 100.0));
+    mesh.setPadding(g.uniformReal(-0.1, 100.0));
+
+    // get the scaled dimensions of the mesh
+    Eigen::Vector3d sizes = { box.size[0], box.size[1], box.size[2] };
+    sizes *= mesh.getScale();
+    sizes += 2 * mesh.getPadding() / sqrt(3) * Eigen::Vector3d::Ones();
+
+    // radii of the inscribed and bounding spheres
+    const auto minRadius = sizes.minCoeff() / 2;
+    const auto maxRadius = (sizes / 2).norm();
+
+    const Eigen::Vector3d meshCenter = mesh.getPose().translation();
+
+    Eigen::Vector3d origin;
+    mesh.samplePointInside(g, 10000, origin);
+
+    const Eigen::Vector3d dir = Eigen::Vector3d::Random().normalized();
+
+    EigenSTL::vector_Vector3d intersections;
+    if (mesh.intersectsRay(origin, dir, &intersections, 2))
+    {
+      EXPECT_EQ(1u, intersections.size());
+      if (intersections.size() == 1)
+      {
+        // just approximate verification that the point is between inscribed and bounding sphere
+        EXPECT_GE(maxRadius, (meshCenter - intersections[0]).norm());
+        EXPECT_LE(minRadius, (meshCenter - intersections[0]).norm());
+        // verify the point lies on the ray
+        EXPECT_NEAR(0.0, (Eigen::ParametrizedLine<double, 3>(origin, dir).distance(intersections[0])), 1e-6);
+        EXPECT_LT(0.0, (intersections[0] - origin).normalized().dot(dir));
+      }
+    }
+    else
+    {
+      GTEST_NONFATAL_FAILURE_(("No intersection in iteration " + std::to_string(i)).c_str());
+    }
+  }
+}
+
+TEST(ConvexMeshRayIntersection, OriginOutsideIntersects)
+{
+  shapes::Box box(2.0, 2.0, 2.0);
+  shapes::Mesh* shape = shapes::createMeshFromShape(&box);
+  bodies::ConvexMesh mesh(shape);
+  delete shape;
+
+  // clang-format off
+  CHECK_INTERSECTS_TWICE(mesh, (-2, 0, 0), ( 1,  0,  0), ( 1,  0,  0), (-1,  0,  0), 1e-6)
+  CHECK_INTERSECTS_TWICE(mesh, ( 2, 0, 0), (-1,  0,  0), (-1,  0,  0), ( 1,  0,  0), 1e-6)
+  CHECK_INTERSECTS_TWICE(mesh, (0, -2, 0), ( 0,  1,  0), ( 0,  1,  0), ( 0, -1,  0), 1e-6)
+  CHECK_INTERSECTS_TWICE(mesh, (0,  2, 0), ( 0, -1,  0), ( 0, -1,  0), ( 0,  1,  0), 1e-6)
+  CHECK_INTERSECTS_TWICE(mesh, (0, 0, -2), ( 0,  0,  1), ( 0,  0,  1), ( 0,  0, -1), 1e-6)
+  CHECK_INTERSECTS_TWICE(mesh, (0, 0,  2), ( 0,  0, -1), ( 0,  0, -1), ( 0,  0,  1), 1e-6)
+  // clang-format on
+
+  // test hitting the surface
+  // clang-format off
+  CHECK_INTERSECTS_TWICE(mesh, (-1, -2,  0), ( 0,  1,  0), (-1, -1,  0), (-1,  1,  0), 1e-6)
+  CHECK_INTERSECTS_TWICE(mesh, (-1,  2,  0), ( 0, -1,  0), (-1,  1,  0), (-1, -1,  0), 1e-6)
+  CHECK_INTERSECTS_TWICE(mesh, ( 1, -2,  0), ( 0,  1,  0), ( 1, -1,  0), ( 1,  1,  0), 1e-6)
+  CHECK_INTERSECTS_TWICE(mesh, ( 1,  2,  0), ( 0, -1,  0), ( 1,  1,  0), ( 1, -1,  0), 1e-6)
+  CHECK_INTERSECTS_TWICE(mesh, ( 0, -1, -2), ( 0,  0,  1), ( 0, -1, -1), ( 0, -1,  1), 1e-6)
+  CHECK_INTERSECTS_TWICE(mesh, ( 0, -1,  2), ( 0,  0, -1), ( 0, -1,  1), ( 0, -1, -1), 1e-6)
+  CHECK_INTERSECTS_TWICE(mesh, ( 0,  1, -2), ( 0,  0,  1), ( 0,  1, -1), ( 0,  1,  1), 1e-6)
+  CHECK_INTERSECTS_TWICE(mesh, ( 0,  1,  2), ( 0,  0, -1), ( 0,  1,  1), ( 0,  1, -1), 1e-6)
+  CHECK_INTERSECTS_TWICE(mesh, (-2,  0, -1), ( 1,  0,  0), (-1,  0, -1), ( 1,  0, -1), 1e-6)
+  CHECK_INTERSECTS_TWICE(mesh, ( 2,  0, -1), (-1,  0,  0), ( 1,  0, -1), (-1,  0, -1), 1e-6)
+  CHECK_INTERSECTS_TWICE(mesh, (-2,  0,  1), ( 1,  0,  0), (-1,  0,  1), ( 1,  0,  1), 1e-6)
+  CHECK_INTERSECTS_TWICE(mesh, ( 2,  0,  1), (-1,  0,  0), ( 1,  0,  1), (-1,  0,  1), 1e-6)
+  // clang-format on
+
+  // test missing the surface
+  // clang-format off
+  CHECK_NO_INTERSECTION(mesh, (-1.1,   -2,    0), ( 0,  1,  0))
+  CHECK_NO_INTERSECTION(mesh, (-1.1,    2,    0), ( 0, -1,  0))
+  CHECK_NO_INTERSECTION(mesh, ( 1.1,   -2,    0), ( 0,  1,  0))
+  CHECK_NO_INTERSECTION(mesh, ( 1.1,    2,    0), ( 0, -1,  0))
+  CHECK_NO_INTERSECTION(mesh, (   0, -1.1,   -2), ( 0,  0,  1))
+  CHECK_NO_INTERSECTION(mesh, (   0, -1.1,    2), ( 0,  0, -1))
+  CHECK_NO_INTERSECTION(mesh, (   0,  1.1,   -2), ( 0,  0,  1))
+  CHECK_NO_INTERSECTION(mesh, (   0,  1.1,    2), ( 0,  0, -1))
+  CHECK_NO_INTERSECTION(mesh, (  -2,    0, -1.1), ( 1,  0,  0))
+  CHECK_NO_INTERSECTION(mesh, (   2,    0, -1.1), (-1,  0,  0))
+  CHECK_NO_INTERSECTION(mesh, (  -2,    0,  1.1), ( 1,  0,  0))
+  CHECK_NO_INTERSECTION(mesh, (   2,    0,  1.1), (-1,  0,  0))
+  // clang-format on
+
+  // generate some random rays outside the mesh and test them
+  random_numbers::RandomNumberGenerator g(0u);
+  for (size_t i = 0; i < 1000; ++i)
+  {
+    std::srand(static_cast<unsigned int>(g.uniformInteger(0, std::numeric_limits<int>::max())));
+    const Eigen::Isometry3d pos(
+        Eigen::Isometry3d::TranslationType(Eigen::Vector3d::Random() * g.uniformReal(-100, 100)) *
+        Eigen::Quaterniond::UnitRandom());
+    mesh.setPose(pos);
+    mesh.setScale(g.uniformReal(0.5, 100.0));
+    mesh.setPadding(g.uniformReal(-0.1, 100.0));
+
+    // choose a random direction
+    const Eigen::Vector3d dir = Eigen::Vector3d::Random().normalized();
+
+    // get the scaled dimensions of the mesh
+    Eigen::Vector3d sizes = { box.size[0], box.size[1], box.size[2] };
+    sizes *= mesh.getScale();
+    sizes += 2 * mesh.getPadding() / sqrt(3) * Eigen::Vector3d::Ones();
+
+    // radii of the inscribed and bounding spheres
+    const auto minRadius = sizes.minCoeff() / 2;
+    const auto maxRadius = (sizes / 2).norm();
+
+    const Eigen::Vector3d meshCenter = mesh.getPose().translation();
+
+    // create origin outside the mesh in the opposite direction than the chosen one
+    const Eigen::Vector3d origin = meshCenter + -dir * 1.5 * maxRadius;
+
+    // a ray constructed in this way should intersect twice (through the mesh center)
+    EigenSTL::vector_Vector3d intersections;
+    if (mesh.intersectsRay(origin, dir, &intersections, 2))
+    {
+      EXPECT_EQ(2u, intersections.size());
+      if (intersections.size() == 2)
+      {
+        // just approximate verification that the point is between inscribed and bounding sphere
+        EXPECT_GE(maxRadius, (meshCenter - intersections[0]).norm());
+        EXPECT_LE(minRadius, (meshCenter - intersections[0]).norm());
+        EXPECT_GE(maxRadius, (meshCenter - intersections[1]).norm());
+        EXPECT_LE(minRadius, (meshCenter - intersections[1]).norm());
+
+        // verify the point lies on the ray
+        EXPECT_NEAR(0.0, (Eigen::ParametrizedLine<double, 3>(origin, dir).distance(intersections[0])), 1e-6);
+        EXPECT_LT(0.0, (intersections[0] - origin).normalized().dot(dir));
+        EXPECT_NEAR(0.0, (Eigen::ParametrizedLine<double, 3>(origin, dir).distance(intersections[1])), 1e-6);
+        EXPECT_LT(0.0, (intersections[1] - origin).normalized().dot(dir));
+      }
+    }
+    else
+    {
+      GTEST_NONFATAL_FAILURE_(("No intersection in iteration " + std::to_string(i)).c_str());
+    }
+
+    // check that the opposite ray misses
+    CHECK_NO_INTERSECTION(mesh, (origin), (-dir))
+
+    // shift the ray a bit sideways
+
+    // choose a perpendicular direction
+    Eigen::Vector3d perpDir = dir.cross(Eigen::Vector3d({ dir.z(), dir.z(), -dir.x() - dir.y() }));
+    if (perpDir.norm() < 1e-6)
+      perpDir = dir.cross(Eigen::Vector3d({ -dir.y() - dir.z(), dir.x(), dir.x() }));
+    perpDir.normalize();
+
+    // now move origin "sideways" but still only so much that the ray will hit the mesh
+    const Eigen::Vector3d origin2 = origin + g.uniformReal(1e-6, minRadius - 1e-4) * perpDir;
+
+    intersections.clear();
+    if (mesh.intersectsRay(origin2, dir, &intersections, 2))
+    {
+      EXPECT_EQ(2u, intersections.size());
+      if (intersections.size() == 2)
+      {
+        // just approximate verification that the point is between inscribed and bounding sphere
+        EXPECT_GE(maxRadius, (meshCenter - intersections[0]).norm());
+        EXPECT_LE(minRadius, (meshCenter - intersections[0]).norm());
+        EXPECT_GE(maxRadius, (meshCenter - intersections[1]).norm());
+        EXPECT_LE(minRadius, (meshCenter - intersections[1]).norm());
+
+        // verify the point lies on the ray
+        EXPECT_NEAR(0.0, (Eigen::ParametrizedLine<double, 3>(origin2, dir).distance(intersections[0])), 1e-6);
+        EXPECT_LT(0.0, (intersections[0] - origin2).normalized().dot(dir));
+        EXPECT_NEAR(0.0, (Eigen::ParametrizedLine<double, 3>(origin2, dir).distance(intersections[1])), 1e-6);
+        EXPECT_LT(0.0, (intersections[1] - origin2).normalized().dot(dir));
+      }
+    }
+    else
+    {
+      GTEST_NONFATAL_FAILURE_(("No intersection in iteration " + std::to_string(i)).c_str());
+    }
+  }
 }
 
 int main(int argc, char** argv)


### PR DESCRIPTION
This PR fixes a multitude of problems the current implementations of `intersectsRay()` had.

In Box, even according to the link to the used method, the approach should only work for axis-aligned boxes. But bodies::Box can be arbitrarily transformed. So I instead strip rotation from both the box and the ray, which gives the same results. The old implementation would fail every time the untransformed min corner ceased to be the min corner of the transformed box.

For Cylinder, there were a few cornercases when incorrect number of intersections were returned (e.g. when the ray is tangential to the cylinder or when it goes through the edge between base and sides).

For ConvexMesh, there were several problems. Many of them arose from a wrong approach to incorporate padding. Also, if a ray hit the edge of two triangles, it was reported twice.

I also restructured the tests for both `containsPoint()` and `intersectsRay()` and added a lot of new tests - both randomized and testing corner cases. There is also a regression test `BoxRayIntersection::Regression109` which fails on current melodic-devel and succeeds with this test.

Aside from the fixes in `intersectsRay()`, I also fixed `Cylinder::samplePointInside()` and `ConvexMesh::containsPoint()` whose correct working is needed by the unit tests.