### PR TITLE
code coverage reporting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ env:
   matrix:
     - TEST="clang-format, catkin_lint"
     - ROS_DISTRO=kinetic
-    - ROS_DISTRO=melodic
+    - ROS_DISTRO=melodic  TEST=code-coverage
 
 matrix:
   include:


### PR DESCRIPTION
The test type `code-coverage` has been merged into moveit_ci.  This is ready for use.