### PR TITLE
Include cassert in check_isometry.h

### DIFF
--- a/include/geometric_shapes/check_isometry.h
+++ b/include/geometric_shapes/check_isometry.h
@@ -32,7 +32,7 @@
 #define GEOMETRIC_SHAPES_CHECK_ISOMETRY_H
 
 #include <algorithm>
-#include <assert.h>
+#include <cassert>
 #include <iostream>
 #include <math.h>
 #include <Eigen/Core>


### PR DESCRIPTION
This is part of an effort to contribute RoboStack downstream patches back upstream.

This upstreams `patch/ros-rolling-geometric-shapes.patch`, authored in RoboStack by Silvio Traversaro `<silvio@traversaro.it>`.

`check_isometry.h` defines `ASSERT_ISOMETRY` with `assert`, so it should include `<cassert>` directly where the macro is defined instead of adding the include to an unrelated translation unit.
