### PR TITLE
Use uppercase octomap to fix header not found errors 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,7 +32,7 @@ find_package(Boost REQUIRED system filesystem)
 find_package(console_bridge REQUIRED)
 find_package(eigen3_cmake_module REQUIRED)
 find_package(Eigen3 REQUIRED)
-find_package(octomap REQUIRED)
+find_package(OCTOMAP REQUIRED)
 find_package(ament_cmake REQUIRED)
 find_package(eigen_stl_containers REQUIRED)
 find_package(random_numbers REQUIRED)
@@ -68,7 +68,7 @@ ament_target_dependencies(${PROJECT_NAME}
   geometry_msgs
   resource_retriever
   console_bridge
-  octomap
+  OCTOMAP
   ASSIMP
   QHULL
 )


### PR DESCRIPTION
Alternative to https://github.com/ros-planning/geometric_shapes/pull/154

The octomap exported CMake variable when find_package'd are using the uppercase name (e.g. OCTOMAP_INCLUDE_DIRS).
This means the lowercase versions (e.g. octomap_INCLUDE_DIRS) are empty and this cause headers not to be found when compiling geometric_shapes.

This PR uses the uppercase name to find octomap and passes OCTOMAP to `ament_target_dependencies`, this way amnt uses the uppercase CMake variables.

@ruffsl can you check if this fixes your issue?