### PR TITLE
Apply clang-tidy fixes

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,25 @@
+---
+Checks:          '-*,
+                  performance-*,
+                  llvm-namespace-comment,
+                  modernize-redundant-void-arg,
+                  modernize-use-nullptr,
+                  modernize-use-default,
+                  modernize-use-override,
+                  modernize-loop-convert,
+                  readability-named-parameter,
+                  readability-redundant-smartptr-get,
+                  readability-redundant-string-cstr,
+                  readability-simplify-boolean-expr,
+                  readability-container-size-empty,
+                  '
+HeaderFilterRegex: ''
+AnalyzeTemporaryDtors: false
+CheckOptions:
+  - key:             llvm-namespace-comment.ShortNamespaceLines
+    value:           '10'
+  - key:             llvm-namespace-comment.SpacesBeforeComments
+    value:           '2'
+  - key:             readability-braces-around-statements.ShortStatementLines
+    value:           '2'
+...

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,8 @@ env:
 matrix:
   include:
     - compiler: clang
-      env: CXXFLAGS="-Wall -Wextra -Wwrite-strings -Wunreachable-code -Wpointer-arith -Wredundant-decls -Wno-unused-parameter -Wno-unused-function -Wno-overloaded-virtual"
+      env: TEST=clang-tidy-fix
+           CXXFLAGS="-Wall -Wextra -Wwrite-strings -Wunreachable-code -Wpointer-arith -Wredundant-decls -Wno-unused-parameter -Wno-unused-function -Wno-overloaded-virtual"
 
 before_script:
   - git clone -q --depth=1 https://github.com/ros-planning/moveit_ci.git .moveit_ci

