### PR TITLE
Suppress warnings

### DIFF
--- a/test/test_create_mesh.cpp
+++ b/test/test_create_mesh.cpp
@@ -44,12 +44,12 @@ namespace
 void assertMesh(shapes::Mesh* mesh)
 {
   ASSERT_TRUE(mesh != nullptr);
-  ASSERT_EQ(3, mesh->vertex_count);
-  ASSERT_EQ(1, mesh->triangle_count);
+  ASSERT_EQ((size_t)3, mesh->vertex_count);
+  ASSERT_EQ((size_t)1, mesh->triangle_count);
 
-  ASSERT_EQ(0, mesh->triangles[0]);
-  ASSERT_EQ(1, mesh->triangles[1]);
-  ASSERT_EQ(2, mesh->triangles[2]);
+  ASSERT_EQ((size_t)0, mesh->triangles[0]);
+  ASSERT_EQ((size_t)1, mesh->triangles[1]);
+  ASSERT_EQ((size_t)2, mesh->triangles[2]);
 
   ASSERT_FLOAT_EQ(0, mesh->vertices[0 + 0]);
   ASSERT_FLOAT_EQ(0, mesh->vertices[0 + 1]);

--- a/test/test_loaded_meshes.cpp
+++ b/test/test_loaded_meshes.cpp
@@ -68,7 +68,7 @@ public:
 
   void TearDown() override
   {
-    for (int i = 0; i < shape_meshes.size(); ++i)
+    for (size_t i = 0; i < shape_meshes.size(); ++i)
     {
       delete shape_meshes[i];
       delete loaded_meshes[i];
@@ -95,7 +95,7 @@ protected:
 TEST_F(CompareMeshVsPrimitive, ContainsPoint)
 {
   // Any point inside a mesh must be inside the other too
-  for (int i = 0; i < shape_meshes.size(); ++i)
+  for (size_t i = 0; i < shape_meshes.size(); ++i)
   {
     shapes::Mesh* shape_ms = shape_meshes[i];
     shapes::Mesh* loaded_ms = loaded_meshes[i];
@@ -120,7 +120,7 @@ TEST_F(CompareMeshVsPrimitive, ContainsPoint)
 TEST_F(CompareMeshVsPrimitive, IntersectsRay)
 {
   // Random rays must intersect both meshes nearly at the same points
-  for (int i = 0; i < shape_meshes.size(); ++i)
+  for (size_t i = 0; i < shape_meshes.size(); ++i)
   {
     shapes::Mesh* shape_ms = shape_meshes[i];
     shapes::Mesh* loaded_ms = loaded_meshes[i];
@@ -163,7 +163,7 @@ TEST_F(CompareMeshVsPrimitive, IntersectsRay)
 TEST_F(CompareMeshVsPrimitive, BoundingSphere)
 {
   // Bounding spheres must be nearly identical
-  for (int i = 0; i < shape_meshes.size(); ++i)
+  for (size_t i = 0; i < shape_meshes.size(); ++i)
   {
     shapes::Mesh* shape_ms = shape_meshes[i];
     shapes::Mesh* loaded_ms = loaded_meshes[i];

--- a/test/test_loaded_meshes.cpp
+++ b/test/test_loaded_meshes.cpp
@@ -97,9 +97,6 @@ TEST_F(CompareMeshVsPrimitive, ContainsPoint)
   // Any point inside a mesh must be inside the other too
   for (size_t i = 0; i < shape_meshes.size(); ++i)
   {
-    shapes::Mesh* shape_ms = shape_meshes[i];
-    shapes::Mesh* loaded_ms = loaded_meshes[i];
-
     bodies::Body* shape_cms = shape_convex_meshes[i];
     bodies::Body* loaded_cms = loaded_convex_meshes[i];
 
@@ -122,9 +119,6 @@ TEST_F(CompareMeshVsPrimitive, IntersectsRay)
   // Random rays must intersect both meshes nearly at the same points
   for (size_t i = 0; i < shape_meshes.size(); ++i)
   {
-    shapes::Mesh* shape_ms = shape_meshes[i];
-    shapes::Mesh* loaded_ms = loaded_meshes[i];
-
     bodies::Body* shape_cms = shape_convex_meshes[i];
     bodies::Body* loaded_cms = loaded_convex_meshes[i];
 
@@ -167,9 +161,6 @@ TEST_F(CompareMeshVsPrimitive, BoundingSphere)
   {
     shapes::Mesh* shape_ms = shape_meshes[i];
     shapes::Mesh* loaded_ms = loaded_meshes[i];
-
-    bodies::Body* shape_cms = shape_convex_meshes[i];
-    bodies::Body* loaded_cms = loaded_convex_meshes[i];
 
     shapes::Sphere shape(1.0);
     Eigen::Vector3d center1, center2;

--- a/test/test_point_inclusion.cpp
+++ b/test/test_point_inclusion.cpp
@@ -241,7 +241,6 @@ TEST(BoxPointContainment, Basic)
   EXPECT_FALSE(box.containsPoint(Eigen::Vector3d(0.00, 1.01, 1.01)));
 
   // near three-axis maximum
-  const double sq3 = sqrt(3) / 3;
   EXPECT_TRUE( box.containsPoint(Eigen::Vector3d(0.99, 0.99, 0.99)));
   EXPECT_SURF( box.containsPoint(Eigen::Vector3d(1.00, 1.00, 1.00)));
   EXPECT_FALSE(box.containsPoint(Eigen::Vector3d(1.01, 1.01, 1.01)));
@@ -541,7 +540,6 @@ TEST(MeshPointContainment, Basic)
   EXPECT_FALSE(cubeMesh.containsPoint(Eigen::Vector3d(0.00, 1.01, 1.01)));
 
   // near three-axis maximum
-  const double sq3 = sqrt(3) / 3;
   EXPECT_TRUE( cubeMesh.containsPoint(Eigen::Vector3d(0.99, 0.99, 0.99)));
   EXPECT_SURF( cubeMesh.containsPoint(Eigen::Vector3d(1.00, 1.00, 1.00)));
   EXPECT_FALSE(cubeMesh.containsPoint(Eigen::Vector3d(1.01, 1.01, 1.01)));


### PR DESCRIPTION
This PR intends to suppress `-Wsign-compare` and `Wunused-variable` warnings showing up moveit [CI result](https://travis-ci.org/ros-planning/moveit/jobs/610040749#L1264) when compiling moveit_core.