### PR TITLE
Fix cmake such that Boost::filesystem is exported properly

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -126,4 +126,4 @@ install(DIRECTORY include/ DESTINATION include)
 ament_export_targets(export_${PROJECT_NAME} HAS_LIBRARY_TARGET)
 ament_export_dependencies(${THIS_PACKAGE_EXPORT_DEPENDS})
 
-ament_package()
+ament_package(CONFIG_EXTRAS "cmake/ConfigExtras.cmake")

--- a/cmake/ConfigExtras.cmake
+++ b/cmake/ConfigExtras.cmake
@@ -1,0 +1,2 @@
+find_package(Boost REQUIRED COMPONENTS filesystem)
+list(APPEND geometric_shapes_LIBRARIES ${Boost_LIBRARIES})


### PR DESCRIPTION
This fixes https://github.com/ros-planning/geometric_shapes/issues/166. Ultimately [this issue](https://github.com/ament/ament_cmake/issues/282) result in the `Boost` components not getting exported with an `ament_target_dependencies` and `ament_export_dependencies` calls.

Before this fix attempting to link against this pkg resulted in,
```
Target "mylib" links to target "Boost::filesystem"
  but the target was not found.  Perhaps a find_package() call is missing for
  an IMPORTED target, or an ALIAS target is missing?
```

After this fix it builds properly.