### PR TITLE
Improve performance of bodies::setPose()

### DIFF
--- a/include/geometric_shapes/bodies.h
+++ b/include/geometric_shapes/bodies.h
@@ -71,9 +71,35 @@ struct BoundingCylinder
   Eigen::Isometry3d pose;
   double radius;
   double length;
-
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 };
+
+// To be able to use the more efficient Eigen::Transform::linear() instead of rotation(),
+// we need to check the user has really passed an isometry. To avoid runtime costs,
+// this check is only done as assert, which get compiled-out in release builds
+#ifdef NDEBUG
+#define ASSERT_ISOMETRY(transform) assert(true);
+#else
+inline void checkIsometry(const Eigen::Isometry3d& transform)
+{
+  if (!transform.matrix().row(3).isApprox(Eigen::Vector4d::UnitW().transpose()))
+  {
+    std::cerr << "The given transform is not an isometry! It's last row is: " << std::endl
+              << transform.matrix().row(3) << std::endl;
+    assert(!"Invalid isometry transform");
+  }
+
+  Eigen::Isometry3d::LinearMatrixType scale;
+  transform.computeRotationScaling((Eigen::Isometry3d::LinearMatrixType*)nullptr, &scale);
+  if (!scale.isApprox(Eigen::Matrix3d::Identity()))
+  {
+    std::cerr << "The given transform is not an isometry! It's linear part involves scaling: " << std::endl
+              << scale.diagonal().transpose() << std::endl;
+    assert(!"Invalid isometry transform");
+  }
+}
+#define ASSERT_ISOMETRY(transform) ::bodies::checkIsometry(transform);
+#endif
 
 class Body;
 

--- a/include/geometric_shapes/bodies.h
+++ b/include/geometric_shapes/bodies.h
@@ -104,11 +104,24 @@ public:
     return type_;
   }
 
+  /**
+   * \brief If the dimension of the body should be scaled, this method sets the scale.
+   * \note This is the dirty version of the function which does not update internal data that depend on the scale.
+   *       In the general case, you should call setScale() instead. Only call this function if you have a series of
+   *       calls like setScale/setPadding/setPose/setDimensions and you want to avoid the overhead of updating the
+   *       internal structures after each call. When you are finished with the batch, call updateInternalData().
+   * \param scale The scale to set. 1.0 means no scaling.
+   */
+  void setScaleDirty(double scale)
+  {
+    scale_ = scale;
+  }
+
   /** \brief If the dimension of the body should be scaled, this
       method sets the scale. Default is 1.0 */
   void setScale(double scale)
   {
-    scale_ = scale;
+    setScaleDirty(scale);
     updateInternalData();
   }
 
@@ -118,11 +131,24 @@ public:
     return scale_;
   }
 
+  /**
+   * \brief If the dimension of the body should be padded, this method sets the pading.
+   * \note This is the dirty version of the function which does not update internal data that depend on the scale.
+   *       In the general case, you should call setPadding() instead. Only call this function if you have a series of
+   *       calls like setScale/setPadding/setPose/setDimensions and you want to avoid the overhead of updating the
+   *       internal structures after each call. When you are finished with the batch, call updateInternalData().
+   * \param padd The padding to set (in meters). 0.0 means no padding.
+   */
+  void setPaddingDirty(double padd)
+  {
+    padding_ = padd;
+  }
+
   /** \brief If constant padding should be added to the body, this
       method sets the padding. Default is 0.0 */
   void setPadding(double padd)
   {
-    padding_ = padd;
+    setPaddingDirty(padd);
     updateInternalData();
   }
 
@@ -132,10 +158,23 @@ public:
     return padding_;
   }
 
