### PR TITLE
Eigen < 3.3.0 needs explicit cast

### DIFF
--- a/src/bodies.cpp
+++ b/src/bodies.cpp
@@ -154,7 +154,7 @@ inline Eigen::Vector3d normalize(const Eigen::Vector3d& dir)
 #if EIGEN_VERSION_AT_LEAST(3, 3, 0)
   return ((norm - 1) > 1e-9) ? (dir / Eigen::numext::sqrt(norm)) : dir;
 #else  // used in kinetic
-  return ((norm - 1) > 1e-9) ? (dir / sqrt(norm)) : dir;
+  return ((norm - 1) > 1e-9) ? (Eigen::Vector3d)(dir / sqrt(norm)) : dir;
 #endif
 }
 }  // namespace bodies


### PR DESCRIPTION
https://github.com/ros-planning/geometric_shapes/blob/016fc5ec15101817a79fd6333ca4ce48c69bff83/src/bodies.cpp#L151-L159

supports  Eigen < 3.3.0, but if we actually compile `geometry_shapes` with eigen 3.1, we have following errors

```
/ws/src/geometric_shapes/src/bodies.cpp: In function ‘Eigen::Vector3d bodies::normalize(const Vector3d&)’:
/ws/src/geometric_shapes/src/bodies.cpp:157:53: error: operands to ?: have different types ‘const Eigen::CwiseUnaryOp<Eigen::internal::scalar_quotient1_op<double>, const Eigen::Matrix<double, 3, 1> >’ and ‘const Vector3d {aka const Eigen::Matrix<double, 3, 1>}’
   return ((norm - 1) > 1e-9) ? (dir / sqrt(norm)) : dir;
```