### PR TITLE
Fix ccache in CI and remove trailing whitespace [ros2]

### DIFF
--- a/.ci.prepare_codecov
+++ b/.ci.prepare_codecov
@@ -13,7 +13,7 @@ lcov --extract coverage.info "$BASEDIR/target_ws/src/$TARGET_REPO_NAME/*" --outp
 echo -e "${BLUE}Filter out test files${NOCOLOR}"
 lcov --remove coverage.info '*/test/*' --output-file coverage.info
 
-echo -e "${BLUE}Output coverage data for debugging${NOCOLOR}" 
+echo -e "${BLUE}Output coverage data for debugging${NOCOLOR}"
 lcov --list coverage.info
 
 popd

--- a/.github/workflows/industrial_ci_action.yml
+++ b/.github/workflows/industrial_ci_action.yml
@@ -19,25 +19,30 @@ jobs:
           - {ROS_DISTRO: foxy, ROS_REPO: testing, CCOV_UPLOAD: false}
     env:
       UPSTREAM_WORKSPACE: geometric_shapes.repos
-      CCACHE_DIR: /home/runner/.ccache
-      BASEDIR: .base
+      CCACHE_DIR: "${{ github.workspace }}/.ccache"
+      BASEDIR: ${{ github.workspace }}/.work
+      CACHE_PREFIX: "${{ matrix.env.ROS_DISTRO }}-${{ matrix.env.ROS_REPO }}"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/cache@v2
+      - name: cache ccache
+        uses: pat-s/always-upload-cache@v2.1.3
         with:
           path: ${{ env.CCACHE_DIR }}
-          key: ccache-${{ matrix.env.ROS_DISTRO }}-${{ matrix.env.ROS_REPO }}-${{ github.sha }}  
+          key: ccache-${{ env.CACHE_PREFIX }}-${{ github.sha }}
           restore-keys: |
-            ccache-${{ matrix.env.ROS_DISTRO }}-${{ matrix.env.ROS_REPO }}
-      - uses: 'ros-industrial/industrial_ci@master'
+            ccache-${{ env.CACHE_PREFIX }}
+      - name: industrial_ci
+        uses: 'ros-industrial/industrial_ci@master'
         env: ${{ matrix.env }}
-      - uses: actions/upload-artifact@v2
+      - name: upload test artifacts (on failure)
+        uses: actions/upload-artifact@v2
         if: failure()
         with:
           name: test-results
           path: ${{ env.BASEDIR }}/target_ws/**/test_results/**/*.xml
-      - uses: codecov/codecov-action@v1
-        if: ${{ matrix.env.CCOV_UPLOAD }} 
+      - name: upload codecov report
+        uses: codecov/codecov-action@v1
+        if: ${{ matrix.env.CCOV_UPLOAD }}
         with:
           files: ${{ env.BASEDIR }}/coverage.info

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,6 +26,7 @@ repos:
       - id: debug-statements
       - id: end-of-file-fixer
       - id: mixed-line-ending
+      - id: trailing-whitespace
 
   - repo: https://github.com/psf/black
     rev: 20.8b1

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,14 +6,14 @@ if(NOT CMAKE_CXX_STANDARD)
   set(CMAKE_CXX_STANDARD 14)
 endif()
 
-# Set compile options 
-set(PROJECT_COMPILE_OPTIONS 
-  -Wall 
-  -Wextra 
-  -Wwrite-strings 
-  -Wunreachable-code 
-  -Wpointer-arith 
-  -Wredundant-decls 
+# Set compile options
+set(PROJECT_COMPILE_OPTIONS
+  -Wall
+  -Wextra
+  -Wwrite-strings
+  -Wunreachable-code
+  -Wpointer-arith
+  -Wredundant-decls
   -Wno-unused-parameter
 )
 


### PR DESCRIPTION
This fixes the ccache path in ci and removes trailing whitespace through yet another pre-commit check.