### PR TITLE
[ros2] WIP: Remove random_numbers dependency

### DIFF
--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -36,8 +36,6 @@ jobs:
       # Globally disable git security
       # https://github.blog/2022-04-12-git-security-vulnerability-announced
       BEFORE_SETUP_UPSTREAM_WORKSPACE: 'sudo apt-get -qq install -y --no-upgrade --no-install-recommends git && git config --global --add safe.directory "*"'
-      UPSTREAM_WORKSPACE: geometric_shapes.repos
-      AFTER_SETUP_UPSTREAM_WORKSPACE: 'vcs pull $BASEDIR/upstream_ws/src'
       AFTER_RUN_TARGET_TEST: ${{ matrix.env.CCOV && './.ci.prepare_codecov' || '' }}
       TARGET_CMAKE_ARGS: >
         -DCMAKE_BUILD_TYPE=${{ matrix.env.CCOV && 'Debug' || 'Release'}}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,7 +45,6 @@ find_package(eigen_stl_containers REQUIRED)
 find_package(geometry_msgs REQUIRED)
 find_package(OCTOMAP REQUIRED)
 find_package(QHULL REQUIRED)
-find_package(random_numbers REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(resource_retriever REQUIRED)
 find_package(shape_msgs REQUIRED)
@@ -61,7 +60,6 @@ set(THIS_PACKAGE_EXPORT_DEPENDS
   eigen_stl_containers
   geometry_msgs
   OCTOMAP
-  random_numbers
   rclcpp
   resource_retriever
   shape_msgs

--- a/geometric_shapes.repos
+++ b/geometric_shapes.repos
@@ -1,5 +1,0 @@
-repositories:
-  random_numbers:
-    type: git
-    url: https://github.com/ros-planning/random_numbers
-    version: ros2

--- a/include/geometric_shapes/bodies.h
+++ b/include/geometric_shapes/bodies.h
@@ -225,10 +225,7 @@ public:
      Sometimes multiple attempts need to be generated.
      The function terminates with failure (returns false) after \e max_attempts attempts.
      If the call is successful (returns true) the point is written to \e result */
-  virtual bool samplePointInside(unsigned int max_attempts, Eigen::Vector3d& result) const;
-
-  /** \brief Alternative version of samplePointInside function that allows using a customly seeded random number generator */
-  virtual bool samplePointInside(std::seed_seq const& seed_sequence, unsigned int max_attempts,
+  virtual bool samplePointInside(std::function<double(double, double)> random_value, unsigned int max_attempts,
                                  Eigen::Vector3d& result) const;
 
   /** \brief Compute the bounding radius for the body, in its current
@@ -305,7 +302,8 @@ public:
 
   bool containsPoint(const Eigen::Vector3d& p, bool verbose = false) const override;
   double computeVolume() const override;
-  bool samplePointInside(unsigned int max_attempts, Eigen::Vector3d& result) const override;
+  bool samplePointInside(std::function<double(double, double)> random_value, unsigned int max_attempts,
+                         Eigen::Vector3d& result) const override;
   void computeBoundingSphere(BoundingSphere& sphere) const override;
   void computeBoundingCylinder(BoundingCylinder& cylinder) const override;
   void computeBoundingBox(AABB& bbox) const override;
@@ -356,7 +354,8 @@ public:
 
   bool containsPoint(const Eigen::Vector3d& p, bool verbose = false) const override;
   double computeVolume() const override;
-  bool samplePointInside(unsigned int max_attempts, Eigen::Vector3d& result) const override;
+  bool samplePointInside(std::function<double(double, double)> random_value, unsigned int max_attempts,
+                         Eigen::Vector3d& result) const override;
   void computeBoundingSphere(BoundingSphere& sphere) const override;
   void computeBoundingCylinder(BoundingCylinder& cylinder) const override;
   void computeBoundingBox(AABB& bbox) const override;
@@ -417,7 +416,8 @@ public:
 
   bool containsPoint(const Eigen::Vector3d& p, bool verbose = false) const override;
   double computeVolume() const override;
-  bool samplePointInside(unsigned int max_attempts, Eigen::Vector3d& result) const override;
+  bool samplePointInside(std::function<double(double, double)> random_value, unsigned int max_attempts,
+                         Eigen::Vector3d& result) const override;
   void computeBoundingSphere(BoundingSphere& sphere) const override;
   void computeBoundingCylinder(BoundingCylinder& cylinder) const override;
   void computeBoundingBox(AABB& bbox) const override;

--- a/include/geometric_shapes/bodies.h
+++ b/include/geometric_shapes/bodies.h
@@ -227,6 +227,10 @@ public:
      If the call is successful (returns true) the point is written to \e result */
   virtual bool samplePointInside(unsigned int max_attempts, Eigen::Vector3d& result) const;
 
+  /** \brief Alternative version of samplePointInside function that allows using a customly seeded random number generator */
+  virtual bool samplePointInside(std::seed_seq const& seed_sequence, unsigned int max_attempts,
+                                 Eigen::Vector3d& result) const;
+
   /** \brief Compute the bounding radius for the body, in its current
       pose. Scaling and padding are accounted for. */
   virtual void computeBoundingSphere(BoundingSphere& sphere) const = 0;

--- a/include/geometric_shapes/bodies.h
+++ b/include/geometric_shapes/bodies.h
@@ -34,8 +34,8 @@
 #define _USE_MATH_DEFINES
 #include "geometric_shapes/aabb.h"
 #include "geometric_shapes/shapes.h"
+#include "geometric_shapes/random_number_utils.hpp"
 #include <eigen_stl_containers/eigen_stl_containers.h>
-#include <random_numbers/random_numbers.h>
 #include <Eigen/Core>
 #include <Eigen/Geometry>
 #include <memory>
@@ -225,8 +225,7 @@ public:
      Sometimes multiple attempts need to be generated.
      The function terminates with failure (returns false) after \e max_attempts attempts.
      If the call is successful (returns true) the point is written to \e result */
-  virtual bool samplePointInside(random_numbers::RandomNumberGenerator& rng, unsigned int max_attempts,
-                                 Eigen::Vector3d& result) const;
+  virtual bool samplePointInside(unsigned int max_attempts, Eigen::Vector3d& result) const;
 
   /** \brief Compute the bounding radius for the body, in its current
       pose. Scaling and padding are accounted for. */
@@ -302,8 +301,7 @@ public:
 
   bool containsPoint(const Eigen::Vector3d& p, bool verbose = false) const override;
   double computeVolume() const override;
-  bool samplePointInside(random_numbers::RandomNumberGenerator& rng, unsigned int max_attempts,
-                         Eigen::Vector3d& result) const override;
+  bool samplePointInside(unsigned int max_attempts, Eigen::Vector3d& result) const override;
   void computeBoundingSphere(BoundingSphere& sphere) const override;
   void computeBoundingCylinder(BoundingCylinder& cylinder) const override;
   void computeBoundingBox(AABB& bbox) const override;
@@ -354,8 +352,7 @@ public:
 
   bool containsPoint(const Eigen::Vector3d& p, bool verbose = false) const override;
   double computeVolume() const override;
-  bool samplePointInside(random_numbers::RandomNumberGenerator& rng, unsigned int max_attempts,
-                         Eigen::Vector3d& result) const override;
+  bool samplePointInside(unsigned int max_attempts, Eigen::Vector3d& result) const override;
   void computeBoundingSphere(BoundingSphere& sphere) const override;
   void computeBoundingCylinder(BoundingCylinder& cylinder) const override;
   void computeBoundingBox(AABB& bbox) const override;
@@ -416,8 +413,7 @@ public:
 
   bool containsPoint(const Eigen::Vector3d& p, bool verbose = false) const override;
   double computeVolume() const override;
-  bool samplePointInside(random_numbers::RandomNumberGenerator& rng, unsigned int max_attempts,
-                         Eigen::Vector3d& result) const override;
+  bool samplePointInside(unsigned int max_attempts, Eigen::Vector3d& result) const override;
   void computeBoundingSphere(BoundingSphere& sphere) const override;
   void computeBoundingCylinder(BoundingCylinder& cylinder) const override;
   void computeBoundingBox(AABB& bbox) const override;

--- a/include/geometric_shapes/bodies.h
+++ b/include/geometric_shapes/bodies.h
@@ -220,7 +220,7 @@ public:
       changes induced by scaling and padding */
   virtual double computeVolume() const = 0;
 
-  /** \brief Sample a point that is included in the body using a given random number generator.
+  /** \brief Sample a point that is included in the body using a given function that produces a random number
 
      Sometimes multiple attempts need to be generated.
      The function terminates with failure (returns false) after \e max_attempts attempts.

--- a/include/geometric_shapes/random_number_utils.hpp
+++ b/include/geometric_shapes/random_number_utils.hpp
@@ -1,0 +1,85 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2022, PickNik Inc.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Author: Sebastian Jahr
+   Description: A random number generator singleton implementation
+*/
+
+#pragma once
+
+#include <random>      // for std::mt19937, random_device , seed_seq
+#include <array>       // for std::array, std::data,
+#include <algorithm>   // for std::generate_n
+#include <functional>  // for std::ref
+
+namespace shapes
+{
+// Singleton random number generator class based on https://www.modernescpp.com/index.php/thread-safe-initialization-of-a-singleton
+class RandomNumberGenerator
+{
+private:
+  std::mt19937 generator_;
+
+  // Delete copy constructor
+  RandomNumberGenerator(const RandomNumberGenerator&) = delete;
+  // Don't allow assigning the instance of this class
+  RandomNumberGenerator& operator=(const RandomNumberGenerator&) = delete;
+
+  RandomNumberGenerator()
+    : generator_{ []() {
+      std::array<int, std::mt19937::state_size> seed_data;
+      std::random_device random_device;
+      std::generate_n(std::data(seed_data), std::size(seed_data), std::ref(random_device));
+      std::seed_seq sequence(std::begin(seed_data), std::end(seed_data));
+      std::mt19937 generator(sequence);
+      return generator;
+    }() } {};
+  ~RandomNumberGenerator() = default;
+
+public:
+  static RandomNumberGenerator& getInstance()
+  {
+    // Static valiables with blocked scopes will be only created once
+    static RandomNumberGenerator instance;
+    return instance;
+  }
+
+  /// \brief Return a randum number based on a bounded uniform distribution
+  auto uniform(double const lower_bound, double const upper_bound)
+  {
+    std::uniform_real_distribution<double> distribution(lower_bound, upper_bound);
+    return distribution(generator_);
+  }
+};
+}  // namespace shapes

--- a/include/geometric_shapes/random_number_utils.hpp
+++ b/include/geometric_shapes/random_number_utils.hpp
@@ -76,22 +76,27 @@ private:
 
 public:
   /** The first time this function is called it creates a thread_local random number generator.
-    * If a seed sequence is provided on that first call it is used to create the generator, otherwise the random device is used to seed the generator.
-    * After the first call to this function, if a seed sequence is provided this function throws.
-    */
+   * If a seed sequence is provided on that first call it is used to create the generator, otherwise the random device
+   * is used to seed the generator. After the first call to this function, if a seed sequence is provided this function
+   * throws.
+   */
   [[nodiscard]] static RandomNumberGenerator& getInstance(std::optional<std::seed_seq> seed_sequence = std::nullopt)
   {
     bool first = false;
     thread_local RandomNumberGenerator instance = [&seed_sequence, &first]() {
       first = true;
-      if (seed_sequence.has_value()) {
-        return RandomNumberGenerator{seed_sequence};
-      } else {
-        return RandomNumberGenerator{};
+      if (seed_sequence.has_value())
+      {
+        return RandomNumberGenerator(seed_sequence.value());
+      }
+      else
+      {
+        return RandomNumberGenerator();
       }
     }();
-    if (!first && seed_sequence.has_value()) {
-      throw std::exception{"RandomNumberGenerator cannot be re-seeded"};
+    if (!first && seed_sequence.has_value())
+    {
+      throw std::runtime_error("RandomNumberGenerator cannot be re-seeded");
     }
     return instance;
   }

--- a/include/geometric_shapes/random_number_utils.hpp
+++ b/include/geometric_shapes/random_number_utils.hpp
@@ -83,7 +83,7 @@ public:
   [[nodiscard]] static RandomNumberGenerator& getInstance(std::optional<std::seed_seq> seed_sequence = std::nullopt)
   {
     thread_local bool first = false;
-    thread_local RandomNumberGenerator instance = [&seed_sequence, &first]() {
+    thread_local RandomNumberGenerator instance = [&seed_sequence]() {
       first = true;
       if (seed_sequence.has_value())
       {

--- a/include/geometric_shapes/random_number_utils.hpp
+++ b/include/geometric_shapes/random_number_utils.hpp
@@ -1,36 +1,32 @@
-/*********************************************************************
- * Software License Agreement (BSD License)
- *
- *  Copyright (c) 2022, PickNik Inc.
- *  All rights reserved.
- *
- *  Redistribution and use in source and binary forms, with or without
- *  modification, are permitted provided that the following conditions
- *  are met:
- *
- *   * Redistributions of source code must retain the above copyright
- *     notice, this list of conditions and the following disclaimer.
- *   * Redistributions in binary form must reproduce the above
- *     copyright notice, this list of conditions and the following
- *     disclaimer in the documentation and/or other materials provided
- *     with the distribution.
- *   * Neither the name of the copyright holder nor the names of its
- *     contributors may be used to endorse or promote products derived
- *     from this software without specific prior written permission.
- *
- *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
- *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
- *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
- *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
- *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
- *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
- *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- *  POSSIBILITY OF SUCH DAMAGE.
- *********************************************************************/
+//  Copyright (c) 2022, PickNik Inc.
+//  All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions
+//  are met:
+//
+//   * Redistributions of source code must retain the above copyright
+//     notice, this list of conditions and the following disclaimer.
+//   * Redistributions in binary form must reproduce the above
+//     copyright notice, this list of conditions and the following
+//     disclaimer in the documentation and/or other materials provided
+//     with the distribution.
+//   * Neither the name of the copyright holder nor the names of its
+//     contributors may be used to endorse or promote products derived
+//     from this software without specific prior written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+//  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+//  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+//  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+//  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+//  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+//  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+//  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+//  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+//  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+//  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+//  POSSIBILITY OF SUCH DAMAGE.
 
 /* Author: Sebastian Jahr
    Description: A random number generator singleton implementation

--- a/include/geometric_shapes/random_number_utils.hpp
+++ b/include/geometric_shapes/random_number_utils.hpp
@@ -1,32 +1,30 @@
-//  Copyright (c) 2022, PickNik Inc.
-//  All rights reserved.
+// Copyright (c) 2022, PickNik Inc.
 //
-//  Redistribution and use in source and binary forms, with or without
-//  modification, are permitted provided that the following conditions
-//  are met:
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
 //
-//   * Redistributions of source code must retain the above copyright
-//     notice, this list of conditions and the following disclaimer.
-//   * Redistributions in binary form must reproduce the above
-//     copyright notice, this list of conditions and the following
-//     disclaimer in the documentation and/or other materials provided
-//     with the distribution.
-//   * Neither the name of the copyright holder nor the names of its
-//     contributors may be used to endorse or promote products derived
-//     from this software without specific prior written permission.
+//    * Redistributions of source code must retain the above copyright
+//      notice, this list of conditions and the following disclaimer.
 //
-//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-//  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-//  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
-//  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
-//  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
-//  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
-//  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-//  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-//  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
-//  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
-//  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-//  POSSIBILITY OF SUCH DAMAGE.
+//    * Redistributions in binary form must reproduce the above copyright
+//      notice, this list of conditions and the following disclaimer in the
+//      documentation and/or other materials provided with the distribution.
+//
+//    * Neither the name of the Willow Garage, Inc. nor the names of its
+//      contributors may be used to endorse or promote products derived from
+//      this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
 
 /* Author: Sebastian Jahr
    Description: A random number generator singleton implementation

--- a/include/geometric_shapes/random_number_utils.hpp
+++ b/include/geometric_shapes/random_number_utils.hpp
@@ -82,7 +82,7 @@ public:
    */
   [[nodiscard]] static RandomNumberGenerator& getInstance(std::optional<std::seed_seq> seed_sequence = std::nullopt)
   {
-    bool first = false;
+    thread_local bool first = false;
     thread_local RandomNumberGenerator instance = [&seed_sequence, &first]() {
       first = true;
       if (seed_sequence.has_value())

--- a/include/geometric_shapes/random_number_utils.hpp
+++ b/include/geometric_shapes/random_number_utils.hpp
@@ -92,23 +92,23 @@ public:
    * is used to seed the generator. After the first call to this function, if a seed sequence is provided this function
    * throws.
    */
-  [[nodiscard]] static RandomNumberGenerator& getInstance(std::optional<std::seed_seq> seed_sequence = std::nullopt)
+  [[nodiscard]] static RandomNumberGenerator& getInstance(std::seed_seq seed_sequence = {})
   {
     // These variables are decleared thread local, to have exactly one instance of this object per thread.
     // This way resource conflicts are avoided while the number of constructor invocations is kept low.
     thread_local bool first = false;
     thread_local RandomNumberGenerator instance = [&seed_sequence]() {
       first = true;
-      if (seed_sequence.has_value())
+      if (seed_sequence.size() > 0)
       {
-        return RandomNumberGenerator(seed_sequence.value());
+        return RandomNumberGenerator(seed_sequence);
       }
       else
       {
         return RandomNumberGenerator();
       }
     }();
-    if (!first && seed_sequence.has_value())
+    if (!first && seed_sequence.size() > 0)
     {
       throw std::runtime_error("RandomNumberGenerator cannot be re-seeded");
     }

--- a/include/geometric_shapes/random_number_utils.hpp
+++ b/include/geometric_shapes/random_number_utils.hpp
@@ -71,7 +71,7 @@ public:
   static RandomNumberGenerator& getInstance()
   {
     // Static valiables with blocked scopes will be only created once
-    static RandomNumberGenerator instance;
+    thread_local RandomNumberGenerator instance;
     return instance;
   }
 

--- a/include/geometric_shapes/random_number_utils.hpp
+++ b/include/geometric_shapes/random_number_utils.hpp
@@ -61,6 +61,12 @@ private:
       std::mt19937 generator(sequence);
       return generator;
     }() } {};
+
+  RandomNumberGenerator(std::seed_seq& seed_sequence)
+    : generator_{ [](std::seed_seq& seed_sequence) {
+      std::mt19937 generator(seed_sequence);
+      return generator;
+    }(seed_sequence) } {};
   ~RandomNumberGenerator() = default;
 
 public:
@@ -68,6 +74,13 @@ public:
   {
     // Static valiables with blocked scopes will be only created once
     thread_local RandomNumberGenerator instance;
+    return instance;
+  }
+
+  static RandomNumberGenerator& getInstance(std::seed_seq& seed_sequence)
+  {
+    // Static valiables with blocked scopes will be only created once
+    thread_local RandomNumberGenerator instance(seed_sequence);
     return instance;
   }
 

--- a/package.xml
+++ b/package.xml
@@ -29,7 +29,6 @@
   <depend>console_bridge_vendor</depend>
   <depend>libqhull</depend>
   <depend>octomap</depend>
-  <depend>random_numbers</depend>
   <depend>resource_retriever</depend>
   <depend>shape_msgs</depend>
   <depend>geometry_msgs</depend>

--- a/src/bodies.cpp
+++ b/src/bodies.cpp
@@ -132,9 +132,9 @@ bool bodies::Body::samplePointInside(std::function<double(double, double)> rando
   computeBoundingSphere(bs);
   for (unsigned int i = 0; i < max_attempts; ++i)
   {
-    result = Eigen::Vector3d(RNG.uniform(bs.center.x() - bs.radius, bs.center.x() + bs.radius),
-                             RNG.uniform(bs.center.y() - bs.radius, bs.center.y() + bs.radius),
-                             RNG.uniform(bs.center.z() - bs.radius, bs.center.z() + bs.radius));
+    result = Eigen::Vector3d(random_value(bs.center.x() - bs.radius, bs.center.x() + bs.radius),
+                             random_value(bs.center.y() - bs.radius, bs.center.y() + bs.radius),
+                             random_value(bs.center.z() - bs.radius, bs.center.z() + bs.radius));
     if (containsPoint(result))
       return true;
   }
@@ -226,7 +226,7 @@ bool bodies::Sphere::samplePointInside(std::function<double(double, double)> ran
     // to sphere volume
     for (int j = 0; j < 20; ++j)
     {
-      result = Eigen::Vector3d(RNG.uniform(minX, maxX), RNG.uniform(minY, maxY), RNG.uniform(minZ, maxZ));
+      result = Eigen::Vector3d(random_value(minX, maxX), random_value(minY, maxY), random_value(minZ, maxZ));
       if (containsPoint(result))
         return true;
     }
@@ -372,13 +372,13 @@ bool bodies::Cylinder::samplePointInside(std::function<double(double, double)> r
                                          unsigned int /* max_attempts */, Eigen::Vector3d& result) const
 {
   // sample a point on the base disc of the cylinder
-  double a = RNG.uniform(-boost::math::constants::pi<double>(), boost::math::constants::pi<double>());
-  double r = RNG.uniform(-radiusU_, radiusU_);
+  double a = random_value(-boost::math::constants::pi<double>(), boost::math::constants::pi<double>());
+  double r = random_value(-radiusU_, radiusU_);
   double x = cos(a) * r;
   double y = sin(a) * r;
 
   // sample e height
-  double z = RNG.uniform(-length2_, length2_);
+  double z = random_value(-length2_, length2_);
 
   result = pose_ * Eigen::Vector3d(x, y, z);
   return true;
@@ -549,8 +549,8 @@ bodies::Cylinder::Cylinder(const bodies::BoundingCylinder& cylinder) : Body()
 bool bodies::Box::samplePointInside(std::function<double(double, double)> random_value, unsigned int /* max_attempts */,
                                     Eigen::Vector3d& result) const
 {
-  result = pose_ * Eigen::Vector3d(RNG.uniform(-length2_, length2_), RNG.uniform(-width2_, width2_),
-                                   RNG.uniform(-height2_, height2_));
+  result = pose_ * Eigen::Vector3d(random_value(-length2_, length2_), random_value(-width2_, width2_),
+                                   random_value(-height2_, height2_));
   return true;
 }
 

--- a/src/bodies.cpp
+++ b/src/bodies.cpp
@@ -50,7 +50,7 @@ namespace bodies
 {
 namespace
 {
-thread_local auto& RNG_ = shapes::RandomNumberGenerator::getInstance();
+auto& RNG_ = shapes::RandomNumberGenerator::getInstance();
 }  // namespace
 
 namespace detail

--- a/src/bodies.cpp
+++ b/src/bodies.cpp
@@ -50,7 +50,7 @@ namespace bodies
 {
 namespace
 {
-auto& RNG_ = shapes::RandomNumberGenerator::getInstance();
+auto& RNG = shapes::RandomNumberGenerator::getInstance();
 }  // namespace
 
 namespace detail
@@ -131,9 +131,9 @@ bool bodies::Body::samplePointInside(unsigned int max_attempts, Eigen::Vector3d&
   computeBoundingSphere(bs);
   for (unsigned int i = 0; i < max_attempts; ++i)
   {
-    result = Eigen::Vector3d(RNG_.uniform(bs.center.x() - bs.radius, bs.center.x() + bs.radius),
-                             RNG_.uniform(bs.center.y() - bs.radius, bs.center.y() + bs.radius),
-                             RNG_.uniform(bs.center.z() - bs.radius, bs.center.z() + bs.radius));
+    result = Eigen::Vector3d(RNG.uniform(bs.center.x() - bs.radius, bs.center.x() + bs.radius),
+                             RNG.uniform(bs.center.y() - bs.radius, bs.center.y() + bs.radius),
+                             RNG.uniform(bs.center.z() - bs.radius, bs.center.z() + bs.radius));
     if (containsPoint(result))
       return true;
   }
@@ -224,7 +224,7 @@ bool bodies::Sphere::samplePointInside(unsigned int max_attempts, Eigen::Vector3
     // to sphere volume
     for (int j = 0; j < 20; ++j)
     {
-      result = Eigen::Vector3d(RNG_.uniform(minX, maxX), RNG_.uniform(minY, maxY), RNG_.uniform(minZ, maxZ));
+      result = Eigen::Vector3d(RNG.uniform(minX, maxX), RNG.uniform(minY, maxY), RNG.uniform(minZ, maxZ));
       if (containsPoint(result))
         return true;
     }
@@ -369,13 +369,13 @@ void bodies::Cylinder::updateInternalData()
 bool bodies::Cylinder::samplePointInside(unsigned int /* max_attempts */, Eigen::Vector3d& result) const
 {
   // sample a point on the base disc of the cylinder
-  double a = RNG_.uniform(-boost::math::constants::pi<double>(), boost::math::constants::pi<double>());
-  double r = RNG_.uniform(-radiusU_, radiusU_);
+  double a = RNG.uniform(-boost::math::constants::pi<double>(), boost::math::constants::pi<double>());
+  double r = RNG.uniform(-radiusU_, radiusU_);
   double x = cos(a) * r;
   double y = sin(a) * r;
 
   // sample e height
-  double z = RNG_.uniform(-length2_, length2_);
+  double z = RNG.uniform(-length2_, length2_);
 
   result = pose_ * Eigen::Vector3d(x, y, z);
   return true;
@@ -545,8 +545,8 @@ bodies::Cylinder::Cylinder(const bodies::BoundingCylinder& cylinder) : Body()
 
 bool bodies::Box::samplePointInside(unsigned int /* max_attempts */, Eigen::Vector3d& result) const
 {
-  result = pose_ * Eigen::Vector3d(RNG_.uniform(-length2_, length2_), RNG_.uniform(-width2_, width2_),
-                                   RNG_.uniform(-height2_, height2_));
+  result = pose_ * Eigen::Vector3d(RNG.uniform(-length2_, length2_), RNG.uniform(-width2_, width2_),
+                                   RNG.uniform(-height2_, height2_));
   return true;
 }
 

--- a/src/bodies.cpp
+++ b/src/bodies.cpp
@@ -125,7 +125,8 @@ inline Eigen::Vector3d normalize(const Eigen::Vector3d& dir)
 }
 }  // namespace bodies
 
-bool bodies::Body::samplePointInside(unsigned int max_attempts, Eigen::Vector3d& result) const
+bool bodies::Body::samplePointInside(std::function<double(double, double)> random_value, unsigned int max_attempts,
+                                     Eigen::Vector3d& result) const
 {
   BoundingSphere bs;
   computeBoundingSphere(bs);
@@ -210,7 +211,8 @@ void bodies::Sphere::computeBoundingBox(bodies::AABB& bbox) const
   bbox.extendWithTransformedBox(transform, Eigen::Vector3d(2 * radiusU_, 2 * radiusU_, 2 * radiusU_));
 }
 
-bool bodies::Sphere::samplePointInside(unsigned int max_attempts, Eigen::Vector3d& result) const
+bool bodies::Sphere::samplePointInside(std::function<double(double, double)> random_value, unsigned int max_attempts,
+                                       Eigen::Vector3d& result) const
 {
   for (unsigned int i = 0; i < max_attempts; ++i)
   {
@@ -366,7 +368,8 @@ void bodies::Cylinder::updateInternalData()
   d2_ = tmp - length2_;
 }
 
-bool bodies::Cylinder::samplePointInside(unsigned int /* max_attempts */, Eigen::Vector3d& result) const
+bool bodies::Cylinder::samplePointInside(std::function<double(double, double)> random_value,
+                                         unsigned int /* max_attempts */, Eigen::Vector3d& result) const
 {
   // sample a point on the base disc of the cylinder
   double a = RNG.uniform(-boost::math::constants::pi<double>(), boost::math::constants::pi<double>());
@@ -543,7 +546,8 @@ bodies::Cylinder::Cylinder(const bodies::BoundingCylinder& cylinder) : Body()
   setPose(cylinder.pose);
 }
 
-bool bodies::Box::samplePointInside(unsigned int /* max_attempts */, Eigen::Vector3d& result) const
+bool bodies::Box::samplePointInside(std::function<double(double, double)> random_value, unsigned int /* max_attempts */,
+                                    Eigen::Vector3d& result) const
 {
   result = pose_ * Eigen::Vector3d(RNG.uniform(-length2_, length2_), RNG.uniform(-width2_, width2_),
                                    RNG.uniform(-height2_, height2_));

--- a/test/test_bounding_box.cpp
+++ b/test/test_bounding_box.cpp
@@ -35,7 +35,7 @@
 
 namespace
 {
-auto& RNG_ = shapes::RandomNumberGenerator::getInstance();
+auto& RNG = shapes::RandomNumberGenerator::getInstance();
 }  // namespace
 
 // The magic numbers in this test were verified visually using Blender
@@ -202,7 +202,7 @@ TEST(CylinderBoundingBox, Cylinder2)
   bodies::AABB bbox2;
   for (size_t i = 0; i < 10; ++i)
   {
-    const auto angle = RNG_.uniform(-M_PI, M_PI);
+    const auto angle = RNG.uniform(-M_PI, M_PI);
     const auto yaw = Eigen::AngleAxisd(angle, Eigen::Vector3d::UnitZ());
     pose.linear() = (rollPitch * yaw).toRotationMatrix();
     body.setPose(pose);

--- a/test/test_bounding_box.cpp
+++ b/test/test_bounding_box.cpp
@@ -30,7 +30,7 @@
 
 #include <geometric_shapes/bodies.h>
 #include <geometric_shapes/body_operations.h>
-#include <random_numbers/random_numbers.h>
+#include "geometric_shapes/random_number_utils.hpp"
 #include <gtest/gtest.h>
 
 // The magic numbers in this test were verified visually using Blender
@@ -80,18 +80,9 @@ TEST(SphereBoundingBox, Sphere2)
   EXPECT_NEAR(5.0, bbox.max().z(), 1e-4);
 
   // verify the bounding box is rotation-invariant
-
-  random_numbers::RandomNumberGenerator gen;
-  double quatData[4];
-  Eigen::Quaterniond quat;
-
   for (size_t i = 0; i < 10; ++i)
   {
-    gen.quaternion(quatData);
-    quat.x() = quatData[0];
-    quat.y() = quatData[1];
-    quat.z() = quatData[2];
-    quat.w() = quatData[3];
+    auto quat = Eigen::Quaterniond::UnitRandom();
     pose.linear() = quat.toRotationMatrix();
     body.setPose(pose);
     bodies::AABB bbox2;
@@ -196,8 +187,6 @@ TEST(CylinderBoundingBox, Cylinder2)
   EXPECT_NEAR(4.2761, bbox.max().z(), 1e-4);
 
   // verify the bounding box is yaw-invariant
-
-  random_numbers::RandomNumberGenerator gen(0);
   const auto rollPitch =
       Eigen::AngleAxisd(1.0, Eigen::Vector3d::UnitX()) * Eigen::AngleAxisd(1.0, Eigen::Vector3d::UnitY());
 
@@ -208,7 +197,7 @@ TEST(CylinderBoundingBox, Cylinder2)
   bodies::AABB bbox2;
   for (size_t i = 0; i < 10; ++i)
   {
-    const auto angle = gen.uniformReal(-M_PI, M_PI);
+    const auto angle = uniform(gen, -M_PI, M_PI);
     const auto yaw = Eigen::AngleAxisd(angle, Eigen::Vector3d::UnitZ());
     pose.linear() = (rollPitch * yaw).toRotationMatrix();
     body.setPose(pose);

--- a/test/test_bounding_box.cpp
+++ b/test/test_bounding_box.cpp
@@ -87,7 +87,7 @@ TEST(SphereBoundingBox, Sphere2)
   // verify the bounding box is rotation-invariant
   for (size_t i = 0; i < 10; ++i)
   {
-    auto quat = Eigen::Quaterniond::UnitRandom();
+    auto quat = RNG.getRandomQuaternion();
     pose.linear() = quat.toRotationMatrix();
     body.setPose(pose);
     bodies::AABB bbox2;

--- a/test/test_bounding_box.cpp
+++ b/test/test_bounding_box.cpp
@@ -35,7 +35,7 @@
 
 namespace
 {
-thread_local auto& RNG_ = shapes::RandomNumberGenerator::getInstance();
+auto& RNG_ = shapes::RandomNumberGenerator::getInstance();
 }  // namespace
 
 // The magic numbers in this test were verified visually using Blender

--- a/test/test_bounding_box.cpp
+++ b/test/test_bounding_box.cpp
@@ -33,6 +33,11 @@
 #include "geometric_shapes/random_number_utils.hpp"
 #include <gtest/gtest.h>
 
+namespace
+{
+thread_local auto& RNG_ = shapes::RandomNumberGenerator::getInstance();
+}  // namespace
+
 // The magic numbers in this test were verified visually using Blender
 
 TEST(SphereBoundingBox, Sphere1)
@@ -197,7 +202,7 @@ TEST(CylinderBoundingBox, Cylinder2)
   bodies::AABB bbox2;
   for (size_t i = 0; i < 10; ++i)
   {
-    const auto angle = uniform(gen, -M_PI, M_PI);
+    const auto angle = RNG_.uniform(-M_PI, M_PI);
     const auto yaw = Eigen::AngleAxisd(angle, Eigen::Vector3d::UnitZ());
     pose.linear() = (rollPitch * yaw).toRotationMatrix();
     body.setPose(pose);

--- a/test/test_bounding_cylinder.cpp
+++ b/test/test_bounding_cylinder.cpp
@@ -33,6 +33,11 @@
 #include "geometric_shapes/random_number_utils.hpp"
 #include <gtest/gtest.h>
 
+namespace
+{
+auto& RNG = shapes::RandomNumberGenerator::getInstance();
+}  // namespace
+
 // The magic numbers in this test were verified visually using Blender
 
 TEST(SphereBoundingCylinder, Sphere1)

--- a/test/test_bounding_cylinder.cpp
+++ b/test/test_bounding_cylinder.cpp
@@ -30,7 +30,7 @@
 
 #include <geometric_shapes/bodies.h>
 #include <geometric_shapes/body_operations.h>
-#include <random_numbers/random_numbers.h>
+#include "geometric_shapes/random_number_utils.hpp"
 #include <gtest/gtest.h>
 
 // The magic numbers in this test were verified visually using Blender
@@ -90,17 +90,9 @@ TEST(SphereBoundingCylinder, Sphere2)
   EXPECT_NEAR(2.0, bcyl.radius, 1e-4);
   EXPECT_NEAR(4.0, bcyl.length, 1e-4);
 
-  random_numbers::RandomNumberGenerator gen;
-  double quatData[4];
-  Eigen::Quaterniond quat;
-
   for (size_t i = 0; i < 10; ++i)
   {
-    gen.quaternion(quatData);
-    quat.x() = quatData[0];
-    quat.y() = quatData[1];
-    quat.z() = quatData[2];
-    quat.w() = quatData[3];
+    auto quat = Eigen::Quaterniond::UnitRandom();
     pose.linear() = quat.toRotationMatrix();
     body.setPose(pose);
     bodies::BoundingCylinder bcyl2;

--- a/test/test_bounding_cylinder.cpp
+++ b/test/test_bounding_cylinder.cpp
@@ -92,7 +92,7 @@ TEST(SphereBoundingCylinder, Sphere2)
 
   for (size_t i = 0; i < 10; ++i)
   {
-    auto quat = Eigen::Quaterniond::UnitRandom();
+    auto quat = RNG.getRandomQuaternion();
     pose.linear() = quat.toRotationMatrix();
     body.setPose(pose);
     bodies::BoundingCylinder bcyl2;

--- a/test/test_loaded_meshes.cpp
+++ b/test/test_loaded_meshes.cpp
@@ -37,7 +37,7 @@
 
 namespace
 {
-auto& RNG_ = shapes::RandomNumberGenerator::getInstance();
+auto& RNG = shapes::RandomNumberGenerator::getInstance();
 }  // namespace
 
 /**
@@ -122,8 +122,8 @@ TEST_F(CompareMeshVsPrimitive, IntersectsRay)
     bool intersects = false;
     for (int i = 0; i < 100; ++i)
     {
-      Eigen::Vector3d ray_o(RNG_.uniform(-1.0, +1.0), RNG_.uniform(-1.0, +1.0), RNG_.uniform(-1.0, +1.0));
-      Eigen::Vector3d ray_d(RNG_.uniform(-1.0, +1.0), RNG_.uniform(-1.0, +1.0), RNG_.uniform(-1.0, +1.0));
+      Eigen::Vector3d ray_o(RNG.uniform(-1.0, +1.0), RNG.uniform(-1.0, +1.0), RNG.uniform(-1.0, +1.0));
+      Eigen::Vector3d ray_d(RNG.uniform(-1.0, +1.0), RNG.uniform(-1.0, +1.0), RNG.uniform(-1.0, +1.0));
       EigenSTL::vector_Vector3d vi1, vi2;
       shape_cms->intersectsRay(ray_o, ray_d, &vi1);
       loaded_cms->intersectsRay(ray_o, ray_d, &vi2);

--- a/test/test_loaded_meshes.cpp
+++ b/test/test_loaded_meshes.cpp
@@ -35,6 +35,11 @@
 #include <gtest/gtest.h>
 #include "resources/config.h"
 
+namespace
+{
+thread_local auto& RNG_ = shapes::RandomNumberGenerator::getInstance();
+}  // namespace
+
 /**
  * Test fixture that generates meshes from the primitive shapes SPHERE, CYLINDER, CONE and BOX,
  * and load their twins from STL files. All the following tests are intended to verify that both
@@ -77,8 +82,6 @@ public:
   }
 
 protected:
-  shapes::RandomNumberGenerator rng;
-
   std::vector<shapes::Mesh*> shape_meshes;
   std::vector<shapes::Mesh*> loaded_meshes;
 
@@ -119,8 +122,8 @@ TEST_F(CompareMeshVsPrimitive, IntersectsRay)
     bool intersects = false;
     for (int i = 0; i < 100; ++i)
     {
-      Eigen::Vector3d ray_o(rng.uniform(-1.0, +1.0), rng.uniform(-1.0, +1.0), rng.uniform(-1.0, +1.0));
-      Eigen::Vector3d ray_d(rng.uniform(-1.0, +1.0), rng.uniform(-1.0, +1.0), rng.uniform(-1.0, +1.0));
+      Eigen::Vector3d ray_o(RNG_.uniform(-1.0, +1.0), RNG_.uniform(-1.0, +1.0), RNG_.uniform(-1.0, +1.0));
+      Eigen::Vector3d ray_d(RNG_.uniform(-1.0, +1.0), RNG_.uniform(-1.0, +1.0), RNG_.uniform(-1.0, +1.0));
       EigenSTL::vector_Vector3d vi1, vi2;
       shape_cms->intersectsRay(ray_o, ray_d, &vi1);
       loaded_cms->intersectsRay(ray_o, ray_d, &vi2);

--- a/test/test_loaded_meshes.cpp
+++ b/test/test_loaded_meshes.cpp
@@ -101,7 +101,11 @@ TEST_F(CompareMeshVsPrimitive, ContainsPoint)
     bool found = false;
     for (int i = 0; i < 100; ++i)
     {
-      if ((shape_cms->samplePointInside(10000, p)) || (loaded_cms->samplePointInside(10000, p)))
+      if ((shape_cms->samplePointInside([](double lower_bound,
+                                              double upper_bound) { return RNG.uniform(lower_bound, upper_bound); },
+                                        10000, p)) ||
+          (loaded_cms->samplePointInside(
+              [](double lower_bound, double upper_bound) { return RNG.uniform(lower_bound, upper_bound); }, 10000, p)))
       {
         found = true;
         EXPECT_EQ(shape_cms->containsPoint(p), loaded_cms->containsPoint(p));

--- a/test/test_loaded_meshes.cpp
+++ b/test/test_loaded_meshes.cpp
@@ -101,9 +101,8 @@ TEST_F(CompareMeshVsPrimitive, ContainsPoint)
     bool found = false;
     for (int i = 0; i < 100; ++i)
     {
-      if ((shape_cms->samplePointInside([](double lower_bound,
-                                              double upper_bound) { return RNG.uniform(lower_bound, upper_bound); },
-                                        10000, p)) ||
+      if ((shape_cms->samplePointInside(
+              [](double lower_bound, double upper_bound) { return RNG.uniform(lower_bound, upper_bound); }, 10000, p)) ||
           (loaded_cms->samplePointInside(
               [](double lower_bound, double upper_bound) { return RNG.uniform(lower_bound, upper_bound); }, 10000, p)))
       {

--- a/test/test_loaded_meshes.cpp
+++ b/test/test_loaded_meshes.cpp
@@ -37,7 +37,7 @@
 
 namespace
 {
-thread_local auto& RNG_ = shapes::RandomNumberGenerator::getInstance();
+auto& RNG_ = shapes::RandomNumberGenerator::getInstance();
 }  // namespace
 
 /**

--- a/test/test_loaded_meshes.cpp
+++ b/test/test_loaded_meshes.cpp
@@ -77,7 +77,7 @@ public:
   }
 
 protected:
-  random_numbers::RandomNumberGenerator rng;
+  shapes::RandomNumberGenerator rng;
 
   std::vector<shapes::Mesh*> shape_meshes;
   std::vector<shapes::Mesh*> loaded_meshes;
@@ -98,7 +98,7 @@ TEST_F(CompareMeshVsPrimitive, ContainsPoint)
     bool found = false;
     for (int i = 0; i < 100; ++i)
     {
-      if ((shape_cms->samplePointInside(rng, 10000, p)) || (loaded_cms->samplePointInside(rng, 10000, p)))
+      if ((shape_cms->samplePointInside(10000, p)) || (loaded_cms->samplePointInside(10000, p)))
       {
         found = true;
         EXPECT_EQ(shape_cms->containsPoint(p), loaded_cms->containsPoint(p));
@@ -119,8 +119,8 @@ TEST_F(CompareMeshVsPrimitive, IntersectsRay)
     bool intersects = false;
     for (int i = 0; i < 100; ++i)
     {
-      Eigen::Vector3d ray_o(rng.uniformReal(-1.0, +1.0), rng.uniformReal(-1.0, +1.0), rng.uniformReal(-1.0, +1.0));
-      Eigen::Vector3d ray_d(rng.uniformReal(-1.0, +1.0), rng.uniformReal(-1.0, +1.0), rng.uniformReal(-1.0, +1.0));
+      Eigen::Vector3d ray_o(rng.uniform(-1.0, +1.0), rng.uniform(-1.0, +1.0), rng.uniform(-1.0, +1.0));
+      Eigen::Vector3d ray_d(rng.uniform(-1.0, +1.0), rng.uniform(-1.0, +1.0), rng.uniform(-1.0, +1.0));
       EigenSTL::vector_Vector3d vi1, vi2;
       shape_cms->intersectsRay(ray_o, ray_d, &vi1);
       loaded_cms->intersectsRay(ray_o, ray_d, &vi2);

--- a/test/test_point_inclusion.cpp
+++ b/test/test_point_inclusion.cpp
@@ -145,7 +145,8 @@ TEST(SpherePointContainment, SimpleInside)
     sphere->setScale(RNG.uniform(0.1, 100.0));
     sphere->setPadding(RNG.uniform(-0.001, 10.0));
 
-    EXPECT_TRUE(sphere->samplePointInside(100, p));
+    EXPECT_TRUE(sphere->samplePointInside(
+        [](double lower_bound, double upper_bound) { return RNG.uniform(lower_bound, upper_bound); }, 100, p));
     EXPECT_TRUE(sphere->containsPoint(p));
   }
   delete sphere;
@@ -260,7 +261,8 @@ TEST(BoxPointContainment, SimpleInside)
   EXPECT_TRUE(contains);
 
   Eigen::Vector3d p;
-  EXPECT_TRUE(box->samplePointInside(100, p));
+  EXPECT_TRUE(box->samplePointInside(
+      [](double lower_bound, double upper_bound) { return RNG.uniform(lower_bound, upper_bound); }, 100, p));
   EXPECT_TRUE(box->containsPoint(p));
 
   delete box;
@@ -304,7 +306,8 @@ TEST(BoxPointContainment, Sampled)
     box.setScale(RNG.uniform(0.1, 100.0));
     box.setPadding(RNG.uniform(-0.001, 10.0));
 
-    EXPECT_TRUE(box.samplePointInside(100, p));
+    EXPECT_TRUE(box.samplePointInside(
+        [](double lower_bound, double upper_bound) { return RNG.uniform(lower_bound, upper_bound); }, 100, p));
     EXPECT_TRUE(box.containsPoint(p));
   }
 }
@@ -438,7 +441,8 @@ TEST(CylinderPointContainment, Sampled)
     cylinder.setScale(RNG.uniform(0.1, 100.0));
     cylinder.setPadding(RNG.uniform(-0.001, 10.0));
 
-    EXPECT_TRUE(cylinder.samplePointInside(100, p));
+    EXPECT_TRUE(cylinder.samplePointInside(
+        [](double lower_bound, double upper_bound) { return RNG.uniform(lower_bound, upper_bound); }, 100, p));
     EXPECT_TRUE(cylinder.containsPoint(p));
   }
 }
@@ -526,7 +530,8 @@ TEST(MeshPointContainment, Pr2Forearm)
   bool found = true;
   for (int i = 0; i < 10; ++i)
   {
-    if (m->samplePointInside(10000, p))
+    if (m->samplePointInside(
+            [](double lower_bound, double upper_bound) { return RNG.uniform(lower_bound, upper_bound); }, 10000, p))
     {
       found = true;
       EXPECT_TRUE(m->containsPoint(p));

--- a/test/test_point_inclusion.cpp
+++ b/test/test_point_inclusion.cpp
@@ -61,7 +61,7 @@ Eigen::Isometry3d getRandomPose()
 {
   const Eigen::Vector3d t(RNG.uniform(-100, 100), RNG.uniform(-100, 100), RNG.uniform(-100, 100));
 
-  const Eigen::Quaterniond r = Eigen::Quaterniond::UnitRandom();
+  const Eigen::Quaterniond r = RNG.getRandomQuaternion();
 
   return Eigen::Isometry3d::TranslationType(t) * r;
 }

--- a/test/test_point_inclusion.cpp
+++ b/test/test_point_inclusion.cpp
@@ -41,7 +41,7 @@
 
 namespace
 {
-thread_local auto& RNG_ = shapes::RandomNumberGenerator::getInstance();
+auto& RNG_ = shapes::RandomNumberGenerator::getInstance();
 }  // namespace
 
 // split length into the largest number elem, such that sqrt(elem^2 + elem^2) <= length

--- a/test/test_point_inclusion.cpp
+++ b/test/test_point_inclusion.cpp
@@ -41,7 +41,7 @@
 
 namespace
 {
-auto& RNG_ = shapes::RandomNumberGenerator::getInstance();
+auto& RNG = shapes::RandomNumberGenerator::getInstance();
 }  // namespace
 
 // split length into the largest number elem, such that sqrt(elem^2 + elem^2) <= length
@@ -59,7 +59,7 @@ double largestComponentForLength2D(const double length)
 
 Eigen::Isometry3d getRandomPose()
 {
-  const Eigen::Vector3d t(RNG_.uniform(-100, 100), RNG_.uniform(-100, 100), RNG_.uniform(-100, 100));
+  const Eigen::Vector3d t(RNG.uniform(-100, 100), RNG.uniform(-100, 100), RNG.uniform(-100, 100));
 
   const Eigen::Quaterniond r = Eigen::Quaterniond::UnitRandom();
 
@@ -142,8 +142,8 @@ TEST(SpherePointContainment, SimpleInside)
   {
     const Eigen::Isometry3d pos = getRandomPose();
     sphere->setPose(pos);
-    sphere->setScale(RNG_.uniform(0.1, 100.0));
-    sphere->setPadding(RNG_.uniform(-0.001, 10.0));
+    sphere->setScale(RNG.uniform(0.1, 100.0));
+    sphere->setPadding(RNG.uniform(-0.001, 10.0));
 
     EXPECT_TRUE(sphere->samplePointInside(100, p));
     EXPECT_TRUE(sphere->containsPoint(p));
@@ -301,8 +301,8 @@ TEST(BoxPointContainment, Sampled)
   {
     const Eigen::Isometry3d pos = getRandomPose();
     box.setPose(pos);
-    box.setScale(RNG_.uniform(0.1, 100.0));
-    box.setPadding(RNG_.uniform(-0.001, 10.0));
+    box.setScale(RNG.uniform(0.1, 100.0));
+    box.setPadding(RNG.uniform(-0.001, 10.0));
 
     EXPECT_TRUE(box.samplePointInside(100, p));
     EXPECT_TRUE(box.containsPoint(p));
@@ -435,8 +435,8 @@ TEST(CylinderPointContainment, Sampled)
   {
     const Eigen::Isometry3d pos = getRandomPose();
     cylinder.setPose(pos);
-    cylinder.setScale(RNG_.uniform(0.1, 100.0));
-    cylinder.setPadding(RNG_.uniform(-0.001, 10.0));
+    cylinder.setScale(RNG.uniform(0.1, 100.0));
+    cylinder.setPadding(RNG.uniform(-0.001, 10.0));
 
     EXPECT_TRUE(cylinder.samplePointInside(100, p));
     EXPECT_TRUE(cylinder.containsPoint(p));

--- a/test/test_point_inclusion.cpp
+++ b/test/test_point_inclusion.cpp
@@ -31,12 +31,18 @@
 #include <geometric_shapes/bodies.h>
 #include <geometric_shapes/shape_operations.h>
 #include <geometric_shapes/body_operations.h>
+#include "geometric_shapes/random_number_utils.hpp"
 #include <boost/filesystem.hpp>
 #include <gtest/gtest.h>
 #include "resources/config.h"
 
 // We expect surface points are counted inside.
 #define EXPECT_SURF EXPECT_TRUE
+
+namespace
+{
+thread_local auto& RNG_ = shapes::RandomNumberGenerator::getInstance();
+}  // namespace
 
 // split length into the largest number elem, such that sqrt(elem^2 + elem^2) <= length
 double largestComponentForLength2D(const double length)
@@ -51,13 +57,11 @@ double largestComponentForLength2D(const double length)
   return sq2;
 }
 
-Eigen::Isometry3d getRandomPose(random_numbers::RandomNumberGenerator& g)
+Eigen::Isometry3d getRandomPose()
 {
-  const Eigen::Vector3d t(g.uniformReal(-100, 100), g.uniformReal(-100, 100), g.uniformReal(-100, 100));
+  const Eigen::Vector3d t(RNG_.uniform(-100, 100), RNG_.uniform(-100, 100), RNG_.uniform(-100, 100));
 
-  double quat[4];
-  g.quaternion(quat);
-  const Eigen::Quaterniond r({ quat[3], quat[0], quat[1], quat[2] });
+  const Eigen::Quaterniond r = Eigen::Quaterniond::UnitRandom();
 
   return Eigen::Isometry3d::TranslationType(t) * r;
 }
@@ -133,16 +137,15 @@ TEST(SpherePointContainment, SimpleInside)
   sphere->setScale(1.05);
   EXPECT_TRUE(sphere->containsPoint(0, 0, 1.0));
 
-  random_numbers::RandomNumberGenerator r(0);
   Eigen::Vector3d p;
   for (int i = 0; i < 1000; ++i)
   {
-    const Eigen::Isometry3d pos = getRandomPose(r);
+    const Eigen::Isometry3d pos = getRandomPose();
     sphere->setPose(pos);
-    sphere->setScale(r.uniformReal(0.1, 100.0));
-    sphere->setPadding(r.uniformReal(-0.001, 10.0));
+    sphere->setScale(RNG_.uniform(0.1, 100.0));
+    sphere->setPadding(RNG_.uniform(-0.001, 10.0));
 
-    EXPECT_TRUE(sphere->samplePointInside(r, 100, p));
+    EXPECT_TRUE(sphere->samplePointInside(100, p));
     EXPECT_TRUE(sphere->containsPoint(p));
   }
   delete sphere;
@@ -256,9 +259,8 @@ TEST(BoxPointContainment, SimpleInside)
   bool contains = box->containsPoint(0, 0, 1.0);
   EXPECT_TRUE(contains);
 
-  random_numbers::RandomNumberGenerator r;
   Eigen::Vector3d p;
-  EXPECT_TRUE(box->samplePointInside(r, 100, p));
+  EXPECT_TRUE(box->samplePointInside(100, p));
   EXPECT_TRUE(box->containsPoint(p));
 
   delete box;
@@ -294,16 +296,15 @@ TEST(BoxPointContainment, Sampled)
   shapes::Box shape(1.0, 2.0, 3.0);
   bodies::Box box(&shape);
 
-  random_numbers::RandomNumberGenerator r(0);
   Eigen::Vector3d p;
   for (int i = 0; i < 1000; ++i)
   {
-    const Eigen::Isometry3d pos = getRandomPose(r);
+    const Eigen::Isometry3d pos = getRandomPose();
     box.setPose(pos);
-    box.setScale(r.uniformReal(0.1, 100.0));
-    box.setPadding(r.uniformReal(-0.001, 10.0));
+    box.setScale(RNG_.uniform(0.1, 100.0));
+    box.setPadding(RNG_.uniform(-0.001, 10.0));
 
-    EXPECT_TRUE(box.samplePointInside(r, 100, p));
+    EXPECT_TRUE(box.samplePointInside(100, p));
     EXPECT_TRUE(box.containsPoint(p));
   }
 }
@@ -429,16 +430,15 @@ TEST(CylinderPointContainment, Sampled)
   shapes::Cylinder shape(1.0, 4.0);
   bodies::Cylinder cylinder(&shape);
 
-  random_numbers::RandomNumberGenerator r(0);
   Eigen::Vector3d p;
   for (int i = 0; i < 1000; ++i)
   {
-    const Eigen::Isometry3d pos = getRandomPose(r);
+    const Eigen::Isometry3d pos = getRandomPose();
     cylinder.setPose(pos);
-    cylinder.setScale(r.uniformReal(0.1, 100.0));
-    cylinder.setPadding(r.uniformReal(-0.001, 10.0));
+    cylinder.setScale(RNG_.uniform(0.1, 100.0));
+    cylinder.setPadding(RNG_.uniform(-0.001, 10.0));
 
-    EXPECT_TRUE(cylinder.samplePointInside(r, 100, p));
+    EXPECT_TRUE(cylinder.samplePointInside(100, p));
     EXPECT_TRUE(cylinder.containsPoint(p));
   }
 }
@@ -522,12 +522,11 @@ TEST(MeshPointContainment, Pr2Forearm)
   t.translation().x() = 1.0;
   EXPECT_FALSE(m->cloneAt(t)->containsPoint(-1.0, 0.0, 0.0));
 
-  random_numbers::RandomNumberGenerator r(0);
   Eigen::Vector3d p;
   bool found = true;
   for (int i = 0; i < 10; ++i)
   {
-    if (m->samplePointInside(r, 10000, p))
+    if (m->samplePointInside(10000, p))
     {
       found = true;
       EXPECT_TRUE(m->containsPoint(p));

--- a/test/test_ray_intersection.cpp
+++ b/test/test_ray_intersection.cpp
@@ -228,7 +228,8 @@ TEST(SphereRayIntersection, OriginInside)
     sphere.setPadding(RNG.uniform(-0.1, 100.0));
 
     Eigen::Vector3d origin;
-    sphere.samplePointInside(10, origin);
+    sphere.samplePointInside(
+        [](double lower_bound, double upper_bound) { return RNG.uniform(lower_bound, upper_bound); }, 10, origin);
 
     // get the scaled sphere
     bodies::BoundingSphere s;
@@ -511,7 +512,8 @@ TEST(CylinderRayIntersection, OriginInside)
     cylinder.setPadding(RNG.uniform(-0.1, 100.0));
 
     Eigen::Vector3d origin;
-    cylinder.samplePointInside(10, origin);
+    cylinder.samplePointInside(
+        [](double lower_bound, double upper_bound) { return RNG.uniform(lower_bound, upper_bound); }, 10, origin);
 
     // get the bounding sphere of the scaled cylinder
     bodies::BoundingSphere s;
@@ -864,7 +866,8 @@ TEST(BoxRayIntersection, OriginInside)
     const Eigen::Vector3d boxCenter = box.getPose().translation();
 
     Eigen::Vector3d origin;
-    box.samplePointInside(10, origin);
+    box.samplePointInside(
+        [](double lower_bound, double upper_bound) { return RNG.uniform(lower_bound, upper_bound); }, 10, origin);
 
     const Eigen::Vector3d dir = Eigen::Vector3d::Random().normalized();
 
@@ -1195,7 +1198,8 @@ TEST(ConvexMeshRayIntersection, OriginInside)
     const Eigen::Vector3d meshCenter = mesh.getPose().translation();
 
     Eigen::Vector3d origin;
-    mesh.samplePointInside(10000, origin);
+    mesh.samplePointInside(
+        [](double lower_bound, double upper_bound) { return RNG.uniform(lower_bound, upper_bound); }, 10000, origin);
 
     const Eigen::Vector3d dir = Eigen::Vector3d::Random().normalized();
 

--- a/test/test_ray_intersection.cpp
+++ b/test/test_ray_intersection.cpp
@@ -866,8 +866,8 @@ TEST(BoxRayIntersection, OriginInside)
     const Eigen::Vector3d boxCenter = box.getPose().translation();
 
     Eigen::Vector3d origin;
-    box.samplePointInside(
-        [](double lower_bound, double upper_bound) { return RNG.uniform(lower_bound, upper_bound); }, 10, origin);
+    box.samplePointInside([](double lower_bound, double upper_bound) { return RNG.uniform(lower_bound, upper_bound); },
+                          10, origin);
 
     const Eigen::Vector3d dir = Eigen::Vector3d::Random().normalized();
 
@@ -1198,8 +1198,8 @@ TEST(ConvexMeshRayIntersection, OriginInside)
     const Eigen::Vector3d meshCenter = mesh.getPose().translation();
 
     Eigen::Vector3d origin;
-    mesh.samplePointInside(
-        [](double lower_bound, double upper_bound) { return RNG.uniform(lower_bound, upper_bound); }, 10000, origin);
+    mesh.samplePointInside([](double lower_bound, double upper_bound) { return RNG.uniform(lower_bound, upper_bound); },
+                           10000, origin);
 
     const Eigen::Vector3d dir = Eigen::Vector3d::Random().normalized();
 

--- a/test/test_ray_intersection.cpp
+++ b/test/test_ray_intersection.cpp
@@ -39,7 +39,7 @@
 
 namespace
 {
-thread_local auto& RNG_ = shapes::RandomNumberGenerator::getInstance();
+auto& RNG_ = shapes::RandomNumberGenerator::getInstance();
 }  // namespace
 
 Eigen::Isometry3d getRandomPose()

--- a/test/test_ray_intersection.cpp
+++ b/test/test_ray_intersection.cpp
@@ -39,12 +39,12 @@
 
 namespace
 {
-auto& RNG_ = shapes::RandomNumberGenerator::getInstance();
+auto& RNG = shapes::RandomNumberGenerator::getInstance();
 }  // namespace
 
 Eigen::Isometry3d getRandomPose()
 {
-  const Eigen::Vector3d t(RNG_.uniform(-100, 100), RNG_.uniform(-100, 100), RNG_.uniform(-100, 100));
+  const Eigen::Vector3d t(RNG.uniform(-100, 100), RNG.uniform(-100, 100), RNG.uniform(-100, 100));
   const auto r = Eigen::Quaterniond::UnitRandom();
 
   return Eigen::Isometry3d::TranslationType(t) * r;
@@ -224,8 +224,8 @@ TEST(SphereRayIntersection, OriginInside)
   {
     const Eigen::Isometry3d pos = getRandomPose();
     sphere.setPose(pos);
-    sphere.setScale(RNG_.uniform(0.5, 100.0));
-    sphere.setPadding(RNG_.uniform(-0.1, 100.0));
+    sphere.setScale(RNG.uniform(0.5, 100.0));
+    sphere.setPadding(RNG.uniform(-0.1, 100.0));
 
     Eigen::Vector3d origin;
     sphere.samplePointInside(10, origin);
@@ -306,8 +306,8 @@ TEST(SphereRayIntersection, OriginOutside)
   {
     const Eigen::Isometry3d pos = getRandomPose();
     sphere.setPose(pos);
-    sphere.setScale(RNG_.uniform(0.5, 100.0));
-    sphere.setPadding(RNG_.uniform(-0.1, 100.0));
+    sphere.setScale(RNG.uniform(0.5, 100.0));
+    sphere.setPadding(RNG.uniform(-0.1, 100.0));
 
     // choose a random direction
     const Eigen::Vector3d dir = Eigen::Vector3d::Random().normalized();
@@ -353,7 +353,7 @@ TEST(SphereRayIntersection, OriginOutside)
     perpDir.normalize();
 
     // now move origin "sideways" but still only so much that the ray will hit the sphere
-    const Eigen::Vector3d origin2 = origin + RNG_.uniform(1e-6, s.radius - 1e-4) * perpDir;
+    const Eigen::Vector3d origin2 = origin + RNG.uniform(1e-6, s.radius - 1e-4) * perpDir;
 
     intersections.clear();
     if (sphere.intersectsRay(origin2, dir, &intersections, 2))
@@ -507,8 +507,8 @@ TEST(CylinderRayIntersection, OriginInside)
   {
     const Eigen::Isometry3d pos = getRandomPose();
     cylinder.setPose(pos);
-    cylinder.setScale(RNG_.uniform(0.5, 100.0));
-    cylinder.setPadding(RNG_.uniform(-0.1, 100.0));
+    cylinder.setScale(RNG.uniform(0.5, 100.0));
+    cylinder.setPadding(RNG.uniform(-0.1, 100.0));
 
     Eigen::Vector3d origin;
     cylinder.samplePointInside(10, origin);
@@ -595,8 +595,8 @@ TEST(CylinderRayIntersection, OriginOutside)
   {
     const Eigen::Isometry3d pos = getRandomPose();
     cylinder.setPose(pos);
-    cylinder.setScale(RNG_.uniform(0.5, 100.0));
-    cylinder.setPadding(RNG_.uniform(-0.1, 100.0));
+    cylinder.setScale(RNG.uniform(0.5, 100.0));
+    cylinder.setPadding(RNG.uniform(-0.1, 100.0));
 
     // choose a random direction
     const Eigen::Vector3d dir = Eigen::Vector3d::Random().normalized();
@@ -647,7 +647,7 @@ TEST(CylinderRayIntersection, OriginOutside)
 
     // now move origin "sideways" but still only so much that the ray will hit the cylinder
     auto minRadius = (std::min)(c.radius, c.length);
-    const Eigen::Vector3d origin2 = origin + RNG_.uniform(1e-6, minRadius - 1e-4) * perpDir;
+    const Eigen::Vector3d origin2 = origin + RNG.uniform(1e-6, minRadius - 1e-4) * perpDir;
 
     intersections.clear();
     if (cylinder.intersectsRay(origin2, dir, &intersections, 2))
@@ -849,8 +849,8 @@ TEST(BoxRayIntersection, OriginInside)
   {
     const Eigen::Isometry3d pos = getRandomPose();
     box.setPose(pos);
-    box.setScale(RNG_.uniform(0.5, 100.0));
-    box.setPadding(RNG_.uniform(-0.1, 100.0));
+    box.setScale(RNG.uniform(0.5, 100.0));
+    box.setPadding(RNG.uniform(-0.1, 100.0));
 
     // get the scaled dimensions of the box
     Eigen::Vector3d sizes = { box.getDimensions()[0], box.getDimensions()[1], box.getDimensions()[2] };
@@ -940,8 +940,8 @@ TEST(BoxRayIntersection, OriginOutsideIntersects)
   {
     const Eigen::Isometry3d pos = getRandomPose();
     box.setPose(pos);
-    box.setScale(RNG_.uniform(0.5, 100.0));
-    box.setPadding(RNG_.uniform(-0.1, 100.0));
+    box.setScale(RNG.uniform(0.5, 100.0));
+    box.setPadding(RNG.uniform(-0.1, 100.0));
 
     // choose a random direction
     const Eigen::Vector3d dir = Eigen::Vector3d::Random().normalized();
@@ -997,7 +997,7 @@ TEST(BoxRayIntersection, OriginOutsideIntersects)
     perpDir.normalize();
 
     // now move origin "sideways" but still only so much that the ray will hit the box
-    const Eigen::Vector3d origin2 = origin + RNG_.uniform(1e-6, minRadius - 1e-4) * perpDir;
+    const Eigen::Vector3d origin2 = origin + RNG.uniform(1e-6, minRadius - 1e-4) * perpDir;
 
     intersections.clear();
     if (box.intersectsRay(origin2, dir, &intersections, 2))
@@ -1180,8 +1180,8 @@ TEST(ConvexMeshRayIntersection, OriginInside)
   {
     const Eigen::Isometry3d pos = getRandomPose();
     mesh.setPose(pos);
-    mesh.setScale(RNG_.uniform(0.5, 100.0));
-    mesh.setPadding(RNG_.uniform(-0.1, 100.0));
+    mesh.setScale(RNG.uniform(0.5, 100.0));
+    mesh.setPadding(RNG.uniform(-0.1, 100.0));
 
     // get the scaled dimensions of the mesh
     Eigen::Vector3d sizes = { box.size[0], box.size[1], box.size[2] };
@@ -1273,8 +1273,8 @@ TEST(ConvexMeshRayIntersection, OriginOutsideIntersects)
   {
     const Eigen::Isometry3d pos = getRandomPose();
     mesh.setPose(pos);
-    mesh.setScale(RNG_.uniform(0.5, 100.0));
-    mesh.setPadding(RNG_.uniform(-0.1, 100.0));
+    mesh.setScale(RNG.uniform(0.5, 100.0));
+    mesh.setPadding(RNG.uniform(-0.1, 100.0));
 
     // choose a random direction
     const Eigen::Vector3d dir = Eigen::Vector3d::Random().normalized();
@@ -1330,7 +1330,7 @@ TEST(ConvexMeshRayIntersection, OriginOutsideIntersects)
     perpDir.normalize();
 
     // now move origin "sideways" but still only so much that the ray will hit the mesh
-    const Eigen::Vector3d origin2 = origin + RNG_.uniform(1e-6, minRadius - 1e-4) * perpDir;
+    const Eigen::Vector3d origin2 = origin + RNG.uniform(1e-6, minRadius - 1e-4) * perpDir;
 
     intersections.clear();
     if (mesh.intersectsRay(origin2, dir, &intersections, 2))

--- a/test/test_ray_intersection.cpp
+++ b/test/test_ray_intersection.cpp
@@ -45,7 +45,7 @@ auto& RNG = shapes::RandomNumberGenerator::getInstance();
 Eigen::Isometry3d getRandomPose()
 {
   const Eigen::Vector3d t(RNG.uniform(-100, 100), RNG.uniform(-100, 100), RNG.uniform(-100, 100));
-  const auto r = Eigen::Quaterniond::UnitRandom();
+  const auto r = RNG.getRandomQuaternion();
 
   return Eigen::Isometry3d::TranslationType(t) * r;
 }


### PR DESCRIPTION
### Description
This PR aims to remove the random number dependency from geometric_shapes. To do so, the cpp std library `<random>` is used directly. Instead of the random_number::RandomNumberGenerator, a simpler one is defined in the header `random_number_utils.hpp`. 

Furthermore, the API of `samplePointInside` is changed by removing the random number generator argument. I did this to aviod the need for the user to create an extra RandomNumberGenerator instance  when using this function

Generating random quaternions can be done with the constructor from Eigen itself. For example like this:
```
Eigen::Quaterniond rand_quaternion = Eigen::Quaterniond::UnitRandom();
```
