### PR TITLE
Resolve octomap dependency with rosdep

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,6 @@ env:
     - UPSTREAM_WORKSPACE=geometric_shapes.repos
     - CXXFLAGS="-Wall -Wextra -Wwrite-strings -Wunreachable-code -Wpointer-arith -Wredundant-decls -Wno-unused-parameter"
     - WARNINGS_OK=false
-    - BEFORE_DOCKER_SCRIPT="sed -i 's/travis_run --retry rosdep install/#rosdep install/g' .moveit_ci/travis.sh"
   matrix:
     - TEST="clang-format, ament_lint"
     - ROS_DISTRO=dashing

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,7 +68,7 @@ ament_target_dependencies(${PROJECT_NAME}
   geometry_msgs
   resource_retriever
   console_bridge
-  OCTOMAP
+  octomap
   ASSIMP
   QHULL
 )

--- a/geometric_shapes.repos
+++ b/geometric_shapes.repos
@@ -7,7 +7,3 @@ repositories:
     type: git
     url: https://github.com/ros-planning/random_numbers
     version: ros2
-  octomap:
-    type: git
-    url: https://github.com/ros-gbp/octomap-release.git
-    version: debian/ros-melodic-octomap_1.9.0-1_bionic


### PR DESCRIPTION
As this should also work for Eloquent, should we rename `dashing-devel` to `ros2`?