### PR TITLE
Find Boost thread in geometric_shapes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,6 +39,7 @@ find_package(Eigen3 REQUIRED)
 
 find_package(ament_cmake REQUIRED)
 find_package(assimp REQUIRED)
+find_package(Boost REQUIRED COMPONENTS thread)
 find_package(console_bridge REQUIRED)
 find_package(console_bridge_vendor REQUIRED)
 find_package(eigen_stl_containers REQUIRED)


### PR DESCRIPTION
This PR is part of an effort to contribute RoboStack downstream patches back upstream.

Origin: RoboStack `patch/ros-rolling-geometric-shapes.win.patch`, authored by Daisuke Nishimatsu.

Best-guess rationale: geometric_shapes links against Boost libraries, and explicitly finding the thread component avoids missing Boost thread link information on toolchains where it is not implied transitively.