+  /**
+   * \brief Set the pose of the body.
+   * \note This is the dirty version of the function which does not update internal data that depend on the pose.
+   *       In the general case, you should call setPose() instead. Only call this function if you have a series of
+   *       calls like setScale/setPadding/setPose/setDimensions and you want to avoid the overhead of updating the
+   *       internal structures after each call. When you are finished with the batch, call updateInternalData().
+   * \param pose The pose to set. Default is identity.
+   */
+  void setPoseDirty(const Eigen::Isometry3d& pose)
+  {
+    pose_ = pose;
+  }
+
   /** \brief Set the pose of the body. Default is identity */
   void setPose(const Eigen::Isometry3d& pose)
   {
-    pose_ = pose;
+    setPoseDirty(pose);
     updateInternalData();
   }
 
@@ -143,6 +182,19 @@ public:
   const Eigen::Isometry3d& getPose() const
   {
     return pose_;
+  }
+
+  /**
+   * \brief Set the dimensions of the body (from corresponding shape).
+   * \note This is the dirty version of the function which does not update internal data that depend on the dimensions.
+   *       In the general case, you should call setDimensions() instead. Only call this function if you have a series of
+   *       calls like setScale/setPadding/setPose/setDimensions and you want to avoid the overhead of updating the
+   *       internal structures after each call. When you are finished with the batch, call updateInternalData().
+   * \param shape The shape whose dimensions should be assumed. After the function finishes, the pointer can be deleted.
+   */
+  inline void setDimensionsDirty(const shapes::Shape* shape)
+  {
+    useDimensions(shape);
   }
 
   /** \brief Get the dimensions associated to this body (as read from corresponding shape) */
@@ -205,12 +257,12 @@ public:
       thread safety, when bodies need to be moved around. */
   virtual BodyPtr cloneAt(const Eigen::Isometry3d& pose, double padding, double scaling) const = 0;
 
-protected:
   /** \brief This function is called every time a change to the body
       is made, so that intermediate values stored for efficiency
       reasons are kept up to date. */
   virtual void updateInternalData() = 0;
 
+protected:
   /** \brief Depending on the shape, this function copies the relevant data to the body. */
   virtual void useDimensions(const shapes::Shape* shape) = 0;
 
@@ -264,9 +316,10 @@ public:
 
   virtual BodyPtr cloneAt(const Eigen::Isometry3d& pose, double padding, double scale) const;
 
+  virtual void updateInternalData();
+
 protected:
   virtual void useDimensions(const shapes::Shape* shape);
-  virtual void updateInternalData();
 
   // shape-dependent data
   double radius_;
@@ -314,9 +367,10 @@ public:
 
   virtual BodyPtr cloneAt(const Eigen::Isometry3d& pose, double padding, double scale) const;
 
+  virtual void updateInternalData();
+
 protected:
   virtual void useDimensions(const shapes::Shape* shape);
-  virtual void updateInternalData();
 
   // shape-dependent data
   double length_;
@@ -374,9 +428,10 @@ public:
 
   virtual BodyPtr cloneAt(const Eigen::Isometry3d& pose, double padding, double scale) const;
 
+  virtual void updateInternalData();
+
 protected:
   virtual void useDimensions(const shapes::Shape* shape);  // (x, y, z) = (length, width, height)
-  virtual void updateInternalData();
 
   // shape-dependent data
   double length_;
@@ -452,9 +507,10 @@ public:
 
   void correctVertexOrderFromPlanes();
 
+  virtual void updateInternalData();
+
 protected:
   virtual void useDimensions(const shapes::Shape* shape);
-  virtual void updateInternalData();
 
   /** \brief (Used mainly for debugging) Count the number of vertices behind a plane*/
   unsigned int countVerticesBehindPlane(const Eigen::Vector4f& planeNormal) const;

--- a/src/bodies.cpp
+++ b/src/bodies.cpp
@@ -118,7 +118,7 @@ inline Eigen::Vector3d normalize(const Eigen::Vector3d& dir)
 
 void bodies::Body::setDimensions(const shapes::Shape* shape)
 {
-  useDimensions(shape);
+  setDimensionsDirty(shape);
   updateInternalData();
 }
 
