### PR TITLE
[kilted] Update deprecated call to ament_target_dependencies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,8 +92,18 @@ target_include_directories(${PROJECT_NAME}
            $<INSTALL_INTERFACE:include/${PROJECT_NAME}>)
 # Private libraries that are not transitively needed by downstream projects
 target_link_libraries(${PROJECT_NAME}
-  PUBLIC ${THIS_PACKAGE_EXPORT_DEPENDS}
-  PRIVATE assimp::assimp fcl ${QHULL_LIBRARIES}
+  PRIVATE
+    assimp::assimp
+    fcl
+    ${QHULL_LIBRARIES}
+  PUBLIC
+    ${geometry_msgs_TARGETS}
+    ${shape_msgs_TARGETS}
+    ${visualization_msgs_TARGETS}
+    eigen_stl_containers::eigen_stl_containers
+    # random_numbers::random_numbers
+    rclcpp::rclcpp
+    resource_retriever::resource_retriever
 )
 target_include_directories(${PROJECT_NAME} PRIVATE ${QHULL_INCLUDE_DIRS})
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,7 +90,7 @@ target_compile_options(${PROJECT_NAME} PRIVATE ${PROJECT_COMPILE_OPTIONS})
 target_include_directories(${PROJECT_NAME}
     PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
            $<INSTALL_INTERFACE:include/${PROJECT_NAME}>)
-ament_target_dependencies(${PROJECT_NAME} PUBLIC
+target_link_libraries(${PROJECT_NAME} PUBLIC
   ${THIS_PACKAGE_EXPORT_DEPENDS}
 )
 # Private libraries that are not transitively needed by downstream projects

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,11 +90,11 @@ target_compile_options(${PROJECT_NAME} PRIVATE ${PROJECT_COMPILE_OPTIONS})
 target_include_directories(${PROJECT_NAME}
     PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
            $<INSTALL_INTERFACE:include/${PROJECT_NAME}>)
-target_link_libraries(${PROJECT_NAME} PUBLIC
-  ${THIS_PACKAGE_EXPORT_DEPENDS}
-)
 # Private libraries that are not transitively needed by downstream projects
-target_link_libraries(${PROJECT_NAME} PRIVATE assimp::assimp fcl ${QHULL_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PUBLIC ${THIS_PACKAGE_EXPORT_DEPENDS}
+  PRIVATE assimp::assimp fcl ${QHULL_LIBRARIES}
+)
 target_include_directories(${PROJECT_NAME} PRIVATE ${QHULL_INCLUDE_DIRS})
 
 if(BUILD_TESTING)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -8,7 +8,7 @@ include_directories(${CMAKE_CURRENT_BINARY_DIR})
 
 ament_add_gtest(test_basics test_basics.cpp)
 target_link_libraries(test_basics ${PROJECT_NAME})
-ament_target_dependencies(test_basics Eigen3)
+target_link_libraries(test_basics PUBLIC Eigen3)
 
 ament_add_gtest(test_point_inclusion test_point_inclusion.cpp)
 target_link_libraries(test_point_inclusion ${PROJECT_NAME})

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -7,7 +7,7 @@ configure_file(resources/config.h.in "${CMAKE_CURRENT_BINARY_DIR}/resources/conf
 include_directories(${CMAKE_CURRENT_BINARY_DIR})
 
 ament_add_gtest(test_basics test_basics.cpp)
-target_link_libraries(test_basics ${PROJECT_NAME} PUBLIC Eigen3)
+target_link_libraries(test_basics ${PROJECT_NAME} Eigen3)
 
 ament_add_gtest(test_point_inclusion test_point_inclusion.cpp)
 target_link_libraries(test_point_inclusion ${PROJECT_NAME})

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -7,8 +7,7 @@ configure_file(resources/config.h.in "${CMAKE_CURRENT_BINARY_DIR}/resources/conf
 include_directories(${CMAKE_CURRENT_BINARY_DIR})
 
 ament_add_gtest(test_basics test_basics.cpp)
-target_link_libraries(test_basics ${PROJECT_NAME})
-target_link_libraries(test_basics PUBLIC Eigen3)
+target_link_libraries(test_basics ${PROJECT_NAME} PUBLIC Eigen3)
 
 ament_add_gtest(test_point_inclusion test_point_inclusion.cpp)
 target_link_libraries(test_point_inclusion ${PROJECT_NAME})


### PR DESCRIPTION
As of the ROS 2 Kilted release [`ament_target_dependencies` is deprecated.](https://docs.ros.org/en/kilted/Releases/Release-Kilted-Kaiju.html#ament-target-dependencies-is-deprecated)

This PR updates the syntax. Caution should be used to ensure that the target branch is not used for other ROS 2 distros.

Note: This PR was generated by a bot script, but using the simple pattern matching of the [`ros_glint`](https://github.com/MetroRobots/ros_glint) library. No LLMs were used.
