### PR TITLE
Add rolling to CI test

### DIFF
--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -1,7 +1,7 @@
 # This config uses industrial_ci (https://github.com/ros-industrial/industrial_ci.git).
 # For troubleshooting, see readme (https://github.com/ros-industrial/industrial_ci/blob/master/README.rst)
 
-name: BuildAndTest
+name: Build and Test
 
 on:
   workflow_dispatch:
@@ -20,8 +20,12 @@ jobs:
             CCOV: true
           - ROS_DISTRO: foxy
             ROS_REPO: testing
+          - ROS_DISTRO: rolling
+            ROS_REPO: main
+          - ROS_DISTRO: rolling
+            ROS_REPO: testing
     env:
-      UPSTREAM_WORKSPACE: geometric_shapes.repos
+      UPSTREAM_WORKSPACE: geometric_shapes${{ matrix.env.ROS_DISTRO == 'rolling' && '_rolling' || '' }}.repos
       AFTER_SETUP_UPSTREAM_WORKSPACE: 'vcs pull $BASEDIR/upstream_ws/src'
       AFTER_RUN_TARGET_TEST: ${{ matrix.env.CCOV && './.ci.prepare_codecov' || '' }}
       TARGET_CMAKE_ARGS: >

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,19 +90,6 @@ ament_target_dependencies(${PROJECT_NAME}
   QHULL
 )
 
-ament_export_libraries(${PROJECT_NAME})
-ament_export_include_directories(include)
-ament_export_dependencies(
-  Eigen3
-  eigen3_cmake_module  # export Eigen3 headers
-  Boost
-  random_numbers
-  eigen_stl_containers
-  shape_msgs
-  visualization_msgs
-  OCTOMAP
-)
-
 if(BUILD_TESTING)
   find_package(ament_cmake_gtest REQUIRED)
   # Unit tests
@@ -120,11 +107,25 @@ install(
 
 install(
   TARGETS ${PROJECT_NAME}
-  EXPORT ${PROJECT_NAME}
+  EXPORT export_${PROJECT_NAME}
   LIBRARY DESTINATION lib
   ARCHIVE DESTINATION lib
   RUNTIME DESTINATION bin
   INCLUDES DESTINATION include
+)
+install(DIRECTORY include/ DESTINATION include)
+
+ament_export_targets(export_${PROJECT_NAME} HAS_LIBRARY_TARGET)
+ament_export_dependencies(${THIS_PACKAGE_INCLUDE_DEPENDS})
+ament_export_dependencies(
+  Eigen3
+  eigen3_cmake_module  # export Eigen3 headers
+  Boost
+  random_numbers
+  eigen_stl_containers
+  shape_msgs
+  visualization_msgs
+  OCTOMAP
 )
 
 ament_package()

--- a/README.md
+++ b/README.md
@@ -21,7 +21,9 @@ Note: `bodies::ConvexMesh::MeshData` was made implementation-private and is no l
 
 ## Build Status
 
-GitHub Actions: [![Format](https://github.com/ros-planning/geometric_shapes/actions/workflows/format.yml/badge.svg?branch=ros2)](https://github.com/ros-planning/geometric_shapes/actions/workflows/format.yml?branch=ros2) [![BuildAndTest](https://github.com/ros-planning/geometric_shapes/actions/workflows/industrial_ci_action.yml/badge.svg?branch=ros2)](https://github.com/ros-planning/geometric_shapes/actions/workflows/industrial_ci_action.yml?branch=ros2)[![codecov](https://codecov.io/gh/ros-planning/geometric_shapes/branch/ros2/graph/badge.svg?token=W7uHKcY0ly)](https://codecov.io/gh/ros-planning/geometric_shapes)
+[![Formatting (pre-commit)](https://github.com/ros-planning/geometric_shapes/actions/workflows/format.yaml/badge.svg?branch=ros2)](https://github.com/ros-planning/geometric_shapes/actions/workflows/format.yaml?query=branch%3Aros2)
+[![Build and Test](https://github.com/ros-planning/geometric_shapes/actions/workflows/build_and_test.yaml/badge.svg?branch=ros2)](https://github.com/ros-planning/geometric_shapes/actions/workflows/build_and_test.yaml?query=branch%3Aros2)
+[![codecov](https://codecov.io/gh/ros-planning/geometric_shapes/branch/ros2/graph/badge.svg?token=W7uHKcY0ly)](https://codecov.io/gh/ros-planning/geometric_shapes)
 
 Code Coverage Grid:
 

--- a/geometric_shapes_rolling.repos
+++ b/geometric_shapes_rolling.repos
@@ -1,0 +1,9 @@
+repositories:
+  octomap:
+    type: git
+    url: https://github.com/octomap/octomap
+    version: devel
+  random_numbers:
+    type: git
+    url: https://github.com/ros-planning/random_numbers
+    version: ros2


### PR DESCRIPTION
This adds rolling to the CI tests for ros2.  I'm going around adding these so we can test rolling regularly and hopefully get releases done on these smaller repos as they will make releasing for moveit2 on rolling possible.  I commented on this issue https://github.com/OctoMap/octomap/issues/300 to to ask for a rolling release from octomap as we need that for this package.