### PR TITLE
Do not export fcl dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,7 +90,7 @@ target_compile_options(${PROJECT_NAME} PRIVATE ${PROJECT_COMPILE_OPTIONS})
 target_include_directories(${PROJECT_NAME}
     PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
            $<INSTALL_INTERFACE:include/${PROJECT_NAME}>)
-target_link_libraries(${PROJECT_NAME} fcl)
+target_link_libraries(${PROJECT_NAME} PRIVATE fcl)
 ament_target_dependencies(${PROJECT_NAME}
   ${THIS_PACKAGE_EXPORT_DEPENDS}
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,15 +90,12 @@ target_compile_options(${PROJECT_NAME} PRIVATE ${PROJECT_COMPILE_OPTIONS})
 target_include_directories(${PROJECT_NAME}
     PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
            $<INSTALL_INTERFACE:include/${PROJECT_NAME}>)
-target_link_libraries(${PROJECT_NAME} PRIVATE fcl)
 ament_target_dependencies(${PROJECT_NAME} PUBLIC
   ${THIS_PACKAGE_EXPORT_DEPENDS}
 )
-ament_target_dependencies(${PROJECT_NAME} SYSTEM
-  # We don't export these dependencies because their cmake is broken
-  assimp
-  QHULL
-)
+# Private libraries that are not transitively needed by downstream projects
+target_link_libraries(${PROJECT_NAME} PRIVATE assimp::assimp fcl ${QHULL_LIBRARIES})
+target_include_directories(${PROJECT_NAME} PRIVATE ${QHULL_INCLUDE_DIRS})
 
 if(BUILD_TESTING)
   find_package(ament_cmake_gtest REQUIRED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,7 +91,7 @@ target_include_directories(${PROJECT_NAME}
     PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
            $<INSTALL_INTERFACE:include/${PROJECT_NAME}>)
 target_link_libraries(${PROJECT_NAME} PRIVATE fcl)
-ament_target_dependencies(${PROJECT_NAME}
+ament_target_dependencies(${PROJECT_NAME} PUBLIC
   ${THIS_PACKAGE_EXPORT_DEPENDS}
 )
 ament_target_dependencies(${PROJECT_NAME} SYSTEM

--- a/package.xml
+++ b/package.xml
@@ -48,7 +48,7 @@
   <exec_depend>libboost-filesystem</exec_depend>
   <exec_depend>rosidl_default_runtime</exec_depend>
   <exec_depend>libfcl</exec_depend>
-  <exec_depend>libqhull</build_depend>
+  <exec_depend>libqhull</exec_depend>
 
   <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_lint_auto</test_depend>

--- a/package.xml
+++ b/package.xml
@@ -27,7 +27,6 @@
   <depend>rclcpp</depend>
   <depend>eigen_stl_containers</depend>
   <depend>console_bridge_vendor</depend>
-  <depend>libqhull</depend>
   <depend>liboctomap-dev</depend>
   <depend>random_numbers</depend>
   <depend>resource_retriever</depend>
@@ -38,6 +37,7 @@
   <build_depend>assimp-dev</build_depend>
   <build_depend>eigen</build_depend>
   <build_depend>libfcl-dev</build_depend>
+  <build_depend>libqhull</build_depend>
   <build_depend>pkg-config</build_depend>
   <build_depend>libboost-dev</build_depend>
   <build_depend>libboost-filesystem-dev</build_depend>
@@ -48,6 +48,7 @@
   <exec_depend>libboost-filesystem</exec_depend>
   <exec_depend>rosidl_default_runtime</exec_depend>
   <exec_depend>libfcl</exec_depend>
+  <exec_depend>libqhull</build_depend>
 
   <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_lint_auto</test_depend>


### PR DESCRIPTION
Hopefully closes #255.

It seems we have erroneousely exported `fcl` as interface link library when it should only be private (it is only used in `obb.cpp` and in no header files).