### PR TITLE
Improve accuracy of computed oriented bounding boxes

### DIFF
--- a/include/geometric_shapes/obb.h
+++ b/include/geometric_shapes/obb.h
@@ -53,6 +53,8 @@ class OBBPrivate;
 class OBB
 {
 public:
+  /** \brief Initialize an oriented bounding box at position 0, with 0 extents and
+   *         identity orientation. */
   OBB();
   OBB(const OBB& other);
   OBB(const Eigen::Isometry3d& pose, const Eigen::Vector3d& extents);

--- a/include/geometric_shapes/obb.h
+++ b/include/geometric_shapes/obb.h
@@ -42,6 +42,7 @@
 #include <Eigen/Core>
 #include <Eigen/Geometry>
 
+#include <eigen_stl_containers/eigen_stl_containers.h>
 #include <geometric_shapes/aabb.h>
 
 namespace bodies
@@ -114,14 +115,27 @@ public:
    * \param point The point to check.
    * \return Whether the point is inside or not.
    */
-  bool contains(const Eigen::Vector3d& point);
+  bool contains(const Eigen::Vector3d& point) const;
 
   /**
    * \brief Check whether this and the given OBBs have nonempty intersection.
    * \param other The other OBB to check.
    * \return Whether the OBBs overlap.
    */
-  bool overlaps(const OBB& other);
+  bool overlaps(const OBB& other) const;
+
+  /**
+   * \brief Check if this OBB contains whole other OBB.
+   * \param point The point to check.
+   * \return Whether the point is inside or not.
+   */
+  bool contains(const OBB& obb) const;
+
+  /**
+   * \brief Compute coordinates of the 8 vertices of this OBB.
+   * \return The vertices.
+   */
+  EigenSTL::vector_Vector3d computeVertices() const;
 
 protected:
   /** \brief PIMPL pointer */

--- a/src/obb.cpp
+++ b/src/obb.cpp
@@ -43,6 +43,13 @@ public:
 OBB::OBB()
 {
   this->obb_.reset(new OBBPrivate);
+#if FCL_MAJOR_VERSION > 0 || FCL_MINOR_VERSION > 5
+  // Zero-initialize the OBB. This is done to unify the behavior of FCL 0.5 (which zero-initializes by default) and
+  // FCL 0.6, which leaves the fields uninitialized.
+  this->obb_->extent.setZero();
+  this->obb_->To.setZero();
+  this->obb_->axis.setZero();
+#endif
 }
 
 OBB::OBB(const OBB& other) : OBB()
@@ -132,18 +139,68 @@ void OBB::toAABB(AABB& aabb) const
 
 OBB* OBB::extendApprox(const OBB& box)
 {
+  if (this->getExtents() == Eigen::Vector3d::Zero())
+  {
+    *obb_ = *box.obb_;
+    return this;
+  }
+
+  if (this->contains(box))
+    return this;
+
+  if (box.contains(*this))
+  {
+    *obb_ = *box.obb_;
+    return this;
+  }
+
   *this->obb_ += *box.obb_;
   return this;
 }
 
-bool OBB::contains(const Eigen::Vector3d& point)
+bool OBB::contains(const Eigen::Vector3d& point) const
 {
   return obb_->contain(toFcl(point));
 }
 
-bool OBB::overlaps(const bodies::OBB& other)
+bool OBB::overlaps(const bodies::OBB& other) const
 {
   return obb_->overlap(*other.obb_);
+}
+
+EigenSTL::vector_Vector3d OBB::computeVertices() const
+{
+  const Eigen::Vector3d e = getExtents() / 2;  // do not use auto type, Eigen would be inefficient
+  // clang-format off
+  EigenSTL::vector_Vector3d result = {
+    { -e[0], -e[1], -e[2] },
+    { -e[0], -e[1],  e[2] },
+    { -e[0],  e[1], -e[2] },
+    { -e[0],  e[1],  e[2] },
+    {  e[0], -e[1], -e[2] },
+    {  e[0], -e[1],  e[2] },
+    {  e[0],  e[1], -e[2] },
+    {  e[0],  e[1],  e[2] },
+  };
+  // clang-format on
+
+  const auto pose = getPose();
+  for (auto& v : result)
+  {
+    v = pose * v;
+  }
+
+  return result;
+}
+
+bool OBB::contains(const OBB& obb) const
+{
+  for (const auto& v : obb.computeVertices())
+  {
+    if (!contains(v))
+      return false;
+  }
+  return true;
 }
 
 OBB::~OBB() = default;

--- a/src/obb.cpp
+++ b/src/obb.cpp
@@ -59,8 +59,7 @@ OBB::OBB()
 
 OBB::OBB(const OBB& other)
 {
-  obb_.reset(new OBBPrivate);
-  *obb_ = *other.obb_;
+  obb_.reset(new OBBPrivate(*other.obb_));
 }
 
 OBB::OBB(const Eigen::Isometry3d& pose, const Eigen::Vector3d& extents)

--- a/test/test_bounding_box.cpp
+++ b/test/test_bounding_box.cpp
@@ -626,17 +626,31 @@ TEST(MergeBoundingBoxes, OBBApprox1)
   boxes.emplace_back(pose, Eigen::Vector3d(1, 1, 1));
 
   bodies::OBB bbox;
-  bbox.setPoseAndExtents(Eigen::Isometry3d::Identity(), Eigen::Vector3d::Zero());
+  // check that the empty constructor constructs a valid empty OBB
+  EXPECT_EQ(0.0, bbox.getPose().translation().x());
+  EXPECT_EQ(0.0, bbox.getPose().translation().y());
+  EXPECT_EQ(0.0, bbox.getPose().translation().z());
+  EXPECT_EQ(0.0, bbox.getExtents().x());
+  EXPECT_EQ(0.0, bbox.getExtents().y());
+  EXPECT_EQ(0.0, bbox.getExtents().z());
+  EXPECT_TRUE(bbox.getPose().rotation().isApprox(Eigen::Matrix3d::Identity()));
+
   bodies::mergeBoundingBoxesApprox(boxes, bbox);
 
-  // the resulting bounding box is not tight, so we only do some sanity checks
+  // the resulting bounding box might not be tight, so we only do some sanity checks
 
-  EXPECT_GE(4.0, bbox.getExtents().x());
-  EXPECT_GE(4.0, bbox.getExtents().y());
-  EXPECT_GE(4.0, bbox.getExtents().z());
+  EXPECT_GE(2.1, bbox.getExtents().x());
+  EXPECT_GE(2.1, bbox.getExtents().y());
+  EXPECT_GE(2.1, bbox.getExtents().z());
+  EXPECT_GE(0.1, bbox.getPose().translation().x());
+  EXPECT_GE(0.1, bbox.getPose().translation().y());
+  EXPECT_GE(0.1, bbox.getPose().translation().z());
   EXPECT_LE(2.0, bbox.getExtents().x());
   EXPECT_LE(2.0, bbox.getExtents().y());
   EXPECT_LE(2.0, bbox.getExtents().z());
+  EXPECT_LE(-0.1, bbox.getPose().translation().x());
+  EXPECT_LE(-0.1, bbox.getPose().translation().y());
+  EXPECT_LE(-0.1, bbox.getPose().translation().z());
 
   EXPECT_TRUE(bbox.contains(boxes[0].getPose().translation()));
   EXPECT_TRUE(bbox.contains(boxes[1].getPose().translation()));


### PR DESCRIPTION
In case one OBB is fully contained inside the other, merging them together will now result in the larger one being returned exactly (normally, FCL yields a larger OBB than the original one).

This change is needed to keep multiple merged OBBs coming from a robot model sane. I don't know exactly why the original PR adding OBBs support did not contain this improvement - my code in robot_body_filter has been doing this for the last 4 years: https://github.com/peci1/robot_body_filter/blob/2c13fc8b0aa5ae7ad71a336a3916f53171c8d9f5/src/utils/obb.cpp#L122-L140 .

With this change, our tracked robot model OBB is kept within +- 2 meters range. Without this change, after being composed by merging 40+ OBBs with various rotations, the overall OBB dimensions are in the range of 40 kilometers! My understanding is that [FCL first computes an average orientation of both OBBs](https://github.com/flexible-collision-library/fcl/blob/54e9619bc2b084ee50e986ac3308160d663481c4/src/BV/OBB.cpp#L128) (altough a bit weird by averaging coordinates of the quaternions) and then finds the smallest box with this orientation. This way, after merging, the resulting box may be up to `sqrt(3)`-times larger. Thus a model composed of 40 OBBs can have the resulting OBB up to `sqrt(3)^40` larger than necessary. This PR stops this infinite growth quite early once an OBB large enough to contain the whole model is created.

I added a few tests that fail when fully relying on FCL to merge the two OBBs.