### PR TITLE
add soname version to library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,6 +74,7 @@ add_library(${PROJECT_NAME}
   src/shape_to_marker.cpp
   src/shapes.cpp
 )
+set_target_properties(${PROJECT_NAME} PROPERTIES VERSION ${${PROJECT_NAME}_VERSION})
 
 target_link_libraries(${PROJECT_NAME} ${ASSIMP_LIBRARIES} ${QHULL_LIBRARIES} ${catkin_LIBRARIES} ${console_bridge_LIBRARIES} ${Boost_LIBRARIES})
 


### PR DESCRIPTION
This is adding the soname version to the library to enable future releases of Noetic to brake the ABI in a nicer way.  This is specifically because Noetic is the last ROS1 release and we can no longer depend on future versions of ROS1 if we want to break the ABI.