### PR TITLE
Remove unnecessary code in `aabb.cpp`

### DIFF
--- a/src/aabb.cpp
+++ b/src/aabb.cpp
@@ -34,18 +34,6 @@
 
 void bodies::AABB::extendWithTransformedBox(const Eigen::Isometry3d& transform, const Eigen::Vector3d& box)
 {
-  // Method adapted from FCL src/shape/geometric_shapes_utility.cpp#computeBV<AABB, Box>(...) (BSD-licensed code):
-  // https://github.com/flexible-collision-library/fcl/blob/fcl-0.4/src/shape/geometric_shapes_utility.cpp#L292
-  // We don't call their code because it would need creating temporary objects, and their method is in floats in FCL 0.5
-  //
-  // Here's a nice explanation why it works: https://zeuxcg.org/2010/10/17/aabb-from-obb-with-component-wise-abs/
-  const Eigen::Matrix3d& r = transform.rotation();
-  const Eigen::Vector3d& t = transform.translation();
-
-  double x_range = 0.5 * (fabs(r(0, 0) * box[0]) + fabs(r(0, 1) * box[1]) + fabs(r(0, 2) * box[2]));
-  double y_range = 0.5 * (fabs(r(1, 0) * box[0]) + fabs(r(1, 1) * box[1]) + fabs(r(1, 2) * box[2]));
-  double z_range = 0.5 * (fabs(r(2, 0) * box[0]) + fabs(r(2, 1) * box[1]) + fabs(r(2, 2) * box[2]));
-
   fcl::AABBd aabb;
   fcl::computeBV(fcl::Boxd(box), transform, aabb);
   extend(aabb.min_);


### PR DESCRIPTION
As described in #257, I think this code can simply be removed since we don't need the older implementation around for older FCL versions that are not in any of the active ROS 2 distros.

Closes #229 
Closes #257 