### PR TITLE
[fix] cmake install command

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,14 +97,18 @@ if(BUILD_TESTING)
   add_subdirectory(test)
 endif()
 
-install(TARGETS ${PROJECT_NAME}
-        ARCHIVE DESTINATION lib
-        LIBRARY DESTINATION lib
-        RUNTIME DESTINATION bin
+install(
+  DIRECTORY include/
+  DESTINATION include
 )
 
-install(DIRECTORY include/
-        DESTINATION include
+install(
+  TARGETS ${PROJECT_NAME}
+  EXPORT ${PROJECT_NAME}
+  LIBRARY DESTINATION lib
+  ARCHIVE DESTINATION lib
+  RUNTIME DESTINATION bin
+  INCLUDES DESTINATION include
 )
 
 ament_package()


### PR DESCRIPTION
This makes the install command conform to the standard here: https://index.ros.org/doc/ros2/Tutorials/Ament-CMake-Documentation/

Specifically what it fixes though is the EXPORT in the install allows this repo to be used in an installed underlay.