### PR TITLE
Foxy support via __has_include

### DIFF
--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -24,6 +24,8 @@ jobs:
             ROS_REPO: main
           - ROS_DISTRO: galactic
             ROS_REPO: testing
+          - ROS_DISTRO: foxy
+            ROS_REPO: testing
     env:
       UPSTREAM_WORKSPACE: geometric_shapes.repos
       AFTER_SETUP_UPSTREAM_WORKSPACE: 'vcs pull $BASEDIR/upstream_ws/src'

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,9 +1,9 @@
 cmake_minimum_required(VERSION 3.5)
 project(geometric_shapes)
 
-# Default to C++14
+# Default to C++17
 if(NOT CMAKE_CXX_STANDARD)
-  set(CMAKE_CXX_STANDARD 14)
+  set(CMAKE_CXX_STANDARD 17)
 endif()
 
 # Set compile options

--- a/src/mesh_operations.cpp
+++ b/src/mesh_operations.cpp
@@ -38,7 +38,13 @@
 #include <float.h>
 
 #include <console_bridge/console.h>
+
+// Shim so this works on foxy/galactic/rolling
+#if __has_include(<resource_retriever/retriever.hpp>)
 #include <resource_retriever/retriever.hpp>
+#else
+#include <resource_retriever/retriever.h>
+#endif
 
 #include <assimp/scene.h>
 #include <assimp/Importer.hpp>


### PR DESCRIPTION
`__has_include` is a C++17 feature [(Reference)](https://en.cppreference.com/w/cpp/preprocessor/include).  We can support foxy from the ros2 branch with this change.  The downside to this is foxy doesn't officially support C++17.  This is the reason I originally created the foxy branch.  If we are ok using C++17 on Foxy we can support all three current ros2 versions (Foxy, Galactic, Rolling) from one branch.  This will also fix the semvar issues created by lot leaving room for more foxy versions (as we can just release foxy from the ros2 branch then).