--- a/src/bodies.cpp
+++ b/src/bodies.cpp
@@ -411,7 +411,7 @@ bool bodies::Cylinder::intersectsRay(const Eigen::Vector3d& origin, const Eigen:
       v1 = v1 - normalH_.dot(v1) * normalH_;
       if (v1.squaredNorm() < radius2_ + detail::ZERO)
       {
-        if (intersections == NULL)
+        if (intersections == nullptr)
           return true;
 
         detail::intersc ip(p1, t1);
@@ -427,7 +427,7 @@ bool bodies::Cylinder::intersectsRay(const Eigen::Vector3d& origin, const Eigen:
       v2 = v2 - normalH_.dot(v2) * normalH_;
       if (v2.squaredNorm() < radius2_ + detail::ZERO)
       {
-        if (intersections == NULL)
+        if (intersections == nullptr)
           return true;
 
         detail::intersc ip(p2, t2);
@@ -459,7 +459,7 @@ bool bodies::Cylinder::intersectsRay(const Eigen::Vector3d& origin, const Eigen:
 
         if (fabs(normalH_.dot(v1)) < length2_ + detail::ZERO)
         {
-          if (intersections == NULL)
+          if (intersections == nullptr)
             return true;
 
           detail::intersc ip(p1, t1);
@@ -474,7 +474,7 @@ bool bodies::Cylinder::intersectsRay(const Eigen::Vector3d& origin, const Eigen:
 
         if (fabs(normalH_.dot(v2)) < length2_ + detail::ZERO)
         {
-          if (intersections == NULL)
+          if (intersections == nullptr)
             return true;
           detail::intersc ip(p2, t2);
           ipts.push_back(ip);
@@ -1267,7 +1267,7 @@ const bodies::Body* bodies::BodyVector::getBody(unsigned int i) const
   if (i >= bodies_.size())
   {
     CONSOLE_BRIDGE_logError("There is no body at index %u", i);
-    return NULL;
+    return nullptr;
   }
   else
     return bodies_[i];

--- a/src/bodies.cpp
+++ b/src/bodies.cpp
@@ -514,10 +514,7 @@ bool bodies::Box::containsPoint(const Eigen::Vector3d& p, bool verbose) const
     return false;
 
   double pH = v.dot(normalH_);
-  if (fabs(pH) > height2_)
-    return false;
-
-  return true;
+  return fabs(pH) <= height2_;
 }
 
 void bodies::Box::useDimensions(const shapes::Shape* shape)  // (x, y, z) = (length, width, height)

--- a/src/bodies.cpp
+++ b/src/bodies.cpp
@@ -944,9 +944,9 @@ void bodies::ConvexMesh::computeScaledVerticesFromPlaneProjections()
   {
     Eigen::Vector3d v(mesh_data_->vertices_[i] - mesh_data_->mesh_center_);
     EigenSTL::vector_Vector3d projected_vertices;
-    for (unsigned int t = 0; t < vertex_to_tris[i].size(); ++t)
+    for (unsigned int t : vertex_to_tris[i])
     {
-      const Eigen::Vector4d& plane = mesh_data_->planes_[mesh_data_->plane_for_triangle_[vertex_to_tris[i][t]]];
+      const Eigen::Vector4d& plane = mesh_data_->planes_[mesh_data_->plane_for_triangle_[t]];
       Eigen::Vector3d plane_normal(plane.x(), plane.y(), plane.z());
       double d_scaled_padded =
           scale_ * plane.w() - (1 - scale_) * mesh_data_->mesh_center_.dot(plane_normal) - padding_;
@@ -968,9 +968,9 @@ void bodies::ConvexMesh::computeScaledVerticesFromPlaneProjections()
     else
     {
       Eigen::Vector3d sum(0, 0, 0);
-      for (unsigned int v = 0; v < projected_vertices.size(); ++v)
+      for (const Eigen::Vector3d& vertex : projected_vertices)
       {
-        sum += projected_vertices[v];
+        sum += vertex;
       }
       sum /= projected_vertices.size();
       scaled_vertices_storage_->at(i) = sum;
@@ -1226,8 +1226,8 @@ bodies::BodyVector::~BodyVector()
 
 void bodies::BodyVector::clear()
 {
-  for (unsigned int i = 0; i < bodies_.size(); i++)
-    delete bodies_[i];
+  for (auto& body : bodies_)
+    delete body;
   bodies_.clear();
 }
 

--- a/src/bodies.cpp
+++ b/src/bodies.cpp
@@ -103,8 +103,8 @@ struct interscOrder
     return a.time < b.time;
   }
 };
-}
-}
+}  // namespace detail
+}  // namespace bodies
 
 void bodies::Body::setDimensions(const shapes::Shape* shape)
 {

--- a/src/body_operations.cpp
+++ b/src/body_operations.cpp
@@ -122,7 +122,7 @@ Body* constructBodyFromMsgHelper(const T& shape_msg, const geometry_msgs::Pose& 
   }
   return nullptr;
 }
-}
+}  // namespace bodies
 
 bodies::Body* bodies::constructBodyFromMsg(const shapes::ShapeMsg& shape_msg, const geometry_msgs::Pose& pose)
 {

--- a/src/body_operations.cpp
+++ b/src/body_operations.cpp
@@ -145,9 +145,9 @@ void bodies::computeBoundingSphere(const std::vector<const bodies::Body*>& bodie
 
   // TODO - expand to all body types
   unsigned int vertex_count = 0;
-  for (unsigned int i = 0; i < bodies.size(); i++)
+  for (auto body : bodies)
   {
-    const bodies::ConvexMesh* conv = dynamic_cast<const bodies::ConvexMesh*>(bodies[i]);
+    const bodies::ConvexMesh* conv = dynamic_cast<const bodies::ConvexMesh*>(body);
     if (!conv)
       continue;
     for (unsigned int j = 0; j < conv->getScaledVertices().size(); j++, vertex_count++)
@@ -159,9 +159,9 @@ void bodies::computeBoundingSphere(const std::vector<const bodies::Body*>& bodie
   sphere.center = sum / (double)vertex_count;
 
   double max_dist_squared = 0.0;
-  for (unsigned int i = 0; i < bodies.size(); i++)
+  for (auto body : bodies)
   {
-    const bodies::ConvexMesh* conv = dynamic_cast<const bodies::ConvexMesh*>(bodies[i]);
+    const bodies::ConvexMesh* conv = dynamic_cast<const bodies::ConvexMesh*>(body);
     if (!conv)
       continue;
     for (unsigned int j = 0; j < conv->getScaledVertices().size(); j++)

--- a/src/body_operations.cpp
+++ b/src/body_operations.cpp
@@ -41,7 +41,7 @@
 
 bodies::Body* bodies::createBodyFromShape(const shapes::Shape* shape)
 {
-  Body* body = NULL;
+  Body* body = nullptr;
 
   if (shape)
     switch (shape->type)
@@ -120,7 +120,7 @@ Body* constructBodyFromMsgHelper(const T& shape_msg, const geometry_msgs::Pose& 
       return body;
     }
   }
-  return NULL;
+  return nullptr;
 }
 }
 

--- a/src/mesh_operations.cpp
+++ b/src/mesh_operations.cpp
@@ -222,7 +222,7 @@ Mesh* createMeshFromBinary(const char* buffer, std::size_t size, const Eigen::Ve
 
   // try to get a file extension
   std::string hint;
-  std::size_t pos = assimp_hint.find_last_of(".");
+  std::size_t pos = assimp_hint.find_last_of('.');
   if (pos != std::string::npos)
   {
     hint = assimp_hint.substr(pos + 1);

--- a/src/mesh_operations.cpp
+++ b/src/mesh_operations.cpp
@@ -102,8 +102,8 @@ struct ltLocalVertexIndex
     return p1.index < p2.index;
   }
 };
-}
-}
+}  // namespace
+}  // namespace detail
 
 Mesh* createMeshFromVertices(const EigenSTL::vector_Vector3d& vertices, const std::vector<unsigned int>& triangles)
 {
@@ -323,7 +323,7 @@ void extractMeshData(const aiScene* scene, const aiNode* node, const aiMatrix4x4
   for (unsigned int n = 0; n < node->mNumChildren; ++n)
     extractMeshData(scene, node->mChildren[n], transform, scale, vertices, triangles);
 }
-}
+}  // namespace
 
 Mesh* createMeshFromAsset(const aiScene* scene, const std::string& resource_name)
 {
@@ -641,7 +641,7 @@ inline void writeFloatToSTL(char*& ptr, double datad)
   memcpy(ptr, &data, sizeof(float));
   ptr += sizeof(float);
 }
