### PR TITLE
fix compile with local octomap

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,7 +85,8 @@ set_target_properties(${PROJECT_NAME} PROPERTIES VERSION ${${PROJECT_NAME}_VERSI
 target_compile_options(${PROJECT_NAME} PRIVATE ${PROJECT_COMPILE_OPTIONS})
 target_include_directories(${PROJECT_NAME}
     PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-           $<INSTALL_INTERFACE:include/${PROJECT_NAME}>)
+           $<INSTALL_INTERFACE:include/${PROJECT_NAME}> ${OCTOMAP_INCLUDE_DIRS})
+
 # Private libraries that are not transitively needed by downstream projects
 target_link_libraries(${PROJECT_NAME}
   PRIVATE
@@ -94,6 +95,7 @@ target_link_libraries(${PROJECT_NAME}
     ${QHULL_LIBRARIES}
   PUBLIC
     ${geometry_msgs_TARGETS}
+    ${OCTOMAP_LIBRARIES}
     ${shape_msgs_TARGETS}
     ${visualization_msgs_TARGETS}
     ${console_bridge_TARGETS}

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,5 +1,7 @@
 find_package(Boost REQUIRED COMPONENTS filesystem)
 find_package(ament_cmake_gtest REQUIRED)
+find_package(octomap REQUIRED)
+
 
 file(TO_NATIVE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/resources" TEST_RESOURCES_DIR)
 if(WIN32)
@@ -10,31 +12,31 @@ configure_file(resources/config.h.in "${CMAKE_CURRENT_BINARY_DIR}/resources/conf
 include_directories(${CMAKE_CURRENT_BINARY_DIR})
 
 ament_add_gtest(test_basics test_basics.cpp)
-target_link_libraries(test_basics ${PROJECT_NAME})
+target_link_libraries(test_basics ${PROJECT_NAME} ${OCTOMAP_LIBRARIES})
 
 ament_add_gtest(test_point_inclusion test_point_inclusion.cpp)
-target_link_libraries(test_point_inclusion ${PROJECT_NAME} Boost::filesystem)
+target_link_libraries(test_point_inclusion ${PROJECT_NAME} ${OCTOMAP_LIBRARIES} Boost::filesystem)
 
 ament_add_gtest(test_bounding_sphere test_bounding_sphere.cpp)
-target_link_libraries(test_bounding_sphere ${PROJECT_NAME} Boost::filesystem)
+target_link_libraries(test_bounding_sphere ${PROJECT_NAME} ${OCTOMAP_LIBRARIES} Boost::filesystem)
 
 ament_add_gtest(test_bounding_box test_bounding_box.cpp)
-target_link_libraries(test_bounding_box ${PROJECT_NAME})
+target_link_libraries(test_bounding_box ${OCTOMAP_LIBRARIES} ${PROJECT_NAME})
 
 ament_add_gtest(test_bounding_cylinder test_bounding_cylinder.cpp)
-target_link_libraries(test_bounding_cylinder ${PROJECT_NAME})
+target_link_libraries(test_bounding_cylinder ${OCTOMAP_LIBRARIES} ${PROJECT_NAME})
 
 ament_add_gtest(test_create_mesh test_create_mesh.cpp)
-target_link_libraries(test_create_mesh ${PROJECT_NAME})
+target_link_libraries(test_create_mesh ${OCTOMAP_LIBRARIES} ${PROJECT_NAME})
 
 ament_add_gtest(test_loaded_meshes test_loaded_meshes.cpp)
-target_link_libraries(test_loaded_meshes ${PROJECT_NAME} Boost::filesystem)
+target_link_libraries(test_loaded_meshes ${PROJECT_NAME} ${OCTOMAP_LIBRARIES} Boost::filesystem)
 
 ament_add_gtest(test_shapes test_shapes.cpp)
-target_link_libraries(test_shapes ${PROJECT_NAME})
+target_link_libraries(test_shapes ${OCTOMAP_LIBRARIES} ${PROJECT_NAME})
 
 ament_add_gtest(test_ray_intersection test_ray_intersection.cpp)
-target_link_libraries(test_ray_intersection ${PROJECT_NAME} Boost::filesystem)
+target_link_libraries(test_ray_intersection ${PROJECT_NAME} ${OCTOMAP_LIBRARIES} Boost::filesystem)
 
 ament_add_gtest(test_body_operations test_body_operations.cpp)
-target_link_libraries(test_body_operations ${PROJECT_NAME} Boost::filesystem)
+target_link_libraries(test_body_operations ${PROJECT_NAME} ${OCTOMAP_LIBRARIES} Boost::filesystem)


### PR DESCRIPTION
fix compile on linux fedora with local fcl and octomap

/usr/bin/ld: /usr/local/lib64/libfcl.so.0.7: undefined reference to `octomap::Pointcloud::Pointcloud()' /usr/bin/ld: /usr/local/lib64/libfcl.so.0.7: undefined reference to `octomap::Pointcloud::~Pointcloud()' /usr/bin/ld: /usr/local/lib64/libfcl.so.0.7: undefined reference to `octomath::Pose6D::Pose6D(octomath::Pose6D const&)' /usr/bin/ld: /usr/local/lib64/libfcl.so.0.7: undefined reference to `octomap::Pointcloud::Pointcloud()' /usr/bin/ld: /usr/local/lib64/libfcl.so.0.7: undefined reference to `octomap::OcTreeNode::addValue(float const&)' /usr/bin/ld: /usr/local/lib64/libfcl.so.0.7: undefined reference to `octomap::Pointcloud::~Pointcloud()' /usr/bin/ld: /usr/local/lib64/libfcl.so.0.7: undefined reference to `octomap::OcTreeNode::OcTreeNode()' /usr/bin/ld/usr/bin/ld: : /usr/local/lib64/libfcl.so.0.7/usr/local/lib64/libfcl.so.0.7: undefined reference to `: undefined reference to `octomap::Pointcloud::Pointcloud()octomap::Pointcloud::Pointcloud()' '
/usr/bin/ld: /usr/local/lib64/libfcl.so.0.7: undefined reference to `octomath::Pose6D::Pose6D(octomath::Pose6D const&)' /usr/bin/ld: /usr/local/lib64/libfcl.so.0.7: undefined reference to `octomap::OcTreeNode::~OcTreeNode()' /usr/bin/ld: /usr/local/lib64/libfcl.so.0.7: undefined reference to `octomap::OcTreeNode::addValue(float const&)' /usr/bin/ld/usr/bin/ld: : /usr/local/lib64/libfcl.so.0.7/usr/local/lib64/libfcl.so.0.7: undefined reference to `: undefined reference to `octomap::Pointcloud::~Pointcloud()octomap::Pointcloud::~Pointcloud()' '
/usr/bin/ld: /usr/local/lib64/libfcl.so.0.7: undefined reference to `octomap::Pointcloud::Pointcloud()' /usr/bin/ld: /usr/local/lib64/libfcl.so.0.7: undefined reference to `octomap::Pointcloud::transform(octomath::Pose6D)' /usr/bin/ld: /usr/local/lib64/libfcl.so.0.7: undefined reference to `octomap::OcTreeNode::OcTreeNode()' /usr/bin/ld: /usr/local/lib64/libfcl.so.0.7: undefined reference to `octomath::Pose6D::Pose6D(octomath::Pose6D const&)' /usr/bin/ld: /usr/local/lib64/libfcl.so.0.7: undefined reference to `octomath::Pose6D::Pose6D(octomath::Pose6D const&)' /usr/bin/ld: /usr/local/lib64/libfcl.so.0.7: undefined reference to `octomath::Pose6D::~Pose6D()' /usr/bin/ld: /usr/local/lib64/libfcl.so.0.7: undefined reference to `octomap::Pointcloud::~Pointcloud()' /usr/bin/ld: /usr/local/lib64/libfcl.so.0.7: undefined reference to `octomap::OcTreeNode::addValue(float const&)' /usr/bin/ld: /usr/local/lib64/libfcl.so.0.7: undefined reference to `octomap::OcTreeNode::addValue(float const&)' /usr/bin/ld/usr/bin/ld: : /usr/local/lib64/libfcl.so.0.7/usr/local/lib64/libfcl.so.0.7: undefined reference to `: undefined reference to `octomap::OcTreeNode::~OcTreeNode()octomap::OcTree::OcTree(double)' '
/usr/bin/ld: /usr/local/lib64/libfcl.so.0.7: undefined reference to `octomath::Pose6D::Pose6D(octomath::Pose6D const&)' /usr/bin/ld: /usr/local/lib64/libfcl.so.0.7: undefined reference to `octomath::Pose6D::inv() const' /usr/bin/ld: /usr/local/lib64/libfcl.so.0.7: undefined reference to `octomap::Pointcloud::Pointcloud()' /usr/bin/ld: /usr/local/lib64/libfcl.so.0.7/usr/bin/ld/usr/bin/ld: : undefined reference to `: /usr/local/lib64/libfcl.so.0.7octomap::Pointcloud::transform(octomath::Pose6D)/usr/local/lib64/libfcl.so.0.7: undefined reference to `'