### PR TITLE
[ros2] trim boost dependencies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,7 +31,7 @@ find_library(ASSIMP_ABS_LIBRARIES NAMES ${ASSIMP_LIBRARIES} assimp HINTS ${ASSIM
 set(ASSIMP_LIBRARIES "${ASSIMP_ABS_LIBRARIES}")
 
 find_package(rclcpp REQUIRED)
-find_package(Boost REQUIRED filesystem math)
+find_package(Boost REQUIRED filesystem)
 find_package(console_bridge_vendor REQUIRED)
 find_package(console_bridge REQUIRED)
 find_package(eigen3_cmake_module REQUIRED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,7 +31,7 @@ find_library(ASSIMP_ABS_LIBRARIES NAMES ${ASSIMP_LIBRARIES} assimp HINTS ${ASSIM
 set(ASSIMP_LIBRARIES "${ASSIMP_ABS_LIBRARIES}")
 
 find_package(rclcpp REQUIRED)
-find_package(Boost REQUIRED system filesystem)
+find_package(Boost REQUIRED filesystem math)
 find_package(console_bridge_vendor REQUIRED)
 find_package(console_bridge REQUIRED)
 find_package(eigen3_cmake_module REQUIRED)

--- a/package.xml
+++ b/package.xml
@@ -40,13 +40,11 @@
   <build_depend>pkg-config</build_depend>
   <build_depend>libboost-dev</build_depend>
   <build_depend>libboost-filesystem-dev</build_depend>
-  <build_depend>libboost-math-dev</build_depend>
 
   <build_export_depend>libboost-dev</build_export_depend>
 
   <exec_depend>assimp</exec_depend>
   <exec_depend>libboost-filesystem</exec_depend>
-  <exec_depend>libboost-math</exec_depend>
   <exec_depend>rosidl_default_runtime</exec_depend>
 
   <test_depend>ament_cmake_gtest</test_depend>

--- a/package.xml
+++ b/package.xml
@@ -5,14 +5,14 @@
   <version>0.7.0</version>
   <description>This package contains generic definitions of geometric shapes and bodies.</description>
 
-  <author email="isucan@google.com">Ioan Sucan</author>
-  <author email="gjones@willowgarage.edu">Gil Jones</author>
-
   <maintainer email="dave@dav.ee">Dave Coleman</maintainer>
   <maintainer email="130s@2000.jukuin.keio.ac.jp">Isaac I. Y. Saito</maintainer>
 
   <license>BSD</license>
   <url>http://ros.org/wiki/geometric_shapes</url>
+
+  <author email="isucan@google.com">Ioan Sucan</author>
+  <author email="gjones@willowgarage.edu">Gil Jones</author>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
   <buildtool_depend>rosidl_default_generators</buildtool_depend>

--- a/package.xml
+++ b/package.xml
@@ -26,7 +26,6 @@
   <build_export_depend>eigen</build_export_depend>
 
   <depend>rclcpp</depend>
-  <depend>boost</depend>
   <depend>eigen_stl_containers</depend>
   <depend>console_bridge_vendor</depend>
   <depend>libqhull</depend>
@@ -39,8 +38,15 @@
 
   <build_depend>assimp-dev</build_depend>
   <build_depend>pkg-config</build_depend>
+  <build_depend>libboost-dev</build_depend>
+  <build_depend>libboost-filesystem-dev</build_depend>
+  <build_depend>libboost-math-dev</build_depend>
+
+  <build_export_depend>libboost-dev</build_export_depend>
 
   <exec_depend>assimp</exec_depend>
+  <exec_depend>libboost-filesystem</exec_depend>
+  <exec_depend>libboost-math</exec_depend>
   <exec_depend>rosidl_default_runtime</exec_depend>
 
   <test_depend>ament_cmake_gtest</test_depend>


### PR DESCRIPTION
In an [ongoing effort](https://discourse.ros.org/t/generating-dev-and-runtime-artefacts-from-ros-packages/12448) to reduce the footprint on the target systems, it is preferred to declare specific dependencies instead of generic ones.

Requires ros/rosdistro#25995