### PR TITLE
Update CMakeLists.txt to include octomap headers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,7 +45,10 @@ if(HAVE_QHULL_2011)
   add_definitions(-DGEOMETRIC_SHAPES_HAVE_QHULL_2011)
 endif()
 
-include_directories(include)
+include_directories(
+  include
+  ${OCTOMAP_INCLUDE_DIRS}
+)
 
 add_library(${PROJECT_NAME} SHARED
   src/aabb.cpp
@@ -88,6 +91,7 @@ ament_export_dependencies(
 target_link_libraries(${PROJECT_NAME}
 # resource_retriever doesn't support ament export hook (fixed in 2.1.1)
   resource_retriever::resource_retriever
+  ${OCTOMAP_LIBRARIES}
 )
 
 if(BUILD_TESTING)


### PR DESCRIPTION
Looks like octomap isn't a properly implemented ament package, so `ament_target_dependencies` doesn't necessary pickup on the correct location for the included header files for the library. This explicitly adds the includes directory using the env exported by the octomap's cmake config, as prescribed here:

https://wiki.ros.org/octomap#Using_OctoMap

I suspect this went under the radar for so long as CI or maintainers where building this packages using released system installed deps for octomap, rather than from a source build of octomap in the same workspace.

cc @mikaelarguedas