### PR TITLE
Remove octomap dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,9 +43,6 @@ find_package(console_bridge REQUIRED)
 find_package(console_bridge_vendor REQUIRED)
 find_package(eigen_stl_containers REQUIRED)
 find_package(geometry_msgs REQUIRED)
-# Enforce the system package version on Ubuntu jammy and noble which is also used by libfcl-dev
-# The version is fixed to prevent ABI conflicts with ros-octomap
-find_package(octomap 1.9.7...<1.10.0 REQUIRED)
 find_package(QHULL REQUIRED)
 find_package(random_numbers REQUIRED)
 find_package(rclcpp REQUIRED)
@@ -62,7 +59,6 @@ set(THIS_PACKAGE_EXPORT_DEPENDS
   console_bridge_vendor
   eigen_stl_containers
   geometry_msgs
-  octomap
   random_numbers
   rclcpp
   resource_retriever

--- a/package.xml
+++ b/package.xml
@@ -27,7 +27,6 @@
   <depend>rclcpp</depend>
   <depend>eigen_stl_containers</depend>
   <depend>console_bridge_vendor</depend>
-  <depend>liboctomap-dev</depend>
   <depend>random_numbers</depend>
   <depend>resource_retriever</depend>
   <depend>shape_msgs</depend>


### PR DESCRIPTION
The versioned dependency doesn't work out on the latest ubuntu release. However, since compatibility to libfcl-dev is mentioned in the comment: Octomap should be linked in as a transitive depencency from fcl.

In fact, octomap isn't linked to the target, anyway, but fcl is. Looking at the built library it seems that it seems to be correctly linked against liboctomap:

```
$ ldd libgeometric_shapes.so
        linux-vdso.so.1 (0x0000735e9514b000)
        libassimp.so.6 => /usr/lib/x86_64-linux-gnu/libassimp.so.6 (0x0000735e9497c000)
        libfcl.so.0.7 => /usr/lib/x86_64-linux-gnu/libfcl.so.0.7 (0x0000735e943f0000)
        libqhull_r.so.8.0 => /usr/lib/x86_64-linux-gnu/libqhull_r.so.8.0 (0x0000735e9437d000)
        libconsole_bridge.so.1.0 => /usr/lib/x86_64-linux-gnu/libconsole_bridge.so.1.0 (0x0000735e94377000)
        libresource_retriever.so => /opt/ros/rolling/lib/libresource_retriever.so (0x0000735e9436a000)
        libstdc++.so.6 => /usr/lib/x86_64-linux-gnu/libstdc++.so.6 (0x0000735e940c8000)
        libm.so.6 => /usr/lib/x86_64-linux-gnu/libm.so.6 (0x0000735e93fa2000)
        libgcc_s.so.1 => /usr/lib/x86_64-linux-gnu/libgcc_s.so.1 (0x0000735e93f74000)
        libc.so.6 => /usr/lib/x86_64-linux-gnu/libc.so.6 (0x0000735e93d53000)
        libz.so.1 => /usr/lib/x86_64-linux-gnu/libz.so.1 (0x0000735e93d35000)
        libdraco.so.9 => /usr/lib/x86_64-linux-gnu/libdraco.so.9 (0x0000735e93a60000)
        libminizip.so.1 => /usr/lib/x86_64-linux-gnu/libminizip.so.1 (0x0000735e93a50000)
        libpugixml.so.1 => /usr/lib/x86_64-linux-gnu/libpugixml.so.1 (0x0000735e93a11000)
        libccd.so.2 => /usr/lib/x86_64-linux-gnu/libccd.so.2 (0x0000735e93a05000)
        liboctomap.so.1.10 => /usr/lib/x86_64-linux-gnu/liboctomap.so.1.10 (0x0000735e939c2000)
        liboctomath.so.1.10 => /usr/lib/x86_64-linux-gnu/liboctomath.so.1.10 (0x0000735e939ba000)
        libament_index_cpp.so => /opt/ros/rolling/lib/libament_index_cpp.so (0x0000735e939a7000)
        libcurl.so.4 => /usr/lib/x86_64-linux-gnu/libcurl.so.4 (0x0000735e938b4000)
        /lib64/ld-linux-x86-64.so.2 (0x0000735e9514d000)
        libnghttp2.so.14 => /usr/lib/x86_64-linux-gnu/libnghttp2.so.14 (0x0000735e9388a000)
        libidn2.so.0 => /usr/lib/x86_64-linux-gnu/libidn2.so.0 (0x0000735e93868000)
        librtmp.so.1 => /usr/lib/x86_64-linux-gnu/librtmp.so.1 (0x0000735e93848000)
        libldap.so.2 => /usr/lib/x86_64-linux-gnu/libldap.so.2 (0x0000735e937e3000)
        liblber.so.2 => /usr/lib/x86_64-linux-gnu/liblber.so.2 (0x0000735e937d2000)
        libssh2.so.1 => /usr/lib/x86_64-linux-gnu/libssh2.so.1 (0x0000735e93786000)
        libpsl.so.5 => /usr/lib/x86_64-linux-gnu/libpsl.so.5 (0x0000735e93771000)
        libssl.so.3 => /usr/lib/x86_64-linux-gnu/libssl.so.3 (0x0000735e93663000)
        libcrypto.so.3 => /usr/lib/x86_64-linux-gnu/libcrypto.so.3 (0x0000735e9304a000)
        libgssapi_krb5.so.2 => /usr/lib/x86_64-linux-gnu/libgssapi_krb5.so.2 (0x0000735e92ff0000)
        libzstd.so.1 => /usr/lib/x86_64-linux-gnu/libzstd.so.1 (0x0000735e92f2d000)
        libbrotlidec.so.1 => /usr/lib/x86_64-linux-gnu/libbrotlidec.so.1 (0x0000735e92f1e000)
        libunistring.so.5 => /usr/lib/x86_64-linux-gnu/libunistring.so.5 (0x0000735e92d37000)
        libgnutls.so.30 => /usr/lib/x86_64-linux-gnu/libgnutls.so.30 (0x0000735e92b27000)
        libhogweed.so.6 => /usr/lib/x86_64-linux-gnu/libhogweed.so.6 (0x0000735e92ada000)
        libnettle.so.8 => /usr/lib/x86_64-linux-gnu/libnettle.so.8 (0x0000735e92a83000)
        libgmp.so.10 => /usr/lib/x86_64-linux-gnu/libgmp.so.10 (0x0000735e929fd000)
        libsasl2.so.2 => /usr/lib/x86_64-linux-gnu/libsasl2.so.2 (0x0000735e929e2000)
        libkrb5.so.3 => /usr/lib/x86_64-linux-gnu/libkrb5.so.3 (0x0000735e92916000)
        libk5crypto.so.3 => /usr/lib/x86_64-linux-gnu/libk5crypto.so.3 (0x0000735e928e8000)
        libcom_err.so.2 => /usr/lib/x86_64-linux-gnu/libcom_err.so.2 (0x0000735e928e2000)
        libkrb5support.so.0 => /usr/lib/x86_64-linux-gnu/libkrb5support.so.0 (0x0000735e928d5000)
        libbrotlicommon.so.1 => /usr/lib/x86_64-linux-gnu/libbrotlicommon.so.1 (0x0000735e928b2000)
        libp11-kit.so.0 => /usr/lib/x86_64-linux-gnu/libp11-kit.so.0 (0x0000735e926d7000)
        libtasn1.so.6 => /usr/lib/x86_64-linux-gnu/libtasn1.so.6 (0x0000735e926be000)
        libkeyutils.so.1 => /usr/lib/x86_64-linux-gnu/libkeyutils.so.1 (0x0000735e926b7000)
        libresolv.so.2 => /usr/lib/x86_64-linux-gnu/libresolv.so.2 (0x0000735e926a4000)
        libffi.so.8 => /usr/lib/x86_64-linux-gnu/libffi.so.8 (0x0000735e92693000)
```

Since it's used a private link target (only used from within a CPP file and fcl being linked privately) it should be save to remove the dependency altogether, at least from my understanding.

Tested to build locally in a resolute-rolling docker container.

This is from my point of view one way to address #268 