### PR TITLE
Update package maintainers

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -6,8 +6,8 @@
   <author email="isucan@google.com">Ioan Sucan</author>
   <author email="gjones@willowgarage.edu">Gil Jones</author>
 
-  <maintainer email="dave@dav.ee">Dave Coleman</maintainer>
-  <maintainer email="130s@2000.jukuin.keio.ac.jp">Isaac I. Y. Saito</maintainer>
+  <maintainer email="tyler@picknik.ai">Tyler Weaver</maintainer>
+  <maintainer email="rhaschke@techfak.uni-bielefeld.de">Robert Haschke</maintainer>
 
   <license>BSD</license>
   <url>http://ros.org/wiki/geometric_shapes</url>


### PR DESCRIPTION
I keep getting emails like:

>Jenkins build is still unstable: Fdev__geometric_shapes__ubuntu_focal_amd64 #9
>See <https://build.ros2.org/job/Fdev__geometric_shapes__ubuntu_focal_amd64/9/display/redirect?page=changes>

But I do not have the bandwidth to address this anymore. I'm hoping @tylerjw @rhaschke are okay with this, based on the recent git commit history.