### PR TITLE
Fix usage of oriented bounding box in test

### DIFF
--- a/test/test_bounding_box.cpp
+++ b/test/test_bounding_box.cpp
@@ -538,6 +538,7 @@ TEST(MergeBoundingBoxes, OBBApprox1)
   boxes.emplace_back(pose, Eigen::Vector3d(1, 1, 1));
 
   bodies::OBB bbox;
+  bbox.setPoseAndExtents(Eigen::Isometry3d::Identity(), Eigen::Vector3d::Zero());
   bodies::mergeBoundingBoxesApprox(boxes, bbox);
 
   // the resulting bounding box is not tight, so we only do some sanity checks


### PR DESCRIPTION
OBB constructor does not initialize the orientation matrix to identity, so it is invalid (all zeros) in the default-constructed OBB object.

"Unfortunately", the test did miraculously work even with the uninitialized OBB. This PR fixes the wrong usage.