### PR TITLE
Fix building on Windows with MSVC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,8 +17,6 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     -Wredundant-decls
     -Wno-unused-parameter
   )
-else()
-  add_definitions(-D_USE_MATH_DEFINES)
 endif()
 
 list(APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake/")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,15 +7,19 @@ if(NOT CMAKE_CXX_STANDARD)
 endif()
 
 # Set compile options
-set(PROJECT_COMPILE_OPTIONS
-  -Wall
-  -Wextra
-  -Wwrite-strings
-  -Wunreachable-code
-  -Wpointer-arith
-  -Wredundant-decls
-  -Wno-unused-parameter
-)
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  set(PROJECT_COMPILE_OPTIONS
+    -Wall
+    -Wextra
+    -Wwrite-strings
+    -Wunreachable-code
+    -Wpointer-arith
+    -Wredundant-decls
+    -Wno-unused-parameter
+  )
+else()
+  add_definitions(-D_USE_MATH_DEFINES)
+endif()
 
 list(APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake/")
 
@@ -90,8 +94,7 @@ add_library(${PROJECT_NAME} SHARED
   src/shape_to_marker.cpp
   src/shapes.cpp
 )
-target_compile_options(${PROJECT_NAME} PRIVATE ${PROJECT_COMPILE_OPTIONS})
-set_target_properties(${PROJECT_NAME} PROPERTIES VERSION ${${PROJECT_NAME}_VERSION})
+set_target_properties(${PROJECT_NAME} PROPERTIES VERSION ${${PROJECT_NAME}_VERSION} WINDOWS_EXPORT_ALL_SYMBOLS TRUE)
 target_compile_options(${PROJECT_NAME} PRIVATE ${PROJECT_COMPILE_OPTIONS})
 ament_target_dependencies(${PROJECT_NAME}
   ${THIS_PACKAGE_EXPORT_DEPENDS}

--- a/include/geometric_shapes/bodies.h
+++ b/include/geometric_shapes/bodies.h
@@ -37,10 +37,6 @@
 #ifndef GEOMETRIC_SHAPES_BODIES_
 #define GEOMETRIC_SHAPES_BODIES_
 
-#if __cplusplus <= 199711L && _MSVC_LANG <= 199711L
-#error This header requires at least C++11
-#endif
-
 #define _USE_MATH_DEFINES
 #include "geometric_shapes/aabb.h"
 #include "geometric_shapes/shapes.h"

--- a/include/geometric_shapes/bodies.h
+++ b/include/geometric_shapes/bodies.h
@@ -37,7 +37,7 @@
 #ifndef GEOMETRIC_SHAPES_BODIES_
 #define GEOMETRIC_SHAPES_BODIES_
 
-#if __cplusplus <= 199711L
+#if __cplusplus <= 199711L && _MSVC_LANG <= 199711L
 #error This header requires at least C++11
 #endif
 

--- a/include/geometric_shapes/bodies.h
+++ b/include/geometric_shapes/bodies.h
@@ -41,6 +41,7 @@
 #error This header requires at least C++11
 #endif
 
+#define _USE_MATH_DEFINES
 #include "geometric_shapes/aabb.h"
 #include "geometric_shapes/shapes.h"
 #include <eigen_stl_containers/eigen_stl_containers.h>

--- a/include/geometric_shapes/shape_messages.h
+++ b/include/geometric_shapes/shape_messages.h
@@ -42,10 +42,6 @@
 #include <shape_msgs/msg/plane.hpp>
 #include <boost/variant.hpp>
 
-#if __cplusplus <= 199711L && _MSVC_LANG <= 199711L
-#error This header requires at least C++11 (boost::variant is incompatible between c++98 and c++11 and we enforce 11)
-#endif
-
 namespace shapes
 {
 /** \brief Type that can hold any of the desired shape message types */

--- a/include/geometric_shapes/shape_messages.h
+++ b/include/geometric_shapes/shape_messages.h
@@ -42,7 +42,7 @@
 #include <shape_msgs/msg/plane.hpp>
 #include <boost/variant.hpp>
 
-#if __cplusplus <= 199711L
+#if __cplusplus <= 199711L && _MSVC_LANG <= 199711L
 #error This header requires at least C++11 (boost::variant is incompatible between c++98 and c++11 and we enforce 11)
 #endif
 

--- a/include/geometric_shapes/shapes.h
+++ b/include/geometric_shapes/shapes.h
@@ -37,10 +37,6 @@
 #ifndef GEOMETRIC_SHAPES_SHAPES_
 #define GEOMETRIC_SHAPES_SHAPES_
 
-#if __cplusplus <= 199711L && _MSVC_LANG <= 199711L
-#error This header requires at least C++11
-#endif
-
 #include <cstdlib>
 #include <vector>
 #include <iostream>

--- a/include/geometric_shapes/shapes.h
+++ b/include/geometric_shapes/shapes.h
@@ -37,7 +37,7 @@
 #ifndef GEOMETRIC_SHAPES_SHAPES_
 #define GEOMETRIC_SHAPES_SHAPES_
 
-#if __cplusplus <= 199711L
+#if __cplusplus <= 199711L && _MSVC_LANG <= 199711L
 #error This header requires at least C++11
 #endif
 


### PR DESCRIPTION
The ROS2 branch fails to compile on Windows with MSVC. 

There were 3 things I had to change.
1. The warning flags (`-Wextra`, `-Wwrite-strings`, etc.) aren't available, so I just got rid of those when using MSVC.
2. `M_PI` is not defined unless `_USE_MATH_DEFINES` is also defined.
3. `__cplusplus` is not set to the correct value unless the `/Zc:__cplusplus` compiler flag is used. However, simply adding this compiler flag still doesn't fix the issue for any other packages that include the files. However, `_MSVC_LANG` seems to be set the correct value, so I used that macro to perform the check.