### PR TITLE
struct SolidPrimitiveDimCount -> function solidPrimitiveDimCount()

### DIFF
--- a/include/geometric_shapes/solid_primitive_dims.h
+++ b/include/geometric_shapes/solid_primitive_dims.h
@@ -38,49 +38,31 @@
 
 namespace geometric_shapes
 {
-/** \brief The number of dimensions of a particular shape */
+/** Get the number of dimensions of a particular shape */
 template <int>
-struct SolidPrimitiveDimCount
-{
-  enum
-  {
-    value = 0u
-  };
-};
+constexpr unsigned int solidPrimitiveDimCount();
 
 template <>
-struct SolidPrimitiveDimCount<shape_msgs::SolidPrimitive::SPHERE>
+constexpr unsigned int solidPrimitiveDimCount<shape_msgs::SolidPrimitive::SPHERE>()
 {
-  enum
-  {
-    value = 1u
-  };
-};
+  return 1u;
+}
 
 template <>
-struct SolidPrimitiveDimCount<shape_msgs::SolidPrimitive::BOX>
+constexpr unsigned int solidPrimitiveDimCount<shape_msgs::SolidPrimitive::BOX>()
 {
-  enum
-  {
-    value = 3u
-  };
-};
+  return 3u;
+}
 
 template <>
-struct SolidPrimitiveDimCount<shape_msgs::SolidPrimitive::CONE>
+constexpr unsigned int solidPrimitiveDimCount<shape_msgs::SolidPrimitive::CYLINDER>()
 {
-  enum
-  {
-    value = 2u
-  };
-};
+  return 2u;
+}
 
 template <>
-struct SolidPrimitiveDimCount<shape_msgs::SolidPrimitive::CYLINDER>
+constexpr unsigned int solidPrimitiveDimCount<shape_msgs::SolidPrimitive::CONE>()
 {
-  enum
-  {
-    value = 2u
-  };
-};
+  return 2u;
+}
 }

