### PR TITLE
Use proper Eigen alignment for make_shared calls

### DIFF
--- a/src/bodies.cpp
+++ b/src/bodies.cpp
@@ -209,7 +209,7 @@ void bodies::Sphere::updateInternalData()
 
 std::shared_ptr<bodies::Body> bodies::Sphere::cloneAt(const Eigen::Isometry3d& pose, double padding, double scale) const
 {
-  auto s = std::make_shared<Sphere>();
+  auto s = std::allocate_shared<Sphere>(Eigen::aligned_allocator<Sphere>());
   s->radius_ = radius_;
   s->padding_ = padding;
   s->scale_ = scale;
@@ -410,7 +410,7 @@ bool bodies::Cylinder::samplePointInside(random_numbers::RandomNumberGenerator& 
 std::shared_ptr<bodies::Body> bodies::Cylinder::cloneAt(const Eigen::Isometry3d& pose, double padding,
                                                         double scale) const
 {
-  auto c = std::make_shared<Cylinder>();
+  auto c = std::allocate_shared<Cylinder>(Eigen::aligned_allocator<Cylinder>());
   c->length_ = length_;
   c->radius_ = radius_;
   c->padding_ = padding;
@@ -625,7 +625,7 @@ void bodies::Box::updateInternalData()
 
 std::shared_ptr<bodies::Body> bodies::Box::cloneAt(const Eigen::Isometry3d& pose, double padding, double scale) const
 {
-  auto b = std::make_shared<Box>();
+  auto b = std::allocate_shared<Box>(Eigen::aligned_allocator<Box>());
   b->length_ = length_;
   b->width_ = width_;
   b->height_ = height_;
@@ -798,7 +798,7 @@ void bodies::ConvexMesh::correctVertexOrderFromPlanes()
 
 void bodies::ConvexMesh::useDimensions(const shapes::Shape* shape)
 {
-  mesh_data_ = std::make_shared<MeshData>();
+  mesh_data_ = std::allocate_shared<MeshData>(Eigen::aligned_allocator<MeshData>());
   const shapes::Mesh* mesh = static_cast<const shapes::Mesh*>(shape);
 
   double maxX = -std::numeric_limits<double>::infinity(), maxY = -std::numeric_limits<double>::infinity(),
@@ -1110,7 +1110,7 @@ const EigenSTL::vector_Vector4d& bodies::ConvexMesh::getPlanes() const
 std::shared_ptr<bodies::Body> bodies::ConvexMesh::cloneAt(const Eigen::Isometry3d& pose, double padding,
                                                           double scale) const
 {
-  auto m = std::make_shared<ConvexMesh>();
+  auto m = std::allocate_shared<ConvexMesh>(Eigen::aligned_allocator<ConvexMesh>());
   m->mesh_data_ = mesh_data_;
   m->padding_ = padding;
   m->scale_ = scale;


### PR DESCRIPTION
I just discovered building with AVX instructions enabled that bodies segfault sometimes on unaligned data.

When building without `NDEBUG`, this error message shows up:

> pointcloud2_filter_chain: /usr/include/eigen3/Eigen/src/Core/DenseStorage.h:128: Eigen::internal::plain_array<T, Size, MatrixOrArrayOptions, 32>::plain_array() [with T = double; int Size = 16; int MatrixOrArrayOptions = 0]: Assertion `(internal::UIntPtr(eigen_unaligned_array_assert_workaround_gcc47(array)) & (31)) == 0 && "this assertion is explained here: " "http://eigen.tuxfamily.org/dox-devel/group__TopicUnalignedArrayAssert.html" " **** READ THIS WEB PAGE !!! ****"' failed.

An example stack trace is here:

<details>

```
#0  __GI_raise (sig=sig@entry=6) at ../sysdeps/unix/sysv/linux/raise.c:51
#1  0x00007f7dcb003921 in __GI_abort () at abort.c:79
#2  0x00007f7dcaff348a in __assert_fail_base (fmt=0x7f7dcb17a750 "%s%s%s:%u: %s%sAssertion `%s' failed.\n%n", 
    assertion=assertion@entry=0x7f7dbd6f3bf0 "(internal::UIntPtr(eigen_unaligned_array_assert_workaround_gcc47(array)) & (31)) == 0 && \"this assertion is explained here: \" \"http://eigen.tuxfamily.org/dox-devel/group__TopicUnalignedArrayAssert.htm"..., file=file@entry=0x7f7dbd6f3bb8 "/usr/include/eigen3/Eigen/src/Core/DenseStorage.h", line=line@entry=128, 
    function=function@entry=0x7f7dbd6f5360 <Eigen::internal::plain_array<double, 16, 0, 32>::plain_array()::__PRETTY_FUNCTION__> "Eigen::internal::plain_array<T, Size, MatrixOrArrayOptions, 32>::plain_array() [with T = double; int Size = 16; int MatrixOrArrayOptions = 0]") at assert.c:92
#3  0x00007f7dcaff3502 in __GI___assert_fail (
    assertion=assertion@entry=0x7f7dbd6f3bf0 "(internal::UIntPtr(eigen_unaligned_array_assert_workaround_gcc47(array)) & (31)) == 0 && \"this assertion is explained here: \" \"http://eigen.tuxfamily.org/dox-devel/group__TopicUnalignedArrayAssert.htm"..., file=file@entry=0x7f7dbd6f3bb8 "/usr/include/eigen3/Eigen/src/Core/DenseStorage.h", line=line@entry=128, 
    function=function@entry=0x7f7dbd6f5360 <Eigen::internal::plain_array<double, 16, 0, 32>::plain_array()::__PRETTY_FUNCTION__> "Eigen::internal::plain_array<T, Size, MatrixOrArrayOptions, 32>::plain_array() [with T = double; int Size = 16; int MatrixOrArrayOptions = 0]") at assert.c:101
#4  0x00007f7dbd6df141 in Eigen::internal::plain_array<double, 16, 0, 32>::plain_array (this=<optimized out>) at /usr/include/eigen3/Eigen/src/Core/util/Memory.h:168
#5  Eigen::DenseStorage<double, 16, 4, 4, 0>::DenseStorage (this=<optimized out>) at /usr/include/eigen3/Eigen/src/Core/DenseStorage.h:187
#6  Eigen::PlainObjectBase<Eigen::Matrix<double, 4, 4, 0, 4, 4> >::PlainObjectBase (this=<optimized out>) at /usr/include/eigen3/Eigen/src/Core/PlainObjectBase.h:484
#7  Eigen::Matrix<double, 4, 4, 0, 4, 4>::Matrix (this=<optimized out>) at /usr/include/eigen3/Eigen/src/Core/Matrix.h:259
#8  Eigen::Transform<double, 3, 1, 0>::Transform (this=<optimized out>) at /usr/include/eigen3/Eigen/src/Geometry/Transform.h:257
#9  bodies::BoundingCylinder::BoundingCylinder (this=<optimized out>) at /media/data/rosdevday/ws/src/geometric_shapes/include/geometric_shapes/bodies.h:69
#10 bodies::ConvexMesh::MeshData::MeshData (this=<optimized out>) at /media/data/rosdevday/ws/src/geometric_shapes/include/geometric_shapes/bodies.h:553
#11 __gnu_cxx::new_allocator<bodies::ConvexMesh::MeshData>::construct<bodies::ConvexMesh::MeshData> (this=<optimized out>, __p=<optimized out>)
    at /media/data/rosdevday/ws/src/geometric_shapes/include/geometric_shapes/bodies.h:553
#12 std::allocator_traits<std::allocator<bodies::ConvexMesh::MeshData> >::construct<bodies::ConvexMesh::MeshData> (__a=..., __p=<optimized out>) at /usr/include/c++/8/bits/alloc_traits.h:475
#13 std::_Sp_counted_ptr_inplace<bodies::ConvexMesh::MeshData, std::allocator<bodies::ConvexMesh::MeshData>, (__gnu_cxx::_Lock_policy)2>::_Sp_counted_ptr_inplace<>(std::allocator<bodies::ConvexMesh::MeshData>)
    (__a=..., this=<optimized out>) at /usr/include/c++/8/bits/shared_ptr_base.h:545
#14 std::__shared_count<(__gnu_cxx::_Lock_policy)2>::__shared_count<bodies::ConvexMesh::MeshData, std::allocator<bodies::ConvexMesh::MeshData>>(bodies::ConvexMesh::MeshData*&, std::_Sp_alloc_shared_tag<std::allocator<bodies::ConvexMesh::MeshData> >) (__a=..., __p=<optimized out>, this=<optimized out>) at /usr/include/c++/8/bits/shared_ptr_base.h:677
#15 std::__shared_ptr<bodies::ConvexMesh::MeshData, (__gnu_cxx::_Lock_policy)2>::__shared_ptr<std::allocator<bodies::ConvexMesh::MeshData>>(std::_Sp_alloc_shared_tag<std::allocator<bodies::ConvexMesh::MeshData> >) (__tag=..., this=<optimized out>) at /usr/include/c++/8/bits/shared_ptr_base.h:1342
#16 std::shared_ptr<bodies::ConvexMesh::MeshData>::shared_ptr<std::allocator<bodies::ConvexMesh::MeshData>>(std::_Sp_alloc_shared_tag<std::allocator<bodies::ConvexMesh::MeshData> >) (__tag=..., 
    this=<optimized out>) at /usr/include/c++/8/bits/shared_ptr.h:359
#17 std::allocate_shared<bodies::ConvexMesh::MeshData, std::allocator<bodies::ConvexMesh::MeshData>>(std::allocator<bodies::ConvexMesh::MeshData> const&) (__a=...) at /usr/include/c++/8/bits/shared_ptr.h:706
#18 std::make_shared<bodies::ConvexMesh::MeshData> () at /usr/include/c++/8/bits/shared_ptr.h:722
#19 bodies::ConvexMesh::useDimensions(shapes::Shape const*) () at /media/data/rosdevday/ws/src/geometric_shapes/src/bodies.cpp:801
#20 0x00007f7dbd6db08a in bodies::Body::setDimensionsDirty (shape=<optimized out>, this=0x5622dc71ee20) at /media/data/rosdevday/ws/src/geometric_shapes/include/geometric_shapes/bodies.h:196
#21 bodies::Body::setDimensions (this=0x5622dc71ee20, shape=<optimized out>) at /media/data/rosdevday/ws/src/geometric_shapes/src/bodies.cpp:164
#22 0x00007f7dbd6e7bf7 in bodies::createBodyFromShape (shape=0x5622dc7b1fe0) at /media/data/rosdevday/ws/src/geometric_shapes/src/body_operations.cpp:75
#23 0x00007f7dbd907b74 in point_containment_filter::ShapeMask::addShape(std::shared_ptr<shapes::Shape const> const&, double, double) () from /opt/ros/melodic/lib/libmoveit_point_containment_filter.so.1.0.7
#24 0x00007f7dbdfaf8cc in robot_body_filter::RayCastingShapeMask::addShape (this=0x5622dbb671f0, shape=std::shared_ptr<const shapes::Shape> (use count 1, weak count 0) = {...}, scale=<optimized out>, 
    padding=<optimized out>, updateInternalStructures=updateInternalStructures@entry=false, name="::0base_link") at /media/data/subt/thirdparty/ws/src/robot_body_filter/src/RayCastingShapeMask.cpp:255
#25 0x00007f7dbdf8e728 in robot_body_filter::RobotBodyFilter<sensor_msgs::PointCloud2_<std::allocator<void> > >::addRobotMaskFromUrdf (this=this@entry=0x5622dc6f8fa0, 
    urdfModel="<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<!-- ", '=' <repeats 83 times>, " -->\n<!-- |    This document was autogenerated by xacro from /media/data/"...)
    at /usr/include/c++/8/bits/unique_ptr.h:345
#26 0x00007f7dbdf91f95 in robot_body_filter::RobotBodyFilter<sensor_msgs::PointCloud2_<std::allocator<void> > >::configure (this=this@entry=0x5622dc6f8fa0) at /usr/include/c++/8/bits/stl_map.h:463
#27 0x00007f7dbdf67bec in robot_body_filter::RobotBodyFilterPointCloud2::configure() () at /media/data/subt/thirdparty/ws/src/robot_body_filter/src/RobotBodyFilter.cpp:299
#28 0x00005622db829f3c in filters::FilterBase<sensor_msgs::PointCloud2_<std::allocator<void> > >::configure (this=this@entry=0x5622dc6f8fa0, config=...) at /opt/ros/melodic/include/filters/filter_base.h:80
#29 0x00005622db82f999 in filters::FilterChain<sensor_msgs::PointCloud2_<std::allocator<void> > >::configure (this=this@entry=0x7ffceddeae68, config=..., filter_ns="/X1/filter")
    at /opt/ros/melodic/include/xmlrpcpp/XmlRpcValue.h:94
#30 0x00005622db83030e in filters::FilterChain<sensor_msgs::PointCloud2_<std::allocator<void> > >::configure (this=this@entry=0x7ffceddeae68, param_name="cloud_filter_chain", node=...)
    at /opt/ros/melodic/include/ros/node_handle.h:191
#31 0x00005622db830676 in sensor_filters::FilterChainBase<sensor_msgs::PointCloud2_<std::allocator<void> > >::initFilters (this=this@entry=0x7ffceddeae40, filterChainNamespace="cloud_filter_chain", 
    filterNodeHandle=..., topicNodeHandle=..., useSharedPtrMessages=useSharedPtrMessages@entry=false, inputQueueSize=inputQueueSize@entry=10, outputQueueSize=10) at /usr/include/c++/8/bits/basic_string.h:936
#32 0x00005622db83b2e7 in sensor_filters::FilterChainNode<sensor_msgs::PointCloud2_<std::allocator<void> > >::FilterChainNode (topicNodeHandle=..., filterNodeHandle=..., 
    filterChainNamespace="cloud_filter_chain", this=0x7ffceddeae40) at /opt/ros/melodic/include/ros/node_handle.h:2153
#33 sensor_filters::spinFilterChain<sensor_msgs::PointCloud2_<std::allocator<void> > > (filterChainNamespace="cloud_filter_chain", argc=<optimized out>, argc@entry=5, argv=argv@entry=0x7ffceddeb298)
    at /media/data/rosdevday/ws/src/sensor_filters/include/sensor_filters/FilterChainNode.h:59
#34 0x00005622db81cadc in main () at /usr/include/c++/8/ext/new_allocator.h:79
```

</details>

The error message from Eigen says that `make_shared` should not be used with aligned types and they should instead be allocated using the custom Eigen allocator. Doing so results in no more segfaults in my application.

I quickly grepped through `geometric_shapes` and it seems these are the only usages of `make_shared`/`make_unique`.

This change should have no compatibility impact on API/ABI, as it only aligns an internal member of the `shared_ptr`. But rather re-check my line of thought.