### PR TITLE
Add qhull as SYSTEM dependency to suppress compiler warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,8 +97,8 @@ ament_target_dependencies(${PROJECT_NAME}
 
   # We don't export these dependencies because their cmake is broken
   ASSIMP
-  QHULL
 )
+ament_target_dependencies(${PROJECT_NAME} SYSTEM QHULL)
 
 if(BUILD_TESTING)
   find_package(ament_cmake_gtest REQUIRED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,13 +92,13 @@ add_library(${PROJECT_NAME} SHARED
 )
 set_target_properties(${PROJECT_NAME} PROPERTIES VERSION ${${PROJECT_NAME}_VERSION})
 target_compile_options(${PROJECT_NAME} PRIVATE ${PROJECT_COMPILE_OPTIONS})
-ament_target_dependencies(${PROJECT_NAME}
+ament_target_dependencies(${PROJECT_NAME} SYSTEM
   ${THIS_PACKAGE_EXPORT_DEPENDS}
 
   # We don't export these dependencies because their cmake is broken
   ASSIMP
+  QHULL
 )
-ament_target_dependencies(${PROJECT_NAME} SYSTEM QHULL)
 
 if(BUILD_TESTING)
   find_package(ament_cmake_gtest REQUIRED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,9 +92,10 @@ add_library(${PROJECT_NAME} SHARED
 )
 set_target_properties(${PROJECT_NAME} PROPERTIES VERSION ${${PROJECT_NAME}_VERSION})
 target_compile_options(${PROJECT_NAME} PRIVATE ${PROJECT_COMPILE_OPTIONS})
-ament_target_dependencies(${PROJECT_NAME} SYSTEM
+ament_target_dependencies(${PROJECT_NAME}
   ${THIS_PACKAGE_EXPORT_DEPENDS}
-
+)
+ament_target_dependencies(${PROJECT_NAME} SYSTEM
   # We don't export these dependencies because their cmake is broken
   ASSIMP
   QHULL


### PR DESCRIPTION
Fix: https://github.com/ros-planning/geometric_shapes/issues/185