--- a/src/shape_extents.cpp
+++ b/src/shape_extents.cpp
@@ -43,13 +43,12 @@ void geometric_shapes::getShapeExtents(const shape_msgs::SolidPrimitive& shape_m
 
   if (shape_msg.type == shape_msgs::SolidPrimitive::SPHERE)
   {
-    if (shape_msg.dimensions.size() >=
-        geometric_shapes::SolidPrimitiveDimCount<shape_msgs::SolidPrimitive::SPHERE>::value)
+    if (shape_msg.dimensions.size() >= geometric_shapes::solidPrimitiveDimCount<shape_msgs::SolidPrimitive::SPHERE>())
       x_extent = y_extent = z_extent = shape_msg.dimensions[shape_msgs::SolidPrimitive::SPHERE_RADIUS] * 2.0;
   }
   else if (shape_msg.type == shape_msgs::SolidPrimitive::BOX)
   {
-    if (shape_msg.dimensions.size() >= geometric_shapes::SolidPrimitiveDimCount<shape_msgs::SolidPrimitive::BOX>::value)
+    if (shape_msg.dimensions.size() >= geometric_shapes::solidPrimitiveDimCount<shape_msgs::SolidPrimitive::BOX>())
     {
       x_extent = shape_msg.dimensions[shape_msgs::SolidPrimitive::BOX_X];
       y_extent = shape_msg.dimensions[shape_msgs::SolidPrimitive::BOX_Y];
@@ -58,8 +57,7 @@ void geometric_shapes::getShapeExtents(const shape_msgs::SolidPrimitive& shape_m
   }
   else if (shape_msg.type == shape_msgs::SolidPrimitive::CYLINDER)
   {
-    if (shape_msg.dimensions.size() >=
-        geometric_shapes::SolidPrimitiveDimCount<shape_msgs::SolidPrimitive::CYLINDER>::value)
+    if (shape_msg.dimensions.size() >= geometric_shapes::solidPrimitiveDimCount<shape_msgs::SolidPrimitive::CYLINDER>())
     {
       x_extent = y_extent = shape_msg.dimensions[shape_msgs::SolidPrimitive::CYLINDER_RADIUS] * 2.0;
       z_extent = shape_msg.dimensions[shape_msgs::SolidPrimitive::CYLINDER_HEIGHT];
@@ -67,8 +65,7 @@ void geometric_shapes::getShapeExtents(const shape_msgs::SolidPrimitive& shape_m
   }
   else if (shape_msg.type == shape_msgs::SolidPrimitive::CONE)
   {
-    if (shape_msg.dimensions.size() >=
-        geometric_shapes::SolidPrimitiveDimCount<shape_msgs::SolidPrimitive::CONE>::value)
+    if (shape_msg.dimensions.size() >= geometric_shapes::solidPrimitiveDimCount<shape_msgs::SolidPrimitive::CONE>())
     {
       x_extent = y_extent = shape_msg.dimensions[shape_msgs::SolidPrimitive::CONE_RADIUS] * 2.0;
       z_extent = shape_msg.dimensions[shape_msgs::SolidPrimitive::CONE_HEIGHT];

--- a/src/shape_operations.cpp
+++ b/src/shape_operations.cpp
@@ -86,28 +86,25 @@ Shape* constructShapeFromMsg(const shape_msgs::SolidPrimitive& shape_msg)
   Shape* shape = nullptr;
   if (shape_msg.type == shape_msgs::SolidPrimitive::SPHERE)
   {
-    if (shape_msg.dimensions.size() >=
-        geometric_shapes::SolidPrimitiveDimCount<shape_msgs::SolidPrimitive::SPHERE>::value)
+    if (shape_msg.dimensions.size() >= geometric_shapes::solidPrimitiveDimCount<shape_msgs::SolidPrimitive::SPHERE>())
       shape = new Sphere(shape_msg.dimensions[shape_msgs::SolidPrimitive::SPHERE_RADIUS]);
   }
   else if (shape_msg.type == shape_msgs::SolidPrimitive::BOX)
   {
-    if (shape_msg.dimensions.size() >= geometric_shapes::SolidPrimitiveDimCount<shape_msgs::SolidPrimitive::BOX>::value)
+    if (shape_msg.dimensions.size() >= geometric_shapes::solidPrimitiveDimCount<shape_msgs::SolidPrimitive::BOX>())
       shape = new Box(shape_msg.dimensions[shape_msgs::SolidPrimitive::BOX_X],
                       shape_msg.dimensions[shape_msgs::SolidPrimitive::BOX_Y],
                       shape_msg.dimensions[shape_msgs::SolidPrimitive::BOX_Z]);
   }
   else if (shape_msg.type == shape_msgs::SolidPrimitive::CYLINDER)
   {
-    if (shape_msg.dimensions.size() >=
-        geometric_shapes::SolidPrimitiveDimCount<shape_msgs::SolidPrimitive::CYLINDER>::value)
+    if (shape_msg.dimensions.size() >= geometric_shapes::solidPrimitiveDimCount<shape_msgs::SolidPrimitive::CYLINDER>())
       shape = new Cylinder(shape_msg.dimensions[shape_msgs::SolidPrimitive::CYLINDER_RADIUS],
                            shape_msg.dimensions[shape_msgs::SolidPrimitive::CYLINDER_HEIGHT]);
   }
   else if (shape_msg.type == shape_msgs::SolidPrimitive::CONE)
   {
-    if (shape_msg.dimensions.size() >=
-        geometric_shapes::SolidPrimitiveDimCount<shape_msgs::SolidPrimitive::CONE>::value)
+    if (shape_msg.dimensions.size() >= geometric_shapes::solidPrimitiveDimCount<shape_msgs::SolidPrimitive::CONE>())
       shape = new Cone(shape_msg.dimensions[shape_msgs::SolidPrimitive::CONE_RADIUS],
                        shape_msg.dimensions[shape_msgs::SolidPrimitive::CONE_HEIGHT]);
   }
@@ -352,7 +349,7 @@ bool constructMsgFromShape(const Shape* shape, ShapeMsg& shape_msg)
   {
     shape_msgs::SolidPrimitive s;
     s.type = shape_msgs::SolidPrimitive::SPHERE;
-    s.dimensions.resize(geometric_shapes::SolidPrimitiveDimCount<shape_msgs::SolidPrimitive::SPHERE>::value);
+    s.dimensions.resize(geometric_shapes::solidPrimitiveDimCount<shape_msgs::SolidPrimitive::SPHERE>());
     s.dimensions[shape_msgs::SolidPrimitive::SPHERE_RADIUS] = static_cast<const Sphere*>(shape)->radius;
     shape_msg = s;
   }
@@ -361,7 +358,7 @@ bool constructMsgFromShape(const Shape* shape, ShapeMsg& shape_msg)
     shape_msgs::SolidPrimitive s;
     s.type = shape_msgs::SolidPrimitive::BOX;
     const double* sz = static_cast<const Box*>(shape)->size;
-    s.dimensions.resize(geometric_shapes::SolidPrimitiveDimCount<shape_msgs::SolidPrimitive::BOX>::value);
+    s.dimensions.resize(geometric_shapes::solidPrimitiveDimCount<shape_msgs::SolidPrimitive::BOX>());
     s.dimensions[shape_msgs::SolidPrimitive::BOX_X] = sz[0];
     s.dimensions[shape_msgs::SolidPrimitive::BOX_Y] = sz[1];
     s.dimensions[shape_msgs::SolidPrimitive::BOX_Z] = sz[2];
@@ -371,7 +368,7 @@ bool constructMsgFromShape(const Shape* shape, ShapeMsg& shape_msg)
   {
     shape_msgs::SolidPrimitive s;
     s.type = shape_msgs::SolidPrimitive::CYLINDER;
-    s.dimensions.resize(geometric_shapes::SolidPrimitiveDimCount<shape_msgs::SolidPrimitive::CYLINDER>::value);
+    s.dimensions.resize(geometric_shapes::solidPrimitiveDimCount<shape_msgs::SolidPrimitive::CYLINDER>());
     s.dimensions[shape_msgs::SolidPrimitive::CYLINDER_RADIUS] = static_cast<const Cylinder*>(shape)->radius;
     s.dimensions[shape_msgs::SolidPrimitive::CYLINDER_HEIGHT] = static_cast<const Cylinder*>(shape)->length;
     shape_msg = s;
@@ -380,7 +377,7 @@ bool constructMsgFromShape(const Shape* shape, ShapeMsg& shape_msg)
   {
     shape_msgs::SolidPrimitive s;
     s.type = shape_msgs::SolidPrimitive::CONE;
-    s.dimensions.resize(geometric_shapes::SolidPrimitiveDimCount<shape_msgs::SolidPrimitive::CONE>::value);
+    s.dimensions.resize(geometric_shapes::solidPrimitiveDimCount<shape_msgs::SolidPrimitive::CONE>());
     s.dimensions[shape_msgs::SolidPrimitive::CONE_RADIUS] = static_cast<const Cone*>(shape)->radius;
     s.dimensions[shape_msgs::SolidPrimitive::CONE_HEIGHT] = static_cast<const Cone*>(shape)->length;
     shape_msg = s;

--- a/src/shape_to_marker.cpp
+++ b/src/shape_to_marker.cpp
@@ -43,8 +43,7 @@ void geometric_shapes::constructMarkerFromShape(const shape_msgs::SolidPrimitive
   switch (shape_msg.type)
   {
     case shape_msgs::SolidPrimitive::SPHERE:
-      if (shape_msg.dimensions.size() <
-          geometric_shapes::SolidPrimitiveDimCount<shape_msgs::SolidPrimitive::SPHERE>::value)
+      if (shape_msg.dimensions.size() < geometric_shapes::solidPrimitiveDimCount<shape_msgs::SolidPrimitive::SPHERE>())
         throw std::runtime_error("Insufficient dimensions in sphere definition");
       else
       {
@@ -53,8 +52,7 @@ void geometric_shapes::constructMarkerFromShape(const shape_msgs::SolidPrimitive
       }
       break;
     case shape_msgs::SolidPrimitive::BOX:
-      if (shape_msg.dimensions.size() <
-          geometric_shapes::SolidPrimitiveDimCount<shape_msgs::SolidPrimitive::BOX>::value)
+      if (shape_msg.dimensions.size() < geometric_shapes::solidPrimitiveDimCount<shape_msgs::SolidPrimitive::BOX>())
         throw std::runtime_error("Insufficient dimensions in box definition");
       else
       {
@@ -65,8 +63,7 @@ void geometric_shapes::constructMarkerFromShape(const shape_msgs::SolidPrimitive
       }
       break;
     case shape_msgs::SolidPrimitive::CONE:
-      if (shape_msg.dimensions.size() <
-          geometric_shapes::SolidPrimitiveDimCount<shape_msgs::SolidPrimitive::CONE>::value)
+      if (shape_msg.dimensions.size() < geometric_shapes::solidPrimitiveDimCount<shape_msgs::SolidPrimitive::CONE>())
         throw std::runtime_error("Insufficient dimensions in cone definition");
       else
       {
@@ -79,7 +76,7 @@ void geometric_shapes::constructMarkerFromShape(const shape_msgs::SolidPrimitive
       break;
     case shape_msgs::SolidPrimitive::CYLINDER:
       if (shape_msg.dimensions.size() <
-          geometric_shapes::SolidPrimitiveDimCount<shape_msgs::SolidPrimitive::CYLINDER>::value)
+          geometric_shapes::solidPrimitiveDimCount<shape_msgs::SolidPrimitive::CYLINDER>())
         throw std::runtime_error("Insufficient dimensions in cylinder definition");
       else
       {


### PR DESCRIPTION
As suggested in https://github.com/ros-planning/geometric_shapes/pull/119#pullrequestreview-317913368, further simplify `SolidPrimitiveDimCount` by introducing a `constexpr` function.