### PR TITLE
get rid of dynamic_cast

### DIFF
--- a/src/body_operations.cpp
+++ b/src/body_operations.cpp
@@ -160,9 +160,11 @@ void bodies::computeBoundingSphere(const std::vector<const bodies::Body*>& bodie
   unsigned int vertex_count = 0;
   for (auto body : bodies)
   {
-    const bodies::ConvexMesh* conv = dynamic_cast<const bodies::ConvexMesh*>(body);
-    if (!conv)
+    if (!body || body->getType() != shapes::MESH)
       continue;
+    // MESH type implies bodies::ConvexMesh
+    const bodies::ConvexMesh* conv = static_cast<const bodies::ConvexMesh*>(body);
+
     for (unsigned int j = 0; j < conv->getScaledVertices().size(); j++, vertex_count++)
     {
       sum += conv->getPose() * conv->getScaledVertices()[j];
@@ -174,9 +176,11 @@ void bodies::computeBoundingSphere(const std::vector<const bodies::Body*>& bodie
   double max_dist_squared = 0.0;
   for (auto body : bodies)
   {
-    const bodies::ConvexMesh* conv = dynamic_cast<const bodies::ConvexMesh*>(body);
-    if (!conv)
+    if (!body || body->getType() != shapes::MESH)
       continue;
+    // MESH type implies bodies::ConvexMesh
+    const bodies::ConvexMesh* conv = static_cast<const bodies::ConvexMesh*>(body);
+
     for (unsigned int j = 0; j < conv->getScaledVertices().size(); j++)
     {
       double dist = (conv->getPose() * conv->getScaledVertices()[j] - sphere.center).squaredNorm();

--- a/test/test_bounding_sphere.cpp
+++ b/test/test_bounding_sphere.cpp
@@ -175,8 +175,8 @@ TEST(ConeBoundingSphere, Cone4)
 TEST(MeshBoundingSphere, Mesh1)
 {
   shapes::Shape* shape = new shapes::Mesh(8, 12);
-  shapes::Mesh* m = dynamic_cast<shapes::Mesh*>(shape);
-  EXPECT_TRUE(m);
+  EXPECT_EQ(shape->type, shapes::MESH);
+  shapes::Mesh* m = static_cast<shapes::Mesh*>(shape);
 
   // box mesh
 


### PR DESCRIPTION
This library does not need RTTI as all bodies & shapes are marked with `type`.

The EXPECT_TRUE in the test degenerates to true for all minimally-optimizing compilers.
Replaced it with something meaningful.

should be backported to melodic.