### PR TITLE
Compile on ROS2 Foxy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,15 +13,15 @@ notifications:
       - 130s@2000.jukuin.keio.ac.jp
 env:
   global:
-    - ROS_DISTRO=dashing
+    - ROS_DISTRO=foxy
     - ROS_REPO=ros
     - UPSTREAM_WORKSPACE=geometric_shapes.repos
     - CXXFLAGS="-Wall -Wextra -Wwrite-strings -Wunreachable-code -Wpointer-arith -Wredundant-decls -Wno-unused-parameter"
     - WARNINGS_OK=false
   matrix:
     - TEST="clang-format, ament_lint"
-    - ROS_DISTRO=dashing
-    - ROS_DISTRO=eloquent  TEST=code-coverage
+    - ROS_DISTRO=eloquent
+    - ROS_DISTRO=foxy TEST=code-coverage
 
 matrix:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ env:
     - CXXFLAGS="-Wall -Wextra -Wwrite-strings -Wunreachable-code -Wpointer-arith -Wredundant-decls -Wno-unused-parameter"
     - WARNINGS_OK=false
   matrix:
-    - TEST="clang-format, ament_lint"
+    - TEST="ament_lint"  # TODO(henningkayser): re-enable clang-format
     - ROS_DISTRO=eloquent
     - ROS_DISTRO=foxy TEST=code-coverage
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,6 @@ env:
     - WARNINGS_OK=false
   matrix:
     - TEST="ament_lint"  # TODO(henningkayser): re-enable clang-format
-    - ROS_DISTRO=eloquent
     - ROS_DISTRO=foxy TEST=code-coverage
 
 matrix:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,7 +35,7 @@ find_package(Boost REQUIRED system filesystem)
 find_package(console_bridge REQUIRED)
 find_package(eigen3_cmake_module REQUIRED)
 find_package(Eigen3 REQUIRED)
-find_package(octomap REQUIRED)
+find_package(OCTOMAP REQUIRED)
 find_package(ament_cmake REQUIRED)
 find_package(eigen_stl_containers REQUIRED)
 find_package(random_numbers REQUIRED)
@@ -71,7 +71,7 @@ ament_target_dependencies(${PROJECT_NAME}
   geometry_msgs
   resource_retriever
   console_bridge
-  octomap
+  OCTOMAP
   ASSIMP
   QHULL
 )
@@ -82,15 +82,11 @@ ament_export_dependencies(
   Eigen3
   eigen3_cmake_module  # export Eigen3 headers
   Boost
-  ASSIMP
   random_numbers
   eigen_stl_containers
   shape_msgs
   visualization_msgs
-)
-target_link_libraries(${PROJECT_NAME}
-# resource_retriever doesn't support ament export hook (fixed in 2.1.1)
-  resource_retriever::resource_retriever
+  OCTOMAP
 )
 
 if(BUILD_TESTING)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,7 @@ set(ASSIMP_LIBRARIES "${ASSIMP_ABS_LIBRARIES}")
 
 find_package(rclcpp REQUIRED)
 find_package(Boost REQUIRED system filesystem)
+find_package(console_bridge_vendor REQUIRED)
 find_package(console_bridge REQUIRED)
 find_package(eigen3_cmake_module REQUIRED)
 find_package(Eigen3 REQUIRED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,9 @@ if(NOT CMAKE_CONFIGURATION_TYPES AND NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE Release)
 endif()
 
+# TODO(henningkayser): Remove policy fix when assimp 5.1 is available
+# Suppress policy warning in assimp (https://github.com/assimp/assimp/pull/2722)
+set(CMAKE_POLICY_DEFAULT_CMP0012 NEW)
 find_package(ASSIMP QUIET)
 if(NOT ASSIMP_FOUND)
   find_package(PkgConfig REQUIRED)

--- a/README.md
+++ b/README.md
@@ -21,8 +21,11 @@ Note: `bodies::ConvexMesh::MeshData` was made implementation-private and is no l
 
 ## Build Status
 
-Travis CI: [![Build Status](https://travis-ci.org/ros-planning/geometric_shapes.svg?branch=ros2)](https://travis-ci.org/ros-planning/geometric_shapes)
+Travis CI: [![Build Status](https://travis-ci.com/ros-planning/geometric_shapes.svg?branch=ros2)](https://travis-ci.com/ros-planning/geometric_shapes)
 
+<!--
+TODO(henningkayser): Fix Devel/Debian build tags for ROS2
 Devel Job: [![Build Status](http://build.ros.org/buildStatus/icon?job=Msrc_uB__geometric_shapes__ubuntu_bionic__source)](http://build.ros.org/view/Msrc_uB/job/Msrc_uB__geometric_shapes__ubuntu_bionic__source)
 
 Debian Job: [![Build Status](http://build.ros.org/buildStatus/icon?job=Mbin_uB64__geometric_shapes__ubuntu_bionic_amd64__binary)](http://build.ros.org/view/Mbin_uB64/job/Mbin_uB64__geometric_shapes__ubuntu_bionic_amd64__binary)
+-->

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Note: `bodies::ConvexMesh::MeshData` was made implementation-private and is no l
 
 ## Build Status
 
-Travis CI: [![Build Status](https://travis-ci.org/ros-planning/geometric_shapes.svg?branch=melodic-devel)](https://travis-ci.org/ros-planning/geometric_shapes)
+Travis CI: [![Build Status](https://travis-ci.org/ros-planning/geometric_shapes.svg?branch=ros2)](https://travis-ci.org/ros-planning/geometric_shapes)
 
 Devel Job: [![Build Status](http://build.ros.org/buildStatus/icon?job=Msrc_uB__geometric_shapes__ubuntu_bionic__source)](http://build.ros.org/view/Msrc_uB/job/Msrc_uB__geometric_shapes__ubuntu_bionic__source)
 

--- a/geometric_shapes.repos
+++ b/geometric_shapes.repos
@@ -2,7 +2,7 @@ repositories:
   geometric_shapes:
     type: git
     url: https://github.com/ros-planning/geometric_shapes
-    version: dashing-devel
+    version: ros2
   random_numbers:
     type: git
     url: https://github.com/ros-planning/random_numbers

--- a/package.xml
+++ b/package.xml
@@ -28,7 +28,7 @@
   <depend>rclcpp</depend>
   <depend>boost</depend>
   <depend>eigen_stl_containers</depend>
-  <depend>libconsole-bridge-dev</depend>
+  <depend>console_bridge_vendor</depend>
   <depend>libqhull</depend>
   <depend>octomap</depend>
   <depend>random_numbers</depend>


### PR DESCRIPTION
This branch is in preparation of the foxy release including following changes:

* Suppress assimp CMP0012 policy warning (see https://github.com/assimp/assimp/pull/2722, should be fixed with 5.1)
* Removes ASSIMP as (redundant) export dependency to prevent warnings in downstream dependencies
* Disables clang-format check until we found a new format version
* Fixes OCTOMAP target (#150)
* Removed Eloquent from CI (I don't think we want to maintain this when MoveIt 2 runs on Foxy only, this allows us to remove explicit linking of the resource_retriever dependency)

I think we can remove dashing-devel after merging this as we would only support Foxy just like MoveIt 2.