### PR TITLE
Added a mutex that protects bodies::detail::g_triangle_for_plane_.

### DIFF
--- a/src/bodies.cpp
+++ b/src/bodies.cpp
@@ -142,9 +142,8 @@ static std::map<size_t, size_t>& getTriangleForPlane(const ConvexMesh* mesh)
   auto it = g_triangle_for_plane_.find(mesh);
   if (it == detail::g_triangle_for_plane_.end())
     return detail::g_triangle_for_plane_.emplace(mesh, std::map<size_t, size_t>()).first->second;
-
-  it->second.clear();
-  return it->second;
+  else
+    return it->second;
 }
 }  // namespace detail
 
@@ -943,6 +942,7 @@ void bodies::ConvexMesh::useDimensions(const shapes::Shape* shape)
 
   // HACK: only needed for ABI compatibility with melodic
   std::map<size_t, size_t>& triangle_for_plane = detail::getTriangleForPlane(this);
+  triangle_for_plane.clear();
 
   // neccessary for qhull macro
   facetT* facet;


### PR DESCRIPTION
Fixes #134.

I just hope that taking a pointer of the map's value is okay. The STL docs say:

> References and pointers to either key or data stored in the container are only invalidated by erasing that element, even when the corresponding iterator is invalidated. 

So it should be okay. We're only erasing in ConvexMesh destructor, and at that time, none of the reading functions should be running for this particular mesh.