### PR TITLE
[ROS 2] Use octomap target directly

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,10 +68,10 @@ ament_target_dependencies(${PROJECT_NAME}
   geometry_msgs
   resource_retriever
   console_bridge
-  octomap
   ASSIMP
   QHULL
 )
+target_link_libraries(${PROJECT_NAME} octomap)
 
 ament_export_libraries(${PROJECT_NAME})
 ament_export_include_directories(include)


### PR DESCRIPTION
This fixes a compile error from missing include directories when building both `geometry_shapes` and [octomap](https://github.com/OctoMap/octomap/tree/ros2) in the same workspace.


```
--- stderr: geometric_shapes                                                                                                                
/home/sloretz/ws/sdfurdf/src/geometric_shapes/src/shapes.cpp:39:10: fatal error: octomap/octomap.h: No such file or directory
   39 | #include <octomap/octomap.h>
      |          ^~~~~~~~~~~~~~~~~~~
compilation terminated.
make[2]: *** [CMakeFiles/geometric_shapes.dir/build.make:154: CMakeFiles/geometric_shapes.dir/src/shapes.cpp.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:127: CMakeFiles/geometric_shapes.dir/all] Error 2
make: *** [Makefile:141: all] Error 2
---
Failed   <<< geometric_shapes	[ Exited with code 2 ]
```

The problem comes from octomap exporting variables beginning with all uppercase `OCTOMAP_` when the CMake package is found using lowercase `octomap`. This prevents `ament_target_dependencies` from adding those variables to the given target. This PR solves the issue by using the imported target `octomap` instead.