### PR TITLE
[melodic backport] Added body operations constructShapeFromBody() and constructMarkerFromBody().

### DIFF
--- a/include/geometric_shapes/bodies.h
+++ b/include/geometric_shapes/bodies.h
@@ -199,6 +199,9 @@ public:
   /** \brief Get the dimensions associated to this body (as read from corresponding shape) */
   virtual std::vector<double> getDimensions() const = 0;
 
+  /** \brief Get the dimensions associated to this body (scaled and padded) */
+  virtual std::vector<double> getScaledDimensions() const = 0;
+
   /** \brief Set the dimensions of the body (from corresponding shape) */
   void setDimensions(const shapes::Shape* shape);
 
@@ -313,6 +316,7 @@ public:
 
   /** \brief Get the radius of the sphere */
   std::vector<double> getDimensions() const override;
+  std::vector<double> getScaledDimensions() const override;
 
   bool containsPoint(const Eigen::Vector3d& p, bool verbose = false) const override;
   double computeVolume() const override;
@@ -372,6 +376,7 @@ public:
 
   /** \brief Get the radius & length of the cylinder */
   std::vector<double> getDimensions() const override;
+  std::vector<double> getScaledDimensions() const override;
 
   bool containsPoint(const Eigen::Vector3d& p, bool verbose = false) const override;
   double computeVolume() const override;
@@ -444,6 +449,7 @@ public:
 
   /** \brief Get the length & width & height (x, y, z) of the box */
   std::vector<double> getDimensions() const override;
+  std::vector<double> getScaledDimensions() const override;
 
   bool containsPoint(const Eigen::Vector3d& p, bool verbose = false) const override;
   double computeVolume() const override;
@@ -507,6 +513,8 @@ public:
 
   /** \brief Returns an empty vector */
   std::vector<double> getDimensions() const override;
+  /** \brief Returns an empty vector */
+  std::vector<double> getScaledDimensions() const override;
 
   bool containsPoint(const Eigen::Vector3d& p, bool verbose = false) const override;
   double computeVolume() const override;

--- a/include/geometric_shapes/body_operations.h
+++ b/include/geometric_shapes/body_operations.h
@@ -41,6 +41,7 @@
 #include "geometric_shapes/bodies.h"
 #include "geometric_shapes/shape_messages.h"
 #include <geometry_msgs/Pose.h>
+#include <visualization_msgs/Marker.h>
 #include <vector>
 
 namespace bodies
@@ -59,6 +60,12 @@ Body* constructBodyFromMsg(const shape_msgs::SolidPrimitive& shape, const geomet
 
 /** \brief Create a body from a given shape */
 Body* constructBodyFromMsg(const shapes::ShapeMsg& shape, const geometry_msgs::Pose& pose);
+
+/** \brief Get a shape that corresponds to this (scaled and padded) body. */
+shapes::ShapeConstPtr constructShapeFromBody(const bodies::Body* body);
+
+/** \brief Construct a Marker message that corresponds to this (scaled and padded) body. */
+void constructMarkerFromBody(const bodies::Body* body, visualization_msgs::Marker& msg);
 
 /** \brief Compute a bounding sphere to enclose a set of bounding spheres */
 void mergeBoundingSpheres(const std::vector<BoundingSphere>& spheres, BoundingSphere& mergedSphere);

--- a/src/bodies.cpp
+++ b/src/bodies.cpp
@@ -193,8 +193,7 @@ void bodies::Sphere::useDimensions(const shapes::Shape* shape)  // radius
 
 std::vector<double> bodies::Sphere::getDimensions() const
 {
-  std::vector<double> d(1, radius_);
-  return d;
+  return { radius_ };
 }
 
 std::vector<double> bodies::Sphere::getScaledDimensions() const
@@ -364,10 +363,7 @@ void bodies::Cylinder::useDimensions(const shapes::Shape* shape)  // (length, ra
 
 std::vector<double> bodies::Cylinder::getDimensions() const
 {
-  std::vector<double> d(2);
-  d[0] = radius_;
-  d[1] = length_;
-  return d;
+  return { radius_, length_ };
 }
 
 std::vector<double> bodies::Cylinder::getScaledDimensions() const
@@ -595,11 +591,7 @@ void bodies::Box::useDimensions(const shapes::Shape* shape)  // (x, y, z) = (len
 
 std::vector<double> bodies::Box::getDimensions() const
 {
-  std::vector<double> d(3);
-  d[0] = length_;
-  d[1] = width_;
-  d[2] = height_;
-  return d;
+  return { length_, width_, height_ };
 }
 
 std::vector<double> bodies::Box::getScaledDimensions() const
@@ -993,12 +985,12 @@ void bodies::ConvexMesh::useDimensions(const shapes::Shape* shape)
 
 std::vector<double> bodies::ConvexMesh::getDimensions() const
 {
-  return std::vector<double>();
+  return {};
 }
 
 std::vector<double> bodies::ConvexMesh::getScaledDimensions() const
 {
-  return std::vector<double>();
+  return {};
 }
 
 void bodies::ConvexMesh::computeScaledVerticesFromPlaneProjections()

--- a/src/bodies.cpp
+++ b/src/bodies.cpp
@@ -197,6 +197,11 @@ std::vector<double> bodies::Sphere::getDimensions() const
   return d;
 }
 