-}
+}  // namespace
 
 void writeSTLBinary(const Mesh* mesh, std::vector<char>& buffer)
 {
@@ -683,4 +683,4 @@ void writeSTLBinary(const Mesh* mesh, std::vector<char>& buffer)
     ptr += 2;
   }
 }
-}
+}  // namespace shapes

--- a/src/mesh_operations.cpp
+++ b/src/mesh_operations.cpp
@@ -126,7 +126,7 @@ Mesh* createMeshFromVertices(const EigenSTL::vector_Vector3d& vertices, const st
 Mesh* createMeshFromVertices(const EigenSTL::vector_Vector3d& source)
 {
   if (source.size() < 3)
-    return NULL;
+    return nullptr;
 
   if (source.size() % 3 != 0)
     CONSOLE_BRIDGE_logError("The number of vertices to construct a mesh from is not divisible by 3. Probably "
@@ -217,7 +217,7 @@ Mesh* createMeshFromBinary(const char* buffer, std::size_t size, const Eigen::Ve
   if (!buffer || size < 1)
   {
     CONSOLE_BRIDGE_logWarn("Cannot construct mesh from empty binary buffer");
-    return NULL;
+    return nullptr;
   }
 
   // try to get a file extension
@@ -248,7 +248,7 @@ Mesh* createMeshFromBinary(const char* buffer, std::size_t size, const Eigen::Ve
                                                          aiProcess_SortByPType | aiProcess_RemoveComponent,
                                                      hint.c_str());
   if (!scene)
-    return NULL;
+    return nullptr;
 
   // Assimp enforces Y_UP convention by rotating models with different conventions.
   // However, that behaviour is confusing and doesn't match the ROS convention
@@ -275,13 +275,13 @@ Mesh* createMeshFromResource(const std::string& resource, const Eigen::Vector3d&
   catch (resource_retriever::Exception& e)
   {
     CONSOLE_BRIDGE_logError("%s", e.what());
-    return NULL;
+    return nullptr;
   }
 
   if (res.size == 0)
   {
     CONSOLE_BRIDGE_logWarn("Retrieved empty mesh for resource '%s'", resource.c_str());
-    return NULL;
+    return nullptr;
   }
 
   Mesh* m = createMeshFromBinary(reinterpret_cast<const char*>(res.data.get()), res.size, scale, resource);
@@ -336,7 +336,7 @@ Mesh* createMeshFromAsset(const aiScene* scene, const Eigen::Vector3d& scale, co
   if (!scene->HasMeshes())
   {
     CONSOLE_BRIDGE_logWarn("Assimp reports scene in %s has no meshes", resource_name.c_str());
-    return NULL;
+    return nullptr;
   }
   EigenSTL::vector_Vector3d vertices;
   std::vector<unsigned int> triangles;
@@ -344,12 +344,12 @@ Mesh* createMeshFromAsset(const aiScene* scene, const Eigen::Vector3d& scale, co
   if (vertices.empty())
   {
     CONSOLE_BRIDGE_logWarn("There are no vertices in the scene %s", resource_name.c_str());
-    return NULL;
+    return nullptr;
   }
   if (triangles.empty())
   {
     CONSOLE_BRIDGE_logWarn("There are no triangles in the scene %s", resource_name.c_str());
-    return NULL;
+    return nullptr;
   }
 
   return createMeshFromVertices(vertices, triangles);
@@ -367,7 +367,7 @@ Mesh* createMeshFromShape(const Shape* shape)
     return shapes::createMeshFromShape(static_cast<const shapes::Cone&>(*shape));
   else
     CONSOLE_BRIDGE_logError("Conversion of shape of type '%s' to a mesh is not known", shapeStringName(shape).c_str());
-  return NULL;
+  return nullptr;
 }
 
 Mesh* createMeshFromShape(const Box& box)

--- a/src/shape_extents.cpp
+++ b/src/shape_extents.cpp
@@ -80,7 +80,7 @@ void geometric_shapes::getShapeExtents(const shape_msgs::Mesh& shape_msg, double
                                        double& z_extent)
 {
   x_extent = y_extent = z_extent = 0.0;
-  if (shape_msg.vertices.size() > 0)
+  if (!shape_msg.vertices.empty())
   {
     double xmin = std::numeric_limits<double>::max(), ymin = std::numeric_limits<double>::max(),
            zmin = std::numeric_limits<double>::max();

--- a/src/shape_extents.cpp
+++ b/src/shape_extents.cpp
@@ -86,20 +86,20 @@ void geometric_shapes::getShapeExtents(const shape_msgs::Mesh& shape_msg, double
            zmin = std::numeric_limits<double>::max();
     double xmax = -std::numeric_limits<double>::max(), ymax = -std::numeric_limits<double>::max(),
            zmax = -std::numeric_limits<double>::max();
-    for (std::size_t i = 0; i < shape_msg.vertices.size(); ++i)
+    for (const geometry_msgs::Point& vertex : shape_msg.vertices)
     {
-      if (shape_msg.vertices[i].x > xmax)
-        xmax = shape_msg.vertices[i].x;
-      if (shape_msg.vertices[i].x < xmin)
-        xmin = shape_msg.vertices[i].x;
-      if (shape_msg.vertices[i].y > ymax)
-        ymax = shape_msg.vertices[i].y;
-      if (shape_msg.vertices[i].y < ymin)
-        ymin = shape_msg.vertices[i].y;
-      if (shape_msg.vertices[i].z > zmax)
-        zmax = shape_msg.vertices[i].z;
-      if (shape_msg.vertices[i].z < zmin)
-        zmin = shape_msg.vertices[i].z;
+      if (vertex.x > xmax)
+        xmax = vertex.x;
+      if (vertex.x < xmin)
+        xmin = vertex.x;
+      if (vertex.y > ymax)
+        ymax = vertex.y;
+      if (vertex.y < ymin)
+        ymin = vertex.y;
+      if (vertex.z > zmax)
+        zmax = vertex.z;
+      if (vertex.z < zmin)
+        zmin = vertex.z;
     }
     x_extent = xmax - xmin;
     y_extent = ymax - ymin;

--- a/src/shape_operations.cpp
+++ b/src/shape_operations.cpp
@@ -138,7 +138,7 @@ public:
     return constructShapeFromMsg(shape_msg);
   }
 };
-}
+}  // namespace
 
 Shape* constructShapeFromMsg(const ShapeMsg& shape_msg)
 {
@@ -174,7 +174,7 @@ private:
   bool use_mesh_triangle_list_;
   visualization_msgs::Marker* marker_;
 };
-}
+}  // namespace
 
 bool constructMarkerFromShape(const Shape* shape, visualization_msgs::Marker& marker, bool use_mesh_triangle_list)
 {
@@ -224,7 +224,7 @@ public:
     return e;
   }
 };
-}
+}  // namespace
 
 Eigen::Vector3d computeShapeExtents(const ShapeMsg& shape_msg)
 {
@@ -577,4 +577,4 @@ const std::string& shapeStringName(const Shape* shape)
     return empty;
   }
 }