@@ -1018,10 +1018,11 @@ void bodies::ConvexMesh::updateInternalData()
   pose.translation() = Eigen::Vector3d(pose_ * mesh_data_->box_offset_);
 
   shapes::Box box_shape(mesh_data_->box_size_.x(), mesh_data_->box_size_.y(), mesh_data_->box_size_.z());
-  bounding_box_.setDimensions(&box_shape);
-  bounding_box_.setPose(pose);
-  bounding_box_.setPadding(padding_);
-  bounding_box_.setScale(scale_);
+  bounding_box_.setPoseDirty(pose);
+  bounding_box_.setPaddingDirty(padding_);
+  bounding_box_.setScaleDirty(scale_);
+  bounding_box_.setDimensionsDirty(&box_shape);
+  bounding_box_.updateInternalData();
 
   i_pose_ = pose_.inverse();
   center_ = pose_ * mesh_data_->mesh_center_;
@@ -1276,8 +1277,9 @@ void bodies::BodyVector::addBody(Body* body)
 void bodies::BodyVector::addBody(const shapes::Shape* shape, const Eigen::Isometry3d& pose, double padding)
 {
   bodies::Body* body = bodies::createBodyFromShape(shape);
-  body->setPose(pose);
-  body->setPadding(padding);
+  body->setPoseDirty(pose);
+  body->setPaddingDirty(padding);
+  body->updateInternalData();
   addBody(body);
 }
 

--- a/src/bodies.cpp
+++ b/src/bodies.cpp
@@ -1017,9 +1017,8 @@ void bodies::ConvexMesh::updateInternalData()
   Eigen::Isometry3d pose = pose_;
   pose.translation() = Eigen::Vector3d(pose_ * mesh_data_->box_offset_);
 
-  std::unique_ptr<shapes::Box> box_shape(
-      new shapes::Box(mesh_data_->box_size_.x(), mesh_data_->box_size_.y(), mesh_data_->box_size_.z()));
-  bounding_box_.setDimensions(box_shape.get());
+  shapes::Box box_shape(mesh_data_->box_size_.x(), mesh_data_->box_size_.y(), mesh_data_->box_size_.z());
+  bounding_box_.setDimensions(&box_shape);
   bounding_box_.setPose(pose);
   bounding_box_.setPadding(padding_);
   bounding_box_.setScale(scale_);

--- a/src/bodies.cpp
+++ b/src/bodies.cpp
@@ -337,6 +337,7 @@ void bodies::Cylinder::updateInternalData()
   radiusBSqr_ = length2_ * length2_ + radius2_;
   radiusB_ = sqrt(radiusBSqr_);
 
+  ASSERT_ISOMETRY(pose_);
   Eigen::Matrix3d basis = pose_.linear();
   normalB1_ = basis.col(0);
   normalB2_ = basis.col(1);
@@ -578,6 +579,7 @@ void bodies::Box::updateInternalData()
   radius2_ = length2_ * length2_ + width2_ * width2_ + height2_ * height2_;
   radiusB_ = sqrt(radius2_);
 
+  ASSERT_ISOMETRY(pose_);
   Eigen::Matrix3d basis = pose_.linear();
   normalL_ = basis.col(0);
   normalW_ = basis.col(1);

--- a/src/bodies.cpp
+++ b/src/bodies.cpp
@@ -337,7 +337,7 @@ void bodies::Cylinder::updateInternalData()
   radiusBSqr_ = length2_ * length2_ + radius2_;
   radiusB_ = sqrt(radiusBSqr_);
 
-  Eigen::Matrix3d basis = pose_.rotation();
+  Eigen::Matrix3d basis = pose_.linear();
   normalB1_ = basis.col(0);
   normalB2_ = basis.col(1);
   normalH_ = basis.col(2);
@@ -578,7 +578,7 @@ void bodies::Box::updateInternalData()
   radius2_ = length2_ * length2_ + width2_ * width2_ + height2_ * height2_;
   radiusB_ = sqrt(radius2_);
 
-  Eigen::Matrix3d basis = pose_.rotation();
+  Eigen::Matrix3d basis = pose_.linear();
   normalL_ = basis.col(0);
   normalW_ = basis.col(1);
   normalH_ = basis.col(2);

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -6,6 +6,9 @@ endif()
 configure_file(resources/config.h.in "${CMAKE_CURRENT_BINARY_DIR}/resources/config.h")
 include_directories(${CMAKE_CURRENT_BINARY_DIR})
 
+catkin_add_gtest(test_basics test_basics.cpp)
+target_link_libraries(test_basics ${PROJECT_NAME} ${catkin_LIBRARIES} ${Boost_LIBRARIES})
+
 catkin_add_gtest(test_point_inclusion test_point_inclusion.cpp)
 target_link_libraries(test_point_inclusion ${PROJECT_NAME} ${catkin_LIBRARIES} ${Boost_LIBRARIES})
 

--- a/test/test_basics.cpp
+++ b/test/test_basics.cpp
@@ -1,0 +1,62 @@
+/*********************************************************************
+* Software License Agreement (BSD License)
+*
+*  Copyright (c) 2019, Bielefeld University
+*  All rights reserved.
+*
+*  Redistribution and use in source and binary forms, with or without
+*  modification, are permitted provided that the following conditions
+*  are met:
+*
+*   * Redistributions of source code must retain the above copyright
+*     notice, this list of conditions and the following disclaimer.
+*   * Redistributions in binary form must reproduce the above
+*     copyright notice, this list of conditions and the following
+*     disclaimer in the documentation and/or other materials provided
+*     with the distribution.
+*   * Neither the name of the Bielefeld University nor the names of its
+*     contributors may be used to endorse or promote products derived
+*     from this software without specific prior written permission.
+*
+*  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+*  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+*  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+*  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+*  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+*  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+*  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+*  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+*  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+*  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+*  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+*  POSSIBILITY OF SUCH DAMAGE.
+*********************************************************************/
+
+#include <geometric_shapes/bodies.h>
+#include <gtest/gtest.h>
+
+TEST(Utils, checkIsometry)
+{
+  Eigen::Isometry3d t(Eigen::AngleAxisd(0.42, Eigen::Vector3d(1, 1, 1).normalized()));
+  ASSERT_ISOMETRY(t);
+
+  t.linear() = t.linear() * Eigen::DiagonalMatrix<double, 3, 3>(1.0, 2.0, 3.0);
+#ifdef NDEBUG
+  ASSERT_ISOMETRY(t)  // noop in release mode
+#else
+  ASSERT_DEATH(ASSERT_ISOMETRY(t), "Invalid isometry transform");
+#endif
+
+  t.matrix().row(3) = Eigen::Vector4d(1e-6, 1e-6, 1e-6, 1 - 1e-6);
+#ifdef NDEBUG
+  ASSERT_ISOMETRY(t)  // noop in release mode
+#else
+  ASSERT_DEATH(ASSERT_ISOMETRY(t), "Invalid isometry transform");
+#endif
+}
+
+int main(int argc, char** argv)
+{
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/test/test_bounding_box.cpp
+++ b/test/test_bounding_box.cpp
@@ -203,7 +203,7 @@ TEST(CylinderBoundingBox, Cylinder2)
 
   // verify the bounding box is yaw-invariant
 
-  random_numbers::RandomNumberGenerator gen;
+  random_numbers::RandomNumberGenerator gen(0);
   const auto rollPitch =
       Eigen::AngleAxisd(1.0, Eigen::Vector3d::UnitX()) * Eigen::AngleAxisd(1.0, Eigen::Vector3d::UnitY());
 

--- a/test/test_bounding_box.cpp
+++ b/test/test_bounding_box.cpp
@@ -74,7 +74,7 @@ TEST(SphereBoundingBox, Sphere2)
   EXPECT_NEAR(4.0, bbox.max().y(), 1e-4);
   EXPECT_NEAR(5.0, bbox.max().z(), 1e-4);
 
-  pose *= Eigen::AngleAxisd(M_PI_2, Eigen::Vector3d(1, 1, 1));
+  pose *= Eigen::AngleAxisd(M_PI_2, Eigen::Vector3d(1, 1, 1).normalized());
   body.setPose(pose);
   body.computeBoundingBox(bbox);
 
@@ -145,7 +145,7 @@ TEST(BoxBoundingBox, Box2)
   EXPECT_NEAR(3.0, bbox.max().y(), 1e-4);
   EXPECT_NEAR(4.5, bbox.max().z(), 1e-4);
 
-  pose *= Eigen::AngleAxisd(M_PI_2, Eigen::Vector3d(1, 1, 1));
+  pose *= Eigen::AngleAxisd(M_PI_2, Eigen::Vector3d(1, 1, 1).normalized());
   body.setPose(pose);
   body.computeBoundingBox(bbox);
 
@@ -190,7 +190,7 @@ TEST(CylinderBoundingBox, Cylinder2)
   EXPECT_NEAR(3.0, bbox.max().y(), 1e-4);
   EXPECT_NEAR(4.0, bbox.max().z(), 1e-4);
 
-  pose.linear() = Eigen::AngleAxisd(M_PI_2, Eigen::Vector3d(1, 1, 1)).toRotationMatrix();
+  pose *= Eigen::AngleAxisd(M_PI_2, Eigen::Vector3d(1, 1, 1).normalized());
   body.setPose(pose);
   body.computeBoundingBox(bbox);
 
@@ -352,7 +352,7 @@ TEST(MeshBoundingBox, Mesh2)
   EXPECT_NEAR(3.0, bbox.max().y(), 1e-4);
   EXPECT_NEAR(4.5, bbox.max().z(), 1e-4);
 
-  pose *= Eigen::AngleAxisd(M_PI_2, Eigen::Vector3d(1, 1, 1));
+  pose *= Eigen::AngleAxisd(M_PI_2, Eigen::Vector3d(1, 1, 1).normalized());
   body.setPose(pose);
   body.computeBoundingBox(bbox);
 

--- a/test/test_bounding_cylinder.cpp
+++ b/test/test_bounding_cylinder.cpp
@@ -301,7 +301,7 @@ TEST(CylinderBoundingCylinder, Cylinder2)
   EXPECT_NEAR(1.0, bcyl.radius, 1e-4);
   EXPECT_NEAR(2.0, bcyl.length, 1e-4);
 
-  pose.linear() = Eigen::AngleAxisd(M_PI_2, Eigen::Vector3d(1, 1, 1)).toRotationMatrix();
+  pose.linear() = Eigen::AngleAxisd(M_PI_2, Eigen::Vector3d(1, 1, 1).normalized()).toRotationMatrix();
   body.setPose(pose);
   body.computeBoundingCylinder(bcyl);
 


### PR DESCRIPTION
Performance of bodies::setPose() was improved by calling .linear() instead of .rotation().
For isometries, these should result to the same code, but this optimization is not in any released version of Eigen so far (3.3.7).

I also had to fix test_bounding_box.cpp test, as I found there a few usages of AngleAxis to which a denormalized axis was passed, which is illegal. And the fixes in this PR broke one of the wrong tests.

I also did additional speedups in ConvexMesh::setPose(). 
First, there was an unncessary dynamic memory allocation, which was not optimized out by the compiler (removing the allocation speeded up the pref. test by ~25%).
Second, the construction of the helper bounding_box_ object led to calling Box::updateInternalData() 4 times in succession. So I fixed that by accessing the protected members of Box and making ConvexMesh its friend class. If this approach is not desirable, I extracted it to a single commit which can be reverted.

For the measured performance improvement, see https://github.com/ros-planning/geometric_shapes/issues/125#issuecomment-602134891.