### PR TITLE
Fix memory leak in createMeshFromBinary

### DIFF
--- a/src/mesh_operations.cpp
+++ b/src/mesh_operations.cpp
@@ -261,7 +261,10 @@ Mesh* createMeshFromBinary(const char* buffer, std::size_t size, const Eigen::Ve
   // so they must be delayed until after clearing the root node transform above.
   importer.ApplyPostProcessing(aiProcess_OptimizeMeshes | aiProcess_OptimizeGraph);
 
-  return createMeshFromAsset(scene, scale, hint);
+  Mesh* mesh = createMeshFromAsset(scene, scale, hint);
+  delete scene;
+
+  return mesh;
 }
 
 Mesh* createMeshFromResource(const std::string& resource, const Eigen::Vector3d& scale)


### PR DESCRIPTION
When using `createMeshFromBinary` `scene` gets created as a raw pointer but never deleted even after the pointer goes out of scope. This resulted in approximately 1.1 GB of memory leaked when loading some of our URDFs. Explicitly deleting the object after use fixes this problem.