### PR TITLE
Added constructors of bodies from the corresponding bounding shapes

### DIFF
--- a/include/geometric_shapes/bodies.h
+++ b/include/geometric_shapes/bodies.h
@@ -244,6 +244,17 @@ public:
     setDimensions(shape);
   }
 
+  explicit Sphere(const BoundingSphere& sphere) : Body()
+  {
+    type_ = shapes::SPHERE;
+    shapes::Sphere shape(sphere.radius);
+    setDimensions(&shape);
+
+    Eigen::Isometry3d pose = Eigen::Isometry3d::Identity();
+    pose.translation() = sphere.center;
+    setPose(pose);
+  }
+
   virtual ~Sphere()
   {
   }
@@ -292,6 +303,14 @@ public:
   {
     type_ = shapes::CYLINDER;
     setDimensions(shape);
+  }
+
+  explicit Cylinder(const BoundingCylinder& cylinder) : Body()
+  {
+    type_ = shapes::CYLINDER;
+    shapes::Cylinder shape(cylinder.radius, cylinder.length);
+    setDimensions(&shape);
+    setPose(cylinder.pose);
   }
 
   virtual ~Cylinder()
@@ -352,6 +371,17 @@ public:
   {
     type_ = shapes::BOX;
     setDimensions(shape);
+  }
+
+  explicit Box(const AABB& aabb) : Body()
+  {
+    type_ = shapes::BOX;
+    shapes::Box shape(aabb.sizes()[0], aabb.sizes()[1], aabb.sizes()[2]);
+    setDimensions(&shape);
+
+    Eigen::Isometry3d pose = Eigen::Isometry3d::Identity();
+    pose.translation() = aabb.center();
+    setPose(pose);
   }
 
   virtual ~Box()


### PR DESCRIPTION
Added constructors `explicit bodies::Sphere(const bodies::BoundingSphere& sphere)`, and analogously for `Box<->AABB` and `Cylinder<->BoundingCylinder`.

These would help in some tests I'm planning to write.

Two comments:

1. Another option would be to instead add methods e.g. `bodies::BoundingSphere::toBody()`. I just chose the constructor way because I like it more, but they should be more or less equivalent.
1. Why are so many methods in bodies implemented in header files? Shouldn't I move the definitions to .cpp? I just wanted to be consistent, so I've put it in the header as the other constructors, but I don't really see a reason for not putting them into .cpp.