-}
+}  // namespace shapes

--- a/src/shape_operations.cpp
+++ b/src/shape_operations.cpp
@@ -62,7 +62,7 @@ Shape* constructShapeFromMsg(const shape_msgs::Mesh& shape_msg)
   if (shape_msg.triangles.empty() || shape_msg.vertices.empty())
   {
     CONSOLE_BRIDGE_logWarn("Mesh definition is empty");
-    return NULL;
+    return nullptr;
   }
   else
   {
@@ -83,7 +83,7 @@ Shape* constructShapeFromMsg(const shape_msgs::Mesh& shape_msg)
 
 Shape* constructShapeFromMsg(const shape_msgs::SolidPrimitive& shape_msg)
 {
-  Shape* shape = NULL;
+  Shape* shape = nullptr;
   if (shape_msg.type == shape_msgs::SolidPrimitive::SPHERE)
   {
     if (shape_msg.dimensions.size() > shape_msgs::SolidPrimitive::SPHERE_RADIUS)
@@ -112,7 +112,7 @@ Shape* constructShapeFromMsg(const shape_msgs::SolidPrimitive& shape_msg)
       shape = new Cone(shape_msg.dimensions[shape_msgs::SolidPrimitive::CONE_RADIUS],
                        shape_msg.dimensions[shape_msgs::SolidPrimitive::CONE_HEIGHT]);
   }
-  if (shape == NULL)
+  if (shape == nullptr)
     CONSOLE_BRIDGE_logError("Unable to construct shape corresponding to shape_msg of type %d", (int)shape_msg.type);
 
   return shape;
@@ -485,7 +485,7 @@ void saveAsText(const Shape* shape, std::ostream& out)
 
 Shape* constructShapeFromText(std::istream& in)
 {
-  Shape* result = NULL;
+  Shape* result = nullptr;
   if (in.good() && !in.eof())
   {
     std::string type;

--- a/src/shapes.cpp
+++ b/src/shapes.cpp
@@ -149,11 +149,11 @@ Mesh::Mesh() : Shape()
 {
   type = MESH;
   vertex_count = 0;
-  vertices = NULL;
+  vertices = nullptr;
   triangle_count = 0;
-  triangles = NULL;
-  triangle_normals = NULL;
-  vertex_normals = NULL;
+  triangles = nullptr;
+  triangle_normals = nullptr;
+  vertex_normals = nullptr;
 }
 
 Mesh::Mesh(unsigned int v_count, unsigned int t_count) : Shape()
@@ -236,7 +236,7 @@ Mesh* Mesh::clone() const
   else
   {
     delete[] dest->vertex_normals;
-    dest->vertex_normals = NULL;
+    dest->vertex_normals = nullptr;
   }
   n = 3 * triangle_count;
   for (unsigned int i = 0; i < n; ++i)
@@ -247,7 +247,7 @@ Mesh* Mesh::clone() const
   else
   {
     delete[] dest->triangle_normals;
-    dest->triangle_normals = NULL;
+    dest->triangle_normals = nullptr;
   }
   return dest;
 }

--- a/test/test_create_mesh.cpp
+++ b/test/test_create_mesh.cpp
@@ -67,7 +67,7 @@ shapes::Mesh* loadMesh(const std::string& mesh)
   std::string path = "file://" + std::string(TEST_RESOURCES_DIR) + "/" + mesh;
   return shapes::createMeshFromResource(path);
 }
-}
+}  // namespace
 
 TEST(CreateMesh, stl)
 {

--- a/test/test_create_mesh.cpp
+++ b/test/test_create_mesh.cpp
@@ -43,7 +43,7 @@ namespace
 {
 void assertMesh(shapes::Mesh* mesh)
 {
-  ASSERT_TRUE(mesh != NULL);
+  ASSERT_TRUE(mesh != nullptr);
   ASSERT_EQ(3, mesh->vertex_count);
   ASSERT_EQ(1, mesh->triangle_count);
 

--- a/test/test_loaded_meshes.cpp
+++ b/test/test_loaded_meshes.cpp
@@ -146,7 +146,7 @@ TEST_F(CompareMeshVsPrimitive, IntersectsRay)
       //    }
 
       EXPECT_EQ(vi1.size(), vi2.size());
-      if (vi1.size() > 0 && vi2.size() > 0)
+      if (!vi1.empty() && !vi2.empty())
       {
         EXPECT_NEAR(vi1[0].x(), vi2[0].x(), 0.01);
         EXPECT_NEAR(vi1[0].y(), vi2[0].y(), 0.01);

--- a/test/test_point_inclusion.cpp
+++ b/test/test_point_inclusion.cpp
@@ -510,7 +510,7 @@ TEST(MeshPointContainment, Basic)
   // clang-format off
   shapes::Mesh *ms = shapes::createMeshFromResource("file://" +
     (boost::filesystem::path(TEST_RESOURCES_DIR) / "/box.dae").string());
-  ASSERT_TRUE(ms != NULL);
+  ASSERT_TRUE(ms != nullptr);
   bodies::ConvexMesh cubeMesh(ms);
 
   // zero
@@ -576,9 +576,9 @@ TEST(MeshPointContainment, Pr2Forearm)
 {
   shapes::Mesh* ms = shapes::createMeshFromResource(
       "file://" + (boost::filesystem::path(TEST_RESOURCES_DIR) / "/forearm_roll.stl").string());
-  ASSERT_TRUE(ms != NULL);
+  ASSERT_TRUE(ms != nullptr);
   bodies::Body* m = new bodies::ConvexMesh(ms);
-  ASSERT_TRUE(m != NULL);
+  ASSERT_TRUE(m != nullptr);
   Eigen::Isometry3d t(Eigen::Isometry3d::Identity());
   t.translation().x() = 1.0;
   EXPECT_FALSE(m->cloneAt(t)->containsPoint(-1.0, 0.0, 0.0));


### PR DESCRIPTION
Apply the most important clang-tidy fixes. I just dropped the naming conventions of MoveIt, because they are not followed in this rep.