+std::vector<double> bodies::Sphere::getScaledDimensions() const
+{
+  return { radiusU_ };
+}
+
 void bodies::Sphere::updateInternalData()
 {
   const auto tmpRadiusU = radius_ * scale_ + padding_;
@@ -363,6 +368,11 @@ std::vector<double> bodies::Cylinder::getDimensions() const
   d[0] = radius_;
   d[1] = length_;
   return d;
+}
+
+std::vector<double> bodies::Cylinder::getScaledDimensions() const
+{
+  return { radiusU_, 2 * length2_ };
 }
 
 void bodies::Cylinder::updateInternalData()
@@ -590,6 +600,11 @@ std::vector<double> bodies::Box::getDimensions() const
   d[1] = width_;
   d[2] = height_;
   return d;
+}
+
+std::vector<double> bodies::Box::getScaledDimensions() const
+{
+  return { 2 * length2_, 2 * width2_, 2 * height2_ };
 }
 
 void bodies::Box::updateInternalData()
@@ -977,6 +992,11 @@ void bodies::ConvexMesh::useDimensions(const shapes::Shape* shape)
 }
 
 std::vector<double> bodies::ConvexMesh::getDimensions() const
+{
+  return std::vector<double>();
+}
+
+std::vector<double> bodies::ConvexMesh::getScaledDimensions() const
 {
   return std::vector<double>();
 }

--- a/src/body_operations.cpp
+++ b/src/body_operations.cpp
@@ -86,19 +86,20 @@ shapes::ShapeConstPtr bodies::constructShapeFromBody(const bodies::Body* body)
   {
     case shapes::SPHERE:
     {
-      const auto& dims = static_cast<const bodies::Sphere*>(body)->getScaledDimensions();
+      // As we already know body's type, we can skip the vtable lookup and use compile-time polymorphism
+      const auto& dims = static_cast<const bodies::Sphere*>(body)->bodies::Sphere::getScaledDimensions();
       result.reset(new shapes::Sphere(dims[0]));
       break;
     }
     case shapes::BOX:
     {
-      const auto& dims = static_cast<const bodies::Box*>(body)->getScaledDimensions();
+      const auto& dims = static_cast<const bodies::Box*>(body)->bodies::Box::getScaledDimensions();
       result.reset(new shapes::Box(dims[0], dims[1], dims[2]));
       break;
     }
     case shapes::CYLINDER:
     {
-      const auto& dims = static_cast<const bodies::Cylinder*>(body)->getScaledDimensions();
+      const auto& dims = static_cast<const bodies::Cylinder*>(body)->bodies::Cylinder::getScaledDimensions();
       result.reset(new shapes::Cylinder(dims[0], dims[1]));
       break;
     }

--- a/src/body_operations.cpp
+++ b/src/body_operations.cpp
@@ -78,6 +78,71 @@ bodies::Body* bodies::createBodyFromShape(const shapes::Shape* shape)
   return body;
 }
 
+shapes::ShapeConstPtr bodies::constructShapeFromBody(const bodies::Body* body)
+{
+  shapes::ShapePtr result;
+
+  switch (body->getType())
+  {
+    case shapes::SPHERE:
+    {
+      const auto& dims = dynamic_cast<const bodies::Sphere*>(body)->getScaledDimensions();
+      result.reset(new shapes::Sphere(dims[0]));
+      break;
+    }
+    case shapes::BOX:
+    {
+      const auto& dims = dynamic_cast<const bodies::Box*>(body)->getScaledDimensions();
+      result.reset(new shapes::Box(dims[0], dims[1], dims[2]));
+      break;
+    }
+    case shapes::CYLINDER:
+    {
+      const auto& dims = dynamic_cast<const bodies::Cylinder*>(body)->getScaledDimensions();
+      result.reset(new shapes::Cylinder(dims[0], dims[1]));
+      break;
+    }
+    case shapes::MESH:
+    {
+      const auto mesh = dynamic_cast<const bodies::ConvexMesh*>(body);
+      const auto& scaledVertices = mesh->getScaledVertices();
+
+      // createMeshFromVertices requires an "expanded" list of triangles where each triangle is
+      // represented by its three vertex positions
+      EigenSTL::vector_Vector3d vertexList;
+      vertexList.reserve(3 * mesh->getTriangles().size());
+      for (const auto& triangle : mesh->getTriangles())
+        vertexList.push_back(scaledVertices[triangle]);
+
+      result.reset(shapes::createMeshFromVertices(vertexList));
+      break;
+    }
+    default:
+    {
+      CONSOLE_BRIDGE_logError("Unknown body type: %d", (int)body->getType());
+      break;
+    }
+  }
+  return result;
+}
+
+void bodies::constructMarkerFromBody(const bodies::Body* body, visualization_msgs::Marker& msg)
+{
+  auto shape = bodies::constructShapeFromBody(body);
+  shapes::constructMarkerFromShape(shape.get(), msg, true);
+  const auto& pose = body->getPose();
+  msg.pose.position.x = pose.translation().x();
+  msg.pose.position.y = pose.translation().y();
+  msg.pose.position.z = pose.translation().z();
+
+  ASSERT_ISOMETRY(pose);
+  Eigen::Quaterniond quat(pose.linear().matrix());
+  msg.pose.orientation.x = quat.x();
+  msg.pose.orientation.y = quat.y();
+  msg.pose.orientation.z = quat.z();
+  msg.pose.orientation.w = quat.w();
+}
+
 void bodies::mergeBoundingSpheres(const std::vector<BoundingSphere>& spheres, BoundingSphere& mergedSphere)
 {
   if (spheres.empty())

--- a/src/body_operations.cpp
+++ b/src/body_operations.cpp
@@ -86,25 +86,25 @@ shapes::ShapeConstPtr bodies::constructShapeFromBody(const bodies::Body* body)
   {
     case shapes::SPHERE:
     {
-      const auto& dims = dynamic_cast<const bodies::Sphere*>(body)->getScaledDimensions();
+      const auto& dims = static_cast<const bodies::Sphere*>(body)->getScaledDimensions();
       result.reset(new shapes::Sphere(dims[0]));
       break;
     }
     case shapes::BOX:
     {
-      const auto& dims = dynamic_cast<const bodies::Box*>(body)->getScaledDimensions();
+      const auto& dims = static_cast<const bodies::Box*>(body)->getScaledDimensions();
       result.reset(new shapes::Box(dims[0], dims[1], dims[2]));
       break;
     }
     case shapes::CYLINDER:
     {
-      const auto& dims = dynamic_cast<const bodies::Cylinder*>(body)->getScaledDimensions();
+      const auto& dims = static_cast<const bodies::Cylinder*>(body)->getScaledDimensions();
       result.reset(new shapes::Cylinder(dims[0], dims[1]));
       break;
     }
     case shapes::MESH:
     {
-      const auto mesh = dynamic_cast<const bodies::ConvexMesh*>(body);
+      const auto mesh = static_cast<const bodies::ConvexMesh*>(body);
       const auto& scaledVertices = mesh->getScaledVertices();
 
       // createMeshFromVertices requires an "expanded" list of triangles where each triangle is

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -32,3 +32,6 @@ target_link_libraries(test_shapes ${PROJECT_NAME} ${catkin_LIBRARIES} ${Boost_LI
 
 catkin_add_gtest(test_ray_intersection test_ray_intersection.cpp)
 target_link_libraries(test_ray_intersection ${PROJECT_NAME} ${catkin_LIBRARIES} ${Boost_LIBRARIES})
+
+catkin_add_gtest(test_body_operations test_body_operations.cpp)
+target_link_libraries(test_body_operations ${PROJECT_NAME} ${catkin_LIBRARIES} ${Boost_LIBRARIES})

--- a/test/test_body_operations.cpp
+++ b/test/test_body_operations.cpp
@@ -1,0 +1,280 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2019, Bielefeld University
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the Bielefeld University nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+#include <geometric_shapes/body_operations.h>
+#include <geometric_shapes/shape_operations.h>
+#include <boost/filesystem.hpp>
+#include "resources/config.h"
+#include <gtest/gtest.h>
+
+using namespace bodies;
+
+void expectVector3dSetsEqual(EigenSTL::vector_Vector3d vec1, EigenSTL::vector_Vector3d vec2,
+                             const double upToError = 1e-6)
+{
+  ASSERT_EQ(vec1.size(), vec2.size());
+
+  auto vecCompare = [upToError](const Eigen::Vector3d& a, const Eigen::Vector3d& b) -> bool {
+    if (a.x() < b.x() - upToError)
+      return true;
+    if (a.x() > b.x() + upToError)
+      return false;
+
+    if (a.y() < b.y() - upToError)
+      return true;
+    if (a.y() > b.y() + upToError)
+      return false;
+
+    if (a.z() < b.z() - upToError)
+      return true;
+    if (a.z() > b.z() + upToError)
+      return false;
+
+    return false;
+  };
+
+  std::sort(vec1.begin(), vec1.end(), vecCompare);
+  std::sort(vec2.begin(), vec2.end(), vecCompare);
+
+  for (size_t i = 0; i < vec1.size(); ++i)
+  {
+    EXPECT_NEAR(vec1[i].x(), vec2[i].x(), upToError);
+    EXPECT_NEAR(vec1[i].y(), vec2[i].y(), upToError);
+    EXPECT_NEAR(vec1[i].z(), vec2[i].z(), upToError);
+  }
+}
+
+TEST(Bodies, ConstructShapeFromBodySphere)
+{
+  const shapes::Shape* shape = new shapes::Sphere(2.0);
+  const auto body = new Sphere(shape);
+
+  const auto constructedShape = constructShapeFromBody(body);
+  const auto constructedSphere = std::dynamic_pointer_cast<const shapes::Sphere>(constructedShape);
+
+  EXPECT_EQ(shape->type, constructedShape->type);
+  ASSERT_NE(nullptr, constructedSphere);
+  EXPECT_EQ(2.0, constructedSphere->radius);
+}
+
+TEST(Bodies, ConstructShapeFromBodyBox)
+{
+  const shapes::Shape* shape = new shapes::Box(1.0, 2.0, 3.0);
+  const auto body = new Box(shape);
+
+  const auto constructedShape = constructShapeFromBody(body);
+  const auto constructedBox = std::dynamic_pointer_cast<const shapes::Box>(constructedShape);
+
+  EXPECT_EQ(shape->type, constructedShape->type);
+  ASSERT_NE(nullptr, constructedBox);
+  EXPECT_EQ(1.0, constructedBox->size[0]);
+  EXPECT_EQ(2.0, constructedBox->size[1]);
+  EXPECT_EQ(3.0, constructedBox->size[2]);
+}
+
+TEST(Bodies, ConstructShapeFromBodyCylinder)
+{
+  const shapes::Shape* shape = new shapes::Cylinder(1.0, 2.0);
+  const auto body = new Cylinder(shape);
+
+  const auto constructedShape = constructShapeFromBody(body);
+  const auto constructedCylinder = std::dynamic_pointer_cast<const shapes::Cylinder>(constructedShape);
+
+  EXPECT_EQ(shape->type, constructedShape->type);
+  ASSERT_NE(nullptr, constructedCylinder);
+  EXPECT_EQ(1.0, constructedCylinder->radius);
+  EXPECT_EQ(2.0, constructedCylinder->length);
+}
+
+TEST(Bodies, ConstructShapeFromBodyMesh)
+{
+  shapes::Mesh* shape =
+      shapes::createMeshFromResource("file://" + (boost::filesystem::path(TEST_RESOURCES_DIR) / "/box.dae").string());
+  const auto body = new ConvexMesh(shape);
+
+  const auto constructedShape = constructShapeFromBody(body);
+  const auto constructedMesh = std::dynamic_pointer_cast<const shapes::Mesh>(constructedShape);
+
+  EXPECT_EQ(shape->type, constructedShape->type);
+  ASSERT_NE(nullptr, constructedMesh);
+  ASSERT_EQ(shape->vertex_count, constructedMesh->vertex_count);
+  ASSERT_EQ(shape->triangle_count, constructedMesh->triangle_count);
+
+  // Compare the vertices and triangle normals of the constructed mesh
+  // Triangle indices cannot be checked because the vertex IDs could change in the constructed mesh
+
+  EigenSTL::vector_Vector3d verticesOrig, verticesConstructed;
+  for (size_t i = 0; i < shape->vertex_count * 3; i += 3)
+    verticesOrig.push_back({ shape->vertices[i], shape->vertices[i + 1], shape->vertices[i + 2] });
+  for (size_t i = 0; i < constructedMesh->vertex_count * 3; i += 3)
+    verticesConstructed.push_back(
+        { constructedMesh->vertices[i], constructedMesh->vertices[i + 1], constructedMesh->vertices[i + 2] });
+
+  expectVector3dSetsEqual(verticesOrig, verticesConstructed);
+
+  EigenSTL::vector_Vector3d normalsOrig, normalsConstructed;
+  shape->computeTriangleNormals();
+  // constructedMesh->computeTriangleNormals();  // is done during construction
+  for (size_t i = 0; i < shape->triangle_count * 3; i += 3)
+    normalsOrig.push_back(
+        { shape->triangle_normals[i], shape->triangle_normals[i + 1], shape->triangle_normals[i + 2] });
+  for (size_t i = 0; i < constructedMesh->triangle_count * 3; i += 3)
+    normalsConstructed.push_back({ constructedMesh->triangle_normals[i], constructedMesh->triangle_normals[i + 1],
+                                   constructedMesh->triangle_normals[i + 2] });
+
+  expectVector3dSetsEqual(normalsOrig, normalsConstructed);
+}
+
+TEST(Bodies, ConstructMarkerFromBodySphere)
+{
+  const Eigen::Isometry3d pose =
+      Eigen::Translation3d(1.0, 2.0, 3.0) * Eigen::AngleAxisd(M_PI_2, Eigen::Vector3d(0.0, 1.0, 0.0));
+
+  const shapes::Shape* shape = new shapes::Sphere(2.0);
+  const auto body = new Sphere(shape);
+  body->setPose(pose);
+
+  visualization_msgs::Marker marker;
+  constructMarkerFromBody(body, marker);
+
+  EXPECT_EQ(visualization_msgs::Marker::SPHERE, marker.type);
+  EXPECT_DOUBLE_EQ(4.0, marker.scale.x);
+  EXPECT_DOUBLE_EQ(4.0, marker.scale.y);
+  EXPECT_DOUBLE_EQ(4.0, marker.scale.z);
+  EXPECT_DOUBLE_EQ(1.0, marker.pose.position.x);
+  EXPECT_DOUBLE_EQ(2.0, marker.pose.position.y);
+  EXPECT_DOUBLE_EQ(3.0, marker.pose.position.z);
+  EXPECT_DOUBLE_EQ(0.0, marker.pose.orientation.x);
+  EXPECT_DOUBLE_EQ(M_SQRT1_2, marker.pose.orientation.y);
+  EXPECT_DOUBLE_EQ(0.0, marker.pose.orientation.z);
+  EXPECT_DOUBLE_EQ(M_SQRT1_2, marker.pose.orientation.w);
+}
+
+TEST(Bodies, ConstructMarkerFromBodyBox)
+{
+  const Eigen::Isometry3d pose =
+      Eigen::Translation3d(1.0, 2.0, 3.0) * Eigen::AngleAxisd(M_PI_2, Eigen::Vector3d(0.0, 1.0, 0.0));
+
+  const shapes::Shape* shape = new shapes::Box(1.0, 2.0, 3.0);
+  const auto body = new Box(shape);
+  body->setPose(pose);
+
+  visualization_msgs::Marker marker;
+  constructMarkerFromBody(body, marker);
+
+  EXPECT_EQ(visualization_msgs::Marker::CUBE, marker.type);
+  EXPECT_DOUBLE_EQ(1.0, marker.scale.x);
+  EXPECT_DOUBLE_EQ(2.0, marker.scale.y);
+  EXPECT_DOUBLE_EQ(3.0, marker.scale.z);
+  EXPECT_DOUBLE_EQ(1.0, marker.pose.position.x);
+  EXPECT_DOUBLE_EQ(2.0, marker.pose.position.y);
+  EXPECT_DOUBLE_EQ(3.0, marker.pose.position.z);
+  EXPECT_DOUBLE_EQ(0.0, marker.pose.orientation.x);
+  EXPECT_DOUBLE_EQ(M_SQRT1_2, marker.pose.orientation.y);
+  EXPECT_DOUBLE_EQ(0.0, marker.pose.orientation.z);
+  EXPECT_DOUBLE_EQ(M_SQRT1_2, marker.pose.orientation.w);
+}
+
+TEST(Bodies, ConstructMarkerFromBodyCylinder)
+{
+  const Eigen::Isometry3d pose =
+      Eigen::Translation3d(1.0, 2.0, 3.0) * Eigen::AngleAxisd(M_PI_2, Eigen::Vector3d(0.0, 1.0, 0.0));
+
+  const shapes::Shape* shape = new shapes::Cylinder(3.0, 2.0);
+  const auto body = new Cylinder(shape);
+  body->setPose(pose);
+
+  visualization_msgs::Marker marker;
+  constructMarkerFromBody(body, marker);
+
+  EXPECT_EQ(visualization_msgs::Marker::CYLINDER, marker.type);
+  EXPECT_DOUBLE_EQ(6.0, marker.scale.x);
+  EXPECT_DOUBLE_EQ(6.0, marker.scale.y);
+  EXPECT_DOUBLE_EQ(2.0, marker.scale.z);
+  EXPECT_DOUBLE_EQ(1.0, marker.pose.position.x);
+  EXPECT_DOUBLE_EQ(2.0, marker.pose.position.y);
+  EXPECT_DOUBLE_EQ(3.0, marker.pose.position.z);
+  EXPECT_DOUBLE_EQ(0.0, marker.pose.orientation.x);
+  EXPECT_DOUBLE_EQ(M_SQRT1_2, marker.pose.orientation.y);
+  EXPECT_DOUBLE_EQ(0.0, marker.pose.orientation.z);
+  EXPECT_DOUBLE_EQ(M_SQRT1_2, marker.pose.orientation.w);
+}
+
+TEST(Bodies, ConstructMarkerFromBodyMesh)
+{
+  const Eigen::Isometry3d pose =
+      Eigen::Translation3d(1.0, 2.0, 3.0) * Eigen::AngleAxisd(M_PI_2, Eigen::Vector3d(0.0, 1.0, 0.0));
+
+  shapes::Mesh* shape =
+      shapes::createMeshFromResource("file://" + (boost::filesystem::path(TEST_RESOURCES_DIR) / "/box.dae").string());
+  const auto body = new ConvexMesh(shape);
+  body->setPose(pose);
+
+  visualization_msgs::Marker marker;
+  constructMarkerFromBody(body, marker);
+
+  EXPECT_EQ(visualization_msgs::Marker::TRIANGLE_LIST, marker.type);
+  EXPECT_DOUBLE_EQ(1.0, marker.scale.x);
+  EXPECT_DOUBLE_EQ(1.0, marker.scale.y);
+  EXPECT_DOUBLE_EQ(1.0, marker.scale.z);
+  EXPECT_DOUBLE_EQ(1.0, marker.pose.position.x);
+  EXPECT_DOUBLE_EQ(2.0, marker.pose.position.y);
+  EXPECT_DOUBLE_EQ(3.0, marker.pose.position.z);
+  EXPECT_DOUBLE_EQ(0.0, marker.pose.orientation.x);
+  EXPECT_DOUBLE_EQ(M_SQRT1_2, marker.pose.orientation.y);
+  EXPECT_DOUBLE_EQ(0.0, marker.pose.orientation.z);
+  EXPECT_DOUBLE_EQ(M_SQRT1_2, marker.pose.orientation.w);
+
+  // We can't directly use shape->triangles because after passing it to the body constructor,
+  // it can "optimize" the vertices (i.e. swap normals etc.) or reorder them
+  const auto shapeFromBody = std::dynamic_pointer_cast<const shapes::Mesh>(constructShapeFromBody(body));
+
+  EigenSTL::vector_Vector3d shapeVertices, markerVertices;
+  for (size_t t = 0; t < shapeFromBody->triangle_count * 3; ++t)
+  {
+    const auto vertexId = shapeFromBody->triangles[t];
+    shapeVertices.push_back({ shapeFromBody->vertices[3 * vertexId + 0], shapeFromBody->vertices[3 * vertexId + 1],
+                              shapeFromBody->vertices[3 * vertexId + 2] });
+  }
+  for (auto& point : marker.points)
+    markerVertices.push_back({ point.x, point.y, point.z });
+
+  expectVector3dSetsEqual(shapeVertices, markerVertices);
+}
+
+int main(int argc, char** argv)
+{
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
This is a backport of #138 to melodic. All tests pass on my side in both debug and release modes. I used the fake non-virtual polymorphy for `Body::getScaledDimensions()` to retain feature parity with noetic and keep melodic ABI unchanged.

I added a special test case for calling `constructShapeFromBody()` on a `bodies::Body` pointer rather than on one of the downstream types. I can port this test to the noetic branch, too, to test that the polymorphic behavior is doing what it is expected to do. I've actually noticed that neither dynamic, nor static casts are needed in the places edited by commit bc1cf5ea43f6b8d09cfd5d53f68f418cdae9defd - as `getScaledDimensions()` is polymorphic (noetic) or fake polymorphic (melodic), calling it directly on a `Body` instance should be good enough. I also did this simplification in this PR, and can transfer it to noetic-devel, too (but it's just a cosmetic issue).

Accepting this backport would allow me to drop a `#define private public` hack from https://github.com/peci1/robot_body_filter/blob/master/src/utils/bodies.cpp (and would also allow me to drop `constructShapeFromBody()` and `constructMarkerFromBody()` implementations in robot_body_filter and use the geometric_shapes versions).