### PR TITLE
Add resource_retriever to CATKIN_DEPENDS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,6 +47,7 @@ catkin_package(
   CATKIN_DEPENDS
     eigen_stl_containers
     random_numbers
+    resource_retriever
     shape_msgs
     visualization_msgs
   DEPENDS


### PR DESCRIPTION
The package resource-retriever is missing in CATKIN_DEPENDS in CMakeLists.txt. This creates a linker failure in moveit-ros-planning when building with openembedded thud. 

The error I encountered when building:
```
| /media/christoph/Ubuntu/ros-industrial-oe/build/tmp/work/core2-64-poky-linux/moveit-ros-planning/1.0.2-1-r0/recipe-sysroot-native/usr/bin/x86_64-poky-linux/../../libexec/x86_64-poky-linux/gcc/x86_64-poky-linux/8.2.0/ld: warning: libresource_retriever.so, needed by /media/christoph/Ubuntu/ros-industrial-oe/build/tmp/work/core2-64-poky-linux/moveit-ros-planning/1.0.2-1-r0/recipe-sysroot/opt/ros/melodic/lib/libgeometric_shapes.so, not found (try using -rpath or -rpath-link)
| /media/christoph/Ubuntu/ros-industrial-oe/build/tmp/work/core2-64-poky-linux/moveit-ros-planning/1.0.2-1-r0/recipe-sysroot-native/usr/bin/x86_64-poky-linux/../../libexec/x86_64-poky-linux/gcc/x86_64-poky-linux/8.2.0/ld: /media/christoph/Ubuntu/ros-industrial-oe/build/tmp/work/core2-64-poky-linux/moveit-ros-planning/1.0.2-1-r0/recipe-sysroot/opt/ros/melodic/lib/libgeometric_shapes.so: undefined reference to `resource_retriever::Retriever::~Retriever()'
| /media/christoph/Ubuntu/ros-industrial-oe/build/tmp/work/core2-64-poky-linux/moveit-ros-planning/1.0.2-1-r0/recipe-sysroot-native/usr/bin/x86_64-poky-linux/../../libexec/x86_64-poky-linux/gcc/x86_64-poky-linux/8.2.0/ld: /media/christoph/Ubuntu/ros-industrial-oe/build/tmp/work/core2-64-poky-linux/moveit-ros-planning/1.0.2-1-r0/recipe-sysroot/opt/ros/melodic/lib/libgeometric_shapes.so: undefined reference to `resource_retriever::Retriever::Retriever()'
| /media/christoph/Ubuntu/ros-industrial-oe/build/tmp/work/core2-64-poky-linux/moveit-ros-planning/1.0.2-1-r0/recipe-sysroot-native/usr/bin/x86_64-poky-linux/../../libexec/x86_64-poky-linux/gcc/x86_64-poky-linux/8.2.0/ld: /media/christoph/Ubuntu/ros-industrial-oe/build/tmp/work/core2-64-poky-linux/moveit-ros-planning/1.0.2-1-r0/recipe-sysroot/opt/ros/melodic/lib/libgeometric_shapes.so: undefined reference to `resource_retriever::Retriever::get(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)'
| collect2: error: ld returned 1 exit status